### PR TITLE
Read version from pyproject.toml at runtime

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,0 +1,22 @@
+"""Quern — server package."""
+
+from functools import lru_cache
+from pathlib import Path
+
+
+@lru_cache(maxsize=1)
+def get_version() -> str:
+    """Return the project version from pyproject.toml. Single source of truth."""
+    path = Path(__file__).resolve().parent
+    for _ in range(5):
+        candidate = path / "pyproject.toml"
+        if candidate.exists():
+            for line in candidate.read_text().splitlines():
+                if line.startswith("version"):
+                    return line.split('"')[1]
+            break
+        parent = path.parent
+        if parent == path:
+            break
+        path = parent
+    return "unknown"

--- a/server/__main__.py
+++ b/server/__main__.py
@@ -354,22 +354,13 @@ def _cmd_mcp_install() -> int:
     return 0 if all_ok else 1
 
 
-def _get_version() -> str:
-    """Read version from pyproject.toml (single source of truth)."""
-    project_root = _find_project_root()
-    if project_root:
-        for line in (project_root / "pyproject.toml").read_text().splitlines():
-            if line.startswith("version"):
-                return line.split('"')[1]
-    return "unknown"
-
-
 def main() -> None:
     _maybe_reexec_in_venv()
 
     # Version flag — handle before anything else
     if len(sys.argv) >= 2 and sys.argv[1] in ("--version", "-V", "version"):
-        print(f"quern {_get_version()}")
+        from server import get_version
+        print(f"quern {get_version()}")
         sys.exit(0)
 
     # Lightweight commands — handle without heavy imports

--- a/server/main.py
+++ b/server/main.py
@@ -30,6 +30,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, RedirectResponse
 
+from server import get_version
 from server.api.app_state import router as app_state_router
 from server.api.build_app import router as build_app_router
 from server.api.builds import router as builds_router
@@ -432,7 +433,7 @@ def create_app(
 
     app = FastAPI(
         title="Quern",
-        version="0.1.0",
+        version=get_version(),
         description="Debug log capture and AI context server",
         lifespan=lifespan,
     )
@@ -579,7 +580,7 @@ fetch('/api/v1/device/list', {
             cache_stats = app.state.device_controller.get_cache_stats()
         return {
             "status": "ok",
-            "version": "0.1.0",
+            "version": get_version(),
             "tools": tools,
             "ui_cache": cache_stats,
         }
@@ -594,7 +595,7 @@ fetch('/api/v1/device/list', {
             cache_stats = app.state.device_controller.get_cache_stats()
         return {
             "status": "ok",
-            "version": "0.1.0",
+            "version": get_version(),
             "tools": tools,
             "ui_cache": cache_stats,
         }
@@ -797,7 +798,7 @@ def _cmd_start(args: argparse.Namespace) -> None:
     write_state(state_dict)
 
     if args.foreground:
-        print("Quern v0.1.0")
+        print(f"Quern v{get_version()}")
         print(f"  http://{config.host}:{server_port}")
         print(f"  API key: {config.api_key[:8]}...{config.api_key[-4:]}")
         print("  API key file: ~/.quern/api-key")


### PR DESCRIPTION
## Summary

Four hardcoded `"0.1.0"` literals in `server/main.py` had drifted badly — actual version is `0.11.0`. Replaces them with a cached `get_version()` helper that reads `pyproject.toml` as the single source of truth.

## Changes

| File | Change |
|---|---|
| `server/__init__.py` | New: `get_version()` (cached, walks up to find pyproject.toml; returns `"unknown"` if not found) |
| `server/main.py` | 4 sites replaced — FastAPI app version, `/health`, `/api/v1/health`, foreground banner |
| `server/__main__.py` | Removes the local `_get_version()` (was duplicating the same logic for `quern --version`); now imports the shared helper |

## Verification

```
$ .venv/bin/python -c "from server import get_version; print(get_version())"
0.11.0

$ .venv/bin/python -m server --version
quern 0.11.0
```

All 1242 tests pass.

## Out of scope (related finding, separate fix)

`mcp/src/index.ts:69` also has a stale `version: "0.1.0"` literal. That's in a different package (npm/TypeScript) and the fix shape is different — likely reading from `mcp/package.json` via `createRequire` at runtime, or a build-time constant. Worth a follow-up but not bundled here.

## Test plan

- [x] Existing test suite green (1242 passed)
- [x] Manual verification: `quern --version` returns `quern 0.11.0`
- [x] Manual verification: `from server import get_version` returns `"0.11.0"`
- [ ] Server boot inspection (reviewer can spin up server and check `GET /health` returns version `"0.11.0"` and OpenAPI docs show `0.11.0`)