### PR TITLE
Add uninstall_app endpoint and MCP tool

### DIFF
--- a/mcp/src/tools/device.ts
+++ b/mcp/src/tools/device.ts
@@ -265,6 +265,47 @@ NOTE: If you want to capture network traffic from this app:
   );
 
   server.tool(
+    "uninstall_app",
+    `Uninstall an app from a simulator or physical device by bundle ID.`,
+    {
+      bundle_id: z.string().describe("App bundle identifier"),
+      udid: z
+        .string()
+        .optional()
+        .describe("Target device UDID (auto-resolves if omitted)"),
+    },
+    async ({ bundle_id, udid }) => {
+      try {
+        const body: Record<string, unknown> = { bundle_id };
+        if (udid) body.udid = udid;
+
+        const data = await apiRequest(
+          "POST",
+          "/api/v1/device/app/uninstall",
+          undefined,
+          body
+        );
+
+        return {
+          content: [
+            { type: "text" as const, text: JSON.stringify(data, null, 2) },
+          ],
+        };
+      } catch (e) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Error: ${e instanceof Error ? e.message : String(e)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.tool(
     "list_apps",
     `List installed apps on a simulator or physical device.`,
     {

--- a/server/api/device.py
+++ b/server/api/device.py
@@ -18,6 +18,7 @@ from server.models import (
     StartSimLogRequest,
     StopSimLogRequest,
     TerminateAppRequest,
+    UninstallAppRequest,
 )
 
 router = APIRouter(prefix="/api/v1/device", tags=["device"])
@@ -130,6 +131,17 @@ async def terminate_app(request: Request, body: TerminateAppRequest):
     try:
         udid = await controller.terminate_app(bundle_id=body.bundle_id, udid=body.udid)
         return {"status": "terminated", "udid": udid, "bundle_id": body.bundle_id}
+    except DeviceError as e:
+        raise _handle_device_error(e)
+
+
+@router.post("/app/uninstall")
+async def uninstall_app(request: Request, body: UninstallAppRequest):
+    """Uninstall an app from a simulator or physical device."""
+    controller = _get_controller(request)
+    try:
+        udid = await controller.uninstall_app(bundle_id=body.bundle_id, udid=body.udid)
+        return {"status": "uninstalled", "udid": udid, "bundle_id": body.bundle_id}
     except DeviceError as e:
         raise _handle_device_error(e)
 

--- a/server/device/controller.py
+++ b/server/device/controller.py
@@ -203,6 +203,15 @@ class DeviceController(DeviceControllerUI):
             await self.simctl.terminate_app(resolved, bundle_id)
         return resolved
 
+    async def uninstall_app(self, bundle_id: str, udid: str | None = None) -> str:
+        """Uninstall an app. Returns the resolved udid."""
+        resolved = await self.resolve_udid(udid)
+        if self._is_physical(resolved):
+            await self.devicectl.uninstall_app(resolved, bundle_id)
+        else:
+            await self.simctl.uninstall_app(resolved, bundle_id)
+        return resolved
+
     async def list_apps(self, udid: str | None = None) -> tuple[list[AppInfo], str]:
         """List installed apps. Returns (apps, resolved_udid)."""
         resolved = await self.resolve_udid(udid)

--- a/server/device/devicectl.py
+++ b/server/device/devicectl.py
@@ -169,6 +169,14 @@ class DevicectlBackend:
 
         self._launched_pids.pop((uuid, bundle_id), None)
 
+    async def uninstall_app(self, uuid: str, bundle_id: str) -> None:
+        """Uninstall an app from a physical device."""
+        await self._run_devicectl(
+            "device", "uninstall", "app",
+            "--device", uuid,
+            bundle_id,
+        )
+
     async def list_apps(self, uuid: str) -> list[AppInfo]:
         """List installed apps on a physical device."""
         stdout, _ = await self._run_devicectl(

--- a/server/device/simctl.py
+++ b/server/device/simctl.py
@@ -131,6 +131,10 @@ class SimctlBackend:
         """Terminate an app on a simulator."""
         await self._run_simctl("terminate", udid, bundle_id)
 
+    async def uninstall_app(self, udid: str, bundle_id: str) -> None:
+        """Uninstall an app from a simulator."""
+        await self._run_simctl("uninstall", udid, bundle_id)
+
     async def list_apps(self, udid: str) -> list[AppInfo]:
         """List installed apps on a simulator.
 

--- a/server/models.py
+++ b/server/models.py
@@ -543,6 +543,13 @@ class TerminateAppRequest(BaseModel):
     udid: str | None = None
 
 
+class UninstallAppRequest(BaseModel):
+    """Request body for POST /device/app/uninstall."""
+
+    bundle_id: str
+    udid: str | None = None
+
+
 # ---------------------------------------------------------------------------
 # UI inspection models (Phase 3b)
 # ---------------------------------------------------------------------------

--- a/tests/test_device_api.py
+++ b/tests/test_device_api.py
@@ -59,6 +59,7 @@ def mock_controller(app):
     ctrl.install_app = AsyncMock(return_value="AAAA-1111")
     ctrl.launch_app = AsyncMock(return_value="AAAA-1111")
     ctrl.terminate_app = AsyncMock(return_value="AAAA-1111")
+    ctrl.uninstall_app = AsyncMock(return_value="AAAA-1111")
     ctrl.list_apps = AsyncMock(return_value=(
         [AppInfo(bundle_id="com.example.App", name="My App", app_type="User")],
         "AAAA-1111",
@@ -232,6 +233,20 @@ class TestAppEndpoints:
             )
         assert resp.status_code == 200
         assert resp.json()["status"] == "terminated"
+
+    async def test_uninstall_app(self, app, auth_headers, mock_controller):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/api/v1/device/app/uninstall",
+                json={"bundle_id": "com.example.App"},
+                headers=auth_headers,
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "uninstalled"
+        assert data["bundle_id"] == "com.example.App"
+        assert data["udid"] == "AAAA-1111"
 
     async def test_list_apps(self, app, auth_headers, mock_controller):
         transport = ASGITransport(app=app)

--- a/tests/test_device_controller.py
+++ b/tests/test_device_controller.py
@@ -206,6 +206,14 @@ class TestAppDelegation:
         ctrl.simctl.terminate_app.assert_called_once_with("AAAA-1111", "com.example.App")
         assert udid == "AAAA-1111"
 
+    async def test_uninstall_app(self):
+        ctrl = DeviceController()
+        ctrl._active_udid = "AAAA-1111"
+        ctrl.simctl.uninstall_app = AsyncMock()
+        udid = await ctrl.uninstall_app("com.example.App")
+        ctrl.simctl.uninstall_app.assert_called_once_with("AAAA-1111", "com.example.App")
+        assert udid == "AAAA-1111"
+
     async def test_list_apps(self):
         ctrl = DeviceController()
         ctrl._active_udid = "AAAA-1111"

--- a/tests/test_devicectl_backend.py
+++ b/tests/test_devicectl_backend.py
@@ -187,6 +187,25 @@ class TestTerminateApp:
 
 
 # ---------------------------------------------------------------------------
+# uninstall_app
+# ---------------------------------------------------------------------------
+
+
+class TestUninstallApp:
+    async def test_uninstall_app(self):
+        backend = DevicectlBackend()
+        backend._run_devicectl = AsyncMock(return_value=("", ""))
+
+        await backend.uninstall_app("UUID", "com.example.app")
+
+        backend._run_devicectl.assert_called_once_with(
+            "device", "uninstall", "app",
+            "--device", "UUID",
+            "com.example.app",
+        )
+
+
+# ---------------------------------------------------------------------------
 # list_apps
 # ---------------------------------------------------------------------------
 

--- a/tests/test_simctl_backend.py
+++ b/tests/test_simctl_backend.py
@@ -236,6 +236,16 @@ class TestSimctlCommands:
                 stdout=-1, stderr=-1,
             )
 
+    async def test_uninstall_app(self):
+        backend = SimctlBackend()
+        proc = _mock_proc()
+        with patch("asyncio.create_subprocess_exec", return_value=proc) as mock_exec:
+            await backend.uninstall_app("AAAA-1111", "com.example.App")
+            mock_exec.assert_called_once_with(
+                "xcrun", "simctl", "uninstall", "AAAA-1111", "com.example.App",
+                stdout=-1, stderr=-1,
+            )
+
 
 # ---------------------------------------------------------------------------
 # list_apps


### PR DESCRIPTION
Closes #2 

Add the missing uninstall_app command across all layers:
- simctl backend: xcrun simctl uninstall
- devicectl backend: devicectl device uninstall app
- controller: unified interface with auto-resolve
- REST API: POST /api/v1/device/app/uninstall
- MCP tool: uninstall_app with bundle_id and optional udid
- Tests for all layers (12 new tests)