### PR TITLE
sim-bridge: native simulator UI control, retires idb on Xcode 26+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to Quern are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **sim-bridge — native simulator control** — a new Swift helper binary that replaces idb for simulator UI automation on Xcode 26+ Apple Silicon hosts. Talks to `CoreSimulator` / `SimulatorKit` / `AccessibilityPlatformTranslation` directly via `dlopen`, runs as a long-lived subprocess over JSON-Lines on stdin/stdout (same pattern as `ios-preview`), and auto-compiles on first use. Removes the `idb_companion` daemon, the per-call subprocess spawn, and the simctl detour for screenshots. idb stays as the automatic fallback when sim-bridge can't be built (Intel Macs, pre-Xcode-26). See [`docs/sim-bridge-spec.md`](docs/sim-bridge-spec.md).
+- **Server-side `objectAtPoint` hit-test in sim-bridge** — calls `AXPTranslator`'s 3-arg `objectAtPoint:displayId:bridgeDelegateToken:` to resolve the deepest accessibility element under a given point. Used to drive group-children probing: SwiftUI tab bars / nav bars / toolbars routinely enumerate as childless even though they clearly contain interactive subviews (the bug behind facebook/idb#767 and Quern's patched-companion). Sim-bridge now grids the interior of each empty container with hit-tests at 20pt intervals and merges the discoveries into the flat element list, matching the behavior agents already got from the patched idb companion.
+- **Shared probing module** (`server/device/probing.py`) — the empty-container detection, hit-test grid, dedup-by-frame, and merge-into-flat logic is now backend-agnostic. Both `IdbBackend` and `SimBridgeBackend` call into it with their own `describe_point` callable; future backends (e.g. a remote sim host) plug in the same way.
+- **RadioButton and CheckBox in screen summaries** — iOS tab-bar items expose as `AXRadioButton` with `role_description="AXTabButton"`. They were landing in the parsed element list with the right labels and identifiers but `get_screen_summary` was dropping them because `_INTERACTIVE_TYPES` only covered Button / TextField / Switch / Slider / Link / SearchField. They now show up in `interactive_elements` (with their `value` field reflecting which tab is selected) and route to `navigation_chrome` so they're never truncated.
+
+### Changed
+- **Setup skips idb install on Xcode 26+ Apple Silicon** — `quern setup` detects when sim-bridge will be used and short-circuits the two idb prompts (`idb_companion` and `fb-idb`) with a SKIPPED status and a one-line note instead of installing them. Existing idb installs are left alone (they still work as a fallback). Older Xcode or Intel hosts keep the existing idb install flow unchanged.
+- **`get_screen_summary` and `tap_element` no longer say "Requires idb."** — the MCP tool descriptions used to advertise an idb requirement that hasn't been true since `WdaBackend` (physical iOS) and `U2Backend` (Android) landed. With sim-bridge added on top, the strings were actively misleading. Descriptions now describe the tool itself and let the server pick the right backend per-device.
+
+### Fixed
+- **`press_button` accepts idb's name set** — `sim-bridge`'s `doButton` was matching lowercase Swift names only (`home` / `lock` / `volumeUp` / `volumeDown`) while the MCP tool contract uses idb's uppercase set (`HOME`, `LOCK`, `SIDE_BUTTON`, `SIRI`, `APPLE_PAY`). Names are now normalized (lowercase, strip `_`/`-`) and the full set is wired through: `HOME` / `LOCK` / `SIDE_BUTTON` press the indigo button, `SIRI` is long-press side, `APPLE_PAY` is double-press side.
+- **`clear_text` actually clears the field on sim-bridge** — the select-all + delete path sends `\x08` through the type-text command, but the character-to-HID-usage map had no entry for ASCII backspace or DEL, so the keypress was silently dropped after the triple-tap selection. Both 0x08 and 0x7F now map to HID usage 0x2A (Keyboard Delete).
+
+### Internal
+- New `tests/test_sim_bridge.py` (7 tests) — describe_point hit / miss, describe_all probing of an empty tab bar, no-probe path when containers are full, dedup of probed-vs-existing frames, describe_all_nested round-trip.
+- Verified end-to-end against Metatext on iOS 17.5 / 18.6 / 26.4 simulators: tap_element resolves the four tab buttons (`tab.timelines` / `tab.explore` / `tab.notifications` / `tab.messages`) and routes a real tap to each.
+
 ## [0.12.0] - 2026-04-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Manage iOS simulators and physical devices, and interact with running apps.
 - **Configuration** — set GPS location, grant permissions
 - **Device pool** — smart device resolution with active device tracking for multi-device workflows
 
-**Simulator UI automation** uses [idb](https://fbidb.io/) (`brew install idb-companion`). Device management and screenshots use `xcrun simctl` (always available with Xcode).
+**Simulator UI automation** uses a native Swift helper, `sim-bridge`, that talks to `CoreSimulator` / `SimulatorKit` / `AccessibilityPlatformTranslation` directly — no daemon, no subprocess per call. It's built automatically on first use and requires Xcode 26+ on Apple Silicon. On Intel Macs or older Xcode, Quern falls back to [idb](https://fbidb.io/) (`brew install idb-companion` + `pip install fb-idb`); `quern setup` handles the install in that case. Device management and screenshots use `xcrun simctl` (always available with Xcode).
 
 **Physical device UI automation** uses [WebDriverAgent](https://github.com/appium/WebDriverAgent) (WDA), which Quern builds and deploys automatically via `setup_wda`. WDA requires a valid Apple Developer signing identity. Once set up, the WDA driver auto-starts on first interaction and idles out after 15 minutes of inactivity. The app appears on the device as **Quern Driver**.
 
@@ -390,7 +390,7 @@ server/
   processing/          Deduplicator, classifier, summarizer
   storage/             Ring buffer
   proxy/               mitmproxy addon, flow store, system proxy, cert management
-  device/              Simulator control (simctl, idb) + physical device control (WDA, pymobiledevice3), device pool
+  device/              Simulator control (simctl, sim-bridge, idb fallback) + physical device control (WDA, pymobiledevice3), device pool
   api/                 HTTP route handlers
 mcp/                   MCP server (TypeScript)
 tests/                 993 tests

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -165,7 +165,7 @@ When the question is "what screen am I on right now?" — for verifying navigati
 **Why use landmarks instead of just reading `get_screen_summary`?**
 
 - **Deterministic.** Quern matches the live UI tree against authored selectors and returns `matched: <screen_name>` with `confidence: exact | ambiguous | none`. No prose interpretation.
-- **Cross-platform.** The same landmarks work on iOS (idb) and Android (uiautomator2) — selection state, identifiers, and labels are normalized to a single schema.
+- **Cross-platform.** The same landmarks work on iOS (sim-bridge / idb / WDA depending on device) and Android (uiautomator2) — selection state, identifiers, and labels are normalized to a single schema.
 - **Stable across LLMs.** A workflow that asks "is this the cart screen?" gets the same answer regardless of which model is driving.
 - **Authored once, reused everywhere.** The screen knowledge base is the source of truth; agents don't re-discover screen identity on every call.
 
@@ -222,7 +222,7 @@ When the question is "what screen am I on right now?" — for verifying navigati
 
 ### Working with Physical Devices
 
-Physical iOS devices are supported for screenshots, UI automation, log capture, and crash reports. The key difference from simulators is that UI automation uses WebDriverAgent (WDA) instead of idb.
+Physical iOS devices are supported for screenshots, UI automation, log capture, and crash reports. The key difference from simulators is that UI automation uses WebDriverAgent (WDA) instead of the simulator backend (sim-bridge / idb).
 
 **First-time setup**: Call `setup_wda` with the device UDID. This builds and installs WDA on the device, which requires a valid Apple Developer signing identity. If multiple identities exist, the tool returns a list — call again with the chosen `team_id`. The app appears on the device as **Quern Driver**.
 
@@ -455,7 +455,7 @@ Use `ensure_devices` to boot multiple simulators at once, then run different tes
 
 **Using mock when you need intercept (or vice versa)** — Mocks return instant synthetic responses for stable test fixtures. Intercept pauses real requests for ad-hoc inspection and modification. Mock rules take priority over intercept.
 
-**Not checking idb availability** — Device management and screenshots use `simctl` (always available with Xcode). Simulator UI automation (`get_ui_tree`, `tap`, `swipe`, `type_text`, `clear_text`, `press_button`) requires `idb`. Physical device UI automation uses WDA (auto-started). Check `list_devices` response for tool availability.
+**Not checking simulator backend availability** — Device management and screenshots use `simctl` (always available with Xcode). Simulator UI automation (`get_ui_tree`, `tap`, `swipe`, `type_text`, `clear_text`, `press_button`) requires either sim-bridge (Xcode 26+ / Apple Silicon, preferred) or idb (fallback). Physical device UI automation uses WDA (auto-started). Check `list_devices` response for tool availability.
 
 **Not using per-simulator flow filtering** — When local capture is enabled, flows are tagged with the originating simulator's UDID. Always pass `simulator_udid` when querying flows during parallel testing — otherwise you'll see traffic from all simulators mixed together.
 

--- a/docs/feature-request-group-children-probe.md
+++ b/docs/feature-request-group-children-probe.md
@@ -1,0 +1,82 @@
+# idb Fix: Probe Childless Group Elements (fixes facebook/idb#767)
+
+> **Status (Quern, v0.13+): shipped natively in sim-bridge.** Quern's
+> default simulator backend now performs the same grid hit-test via
+> AXPTranslator's `objectAtPoint:displayId:bridgeDelegateToken:`,
+> implemented in `tools/sim-bridge.swift` and wired through
+> `server/device/probing.py`. The idb patch described below is still
+> the right fix for the upstream `idb_companion` and remains relevant
+> for Intel Macs / pre-Xcode-26 hosts that fall back to the idb path.
+
+## Status: FIXED — PR ready
+
+Branch: `fix/group-children-fallback` in our idb fork at `/Users/jerimiah/Dev/idb`
+
+## Problem
+
+`idb ui describe-all` drops children of Group-type accessibility containers. This is a known idb bug ([facebook/idb#767](https://github.com/facebook/idb/issues/767), open since March 2023).
+
+The root cause: `accessibilityChildren` returns an empty array for certain container elements (e.g., `UITableView` with 0 data rows reporting as "Empty list"). No alternative attribute accessor (`AXVisibleChildren`, `AXChildren`, `accessibilityVisibleChildren`) returns the children either. However, `objectAtPoint` hit-testing CAN find elements within these groups.
+
+## Solution
+
+After the recursive tree traversal in `FBAXTranslationRequest_FrontmostApplication.run:`, scan the results for Group elements with:
+- No children in the tree
+- A frame area > 5000 pt² (filters out small icon containers)
+
+For each such group, probe its interior at a 30px grid using `objectAtPoint`. Discovered elements are deduplicated by frame and tagged with `discovery_method="group_probe"`.
+
+### Before
+```
+Total elements: 4
+Application  label=Geocaching
+Button       label=Search By:
+TextField    label=                   id=_Geocache search field
+Group        label=Empty list
+```
+
+### After
+```
+Total elements: 6
+Application  label=Geocaching
+Button       label=Search By:
+TextField    label=                   id=_Geocache search field
+Group        label=Empty list
+StaticText   label=This is a Premium-only cache...
+Button       label=Upgrade            id=_CTA Upgrade button
+```
+
+## Files Changed
+
+- `FBSimulatorControl/Commands/FBSimulatorAccessibilityCommands.m` — added `probeChildlessGroupsInElements:` method, wired into `run:`
+- `FBControlCore/Utility/FBVideoStream.m` — suppress `-Wgnu-folding-constant` for Xcode 26 compat
+- `FBSimulatorControl/FBSimulatorControl.h` — add missing umbrella header entries
+- `FBSimulatorControl/Framebuffer/FBSimulatorVideoStream_Testing.h` — fix include style
+
+## Build Notes
+
+Building from `main` requires Xcode 26+ build fixes (included in our branch). Build arm64-only:
+
+```bash
+cd /Users/jerimiah/Dev/idb
+./build.sh generate  # generates xcodeproj from project.yml
+# Then build each target arm64:
+xcodebuild ONLY_ACTIVE_ARCH=YES ARCHS=arm64 -project FBSimulatorControl.xcodeproj -scheme FBControlCore -sdk macosx -derivedDataPath build -configuration Release build
+xcodebuild ONLY_ACTIVE_ARCH=YES ARCHS=arm64 -project FBSimulatorControl.xcodeproj -scheme XCTestBootstrap -sdk macosx -derivedDataPath build -configuration Release build
+xcodebuild ONLY_ACTIVE_ARCH=YES ARCHS=arm64 -project FBSimulatorControl.xcodeproj -scheme FBSimulatorControl -sdk macosx -derivedDataPath build -configuration Release build
+xcodebuild ONLY_ACTIVE_ARCH=YES ARCHS=arm64 -project FBSimulatorControl.xcodeproj -scheme FBDeviceControl -sdk macosx -derivedDataPath build -configuration Release build
+xcodebuild ONLY_ACTIVE_ARCH=YES ARCHS=arm64 -project FBSimulatorControl.xcodeproj -scheme CompanionLib -sdk macosx -derivedDataPath build -configuration Release build
+xcodebuild ONLY_ACTIVE_ARCH=YES ARCHS=arm64 -project FBSimulatorControl.xcodeproj -scheme IDBCompanionUtilities -sdk macosx -derivedDataPath build -configuration Release build
+xcodebuild ONLY_ACTIVE_ARCH=YES ARCHS=arm64 -project idb_companion/idb_companion.xcodeproj -scheme idb_companion -sdk macosx -derivedDataPath build -configuration Release build
+```
+
+## Running the Patched Companion
+
+```bash
+DYLD_FRAMEWORK_PATH=~/.quern/bin:~/.quern/bin/PackageFrameworks \
+  ~/.quern/bin/idb_companion \
+  --udid <SIMULATOR_UDID> \
+  --grpc-domain-sock /tmp/idb/<SIMULATOR_UDID>_companion.sock \
+  --only simulator
+```
+

--- a/docs/idb-companion-distribution.md
+++ b/docs/idb-companion-distribution.md
@@ -1,0 +1,217 @@
+# Distributing the Patched idb_companion
+
+> **Status (v0.13+):** sim-bridge replaces this path on Xcode 26+ Apple Silicon
+> hosts. The group-children probe, native screenshot capture, and HID input
+> injection all run through `tools/sim-bridge.swift` now — no idb daemon, no
+> companion binary, no subprocess-per-call. This doc remains relevant only as
+> the fallback path for Intel Macs and pre-Xcode-26 setups; the `quern setup`
+> flow skips the companion install entirely when sim-bridge is supported.
+> See [`sim-bridge-spec.md`](sim-bridge-spec.md) for the current backend.
+
+## Overview
+
+Quern ships its own `idb_companion` binary instead of depending on the stale Homebrew `facebook/fb/idb-companion` (v1.1.8, August 2022). Our patched build is from `main` (March 2026) and includes:
+
+- **Group children probe** — discovers hidden elements inside childless Group containers (fixes [facebook/idb#767](https://github.com/facebook/idb/issues/767))
+- **xcode-select fallback** — works without `/var/db/xcode_select_link` symlink
+- **Xcode 26 build fixes** — compiles cleanly with current toolchain
+
+## Artifact
+
+- **File**: `idb-companion-arm64.tar.gz` (~17MB)
+- **Architecture**: arm64 (Apple Silicon only for now)
+- **Contents**:
+  ```
+  bin/idb_companion          # 2.4MB binary
+  Frameworks/                # Framework dependencies
+    CompanionLib.framework
+    FBControlCore.framework
+    FBDeviceControl.framework
+    FBSimulatorControl.framework
+    IDBCompanionUtilities.framework
+    IDBGRPCSwift.framework
+    XCTestBootstrap.framework
+    PackageFrameworks/       # SPM-built gRPC dependencies
+  ```
+
+## Hosting
+
+Publish the tarball as a GitHub release asset on the Quern repo (or a dedicated `quern-idb` repo). Tag it with the idb commit hash for traceability.
+
+## Installation (quern setup)
+
+During `quern setup`, replace the Homebrew `idb-companion` check with:
+
+```python
+def install_companion():
+    """Download and install the patched idb_companion."""
+    dest = Path.home() / ".quern" / "bin"
+    dest.mkdir(parents=True, exist_ok=True)
+
+    if (dest / "idb_companion").exists():
+        return  # Already installed
+
+    url = "https://github.com/<org>/quern/releases/download/idb-companion-v1/<idb-companion-arm64.tar.gz>"
+    tarball = dest / "idb-companion.tar.gz"
+
+    # Download
+    urllib.request.urlretrieve(url, tarball)
+
+    # Extract
+    subprocess.run(["tar", "xzf", str(tarball), "-C", str(dest)], check=True)
+    tarball.unlink()
+
+    # Move bin/idb_companion to dest directly
+    (dest / "bin" / "idb_companion").rename(dest / "idb_companion")
+    # Move Frameworks alongside
+    # (already extracted to dest/Frameworks/)
+```
+
+## Runtime Integration
+
+### How idb finds the companion
+
+The `idb` Python CLI accepts `--companion-path` to specify the companion binary:
+
+```bash
+idb ui describe-all --companion-path ~/.quern/bin/idb_companion --udid <UDID>
+```
+
+### How Quern should launch it
+
+Option 1 — pass `--companion-path` on every `idb` call in `idb.py`:
+
+```python
+async def _run(self, *args: str) -> tuple[str, str]:
+    companion = Path.home() / ".quern" / "bin" / "idb_companion"
+    cmd = [self._resolve_binary()]
+    if companion.exists():
+        cmd.extend(["--companion-path", str(companion)])
+    cmd.extend(args)
+    ...
+```
+
+Option 2 — start the companion directly with `DYLD_FRAMEWORK_PATH`:
+
+```python
+async def _ensure_companion(self, udid: str):
+    """Start our patched companion for a simulator."""
+    bin_dir = Path.home() / ".quern" / "bin"
+    companion = bin_dir / "idb_companion"
+    sock = Path(f"/tmp/idb/{udid}_companion.sock")
+
+    env = os.environ.copy()
+    env["DYLD_FRAMEWORK_PATH"] = f"{bin_dir}:{bin_dir / 'Frameworks' / 'PackageFrameworks'}"
+
+    proc = await asyncio.create_subprocess_exec(
+        str(companion),
+        "--udid", udid,
+        "--grpc-domain-sock", str(sock),
+        "--only", "simulator",
+        env=env,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    # Wait for gRPC socket to appear
+    ...
+```
+
+Option 2 is more reliable since it controls the framework path. Option 1 is simpler but may not handle `DYLD_FRAMEWORK_PATH`.
+
+## Removing Homebrew Dependency
+
+Once this is in place:
+1. Remove `brew install idb-companion` from setup
+2. Remove `check_idb_companion()` or repurpose it to check `~/.quern/bin/idb_companion`
+3. Update all "install idb-companion" messages
+
+## Rebuilding
+
+To rebuild from source (e.g., after pulling upstream changes):
+
+```bash
+cd /path/to/idb
+git checkout fix/group-children-fallback
+./build.sh generate
+# Build arm64:
+for scheme in FBControlCore XCTestBootstrap FBSimulatorControl FBDeviceControl CompanionLib IDBCompanionUtilities; do
+    xcodebuild ONLY_ACTIVE_ARCH=YES ARCHS=arm64 -project FBSimulatorControl.xcodeproj \
+        -scheme $scheme -sdk macosx -derivedDataPath build -configuration Release build
+done
+xcodebuild ONLY_ACTIVE_ARCH=YES ARCHS=arm64 -project idb_companion/idb_companion.xcodeproj \
+    -scheme idb_companion -sdk macosx -derivedDataPath build -configuration Release build
+
+# Package:
+tar czf idb-companion-arm64.tar.gz -C build/Build/Products/Release .
+```
+
+Prerequisites: Xcode 26+, `brew install xcodegen protobuf swift-protobuf`
+
+## Current State of the Work Machine
+
+On the work Mac (`/Users/jerimiah`):
+
+- **idb fork**: `/Users/jerimiah/Dev/idb` on branch `fix/group-children-fallback`
+  - NOT pushed to a remote yet — need to fork facebook/idb on GitHub first
+- **Pre-built tarball**: `/tmp/idb-companion-patched-arm64.tar.gz` (17MB)
+  - This is in `/tmp` — copy it somewhere durable before reboot!
+- **Running patched companion**: `~/.quern/bin/idb_companion` (PID varies)
+  - Started with: `DYLD_FRAMEWORK_PATH=~/.quern/bin:~/.quern/bin/PackageFrameworks ~/.quern/bin/idb_companion --udid <UDID> --grpc-domain-sock /tmp/idb/<UDID>_companion.sock --only simulator`
+  - Frameworks live alongside binary in `~/.quern/bin/` and `~/.quern/bin/PackageFrameworks/`
+- **Homebrew idb-companion was uninstalled** — `brew install facebook/fb/idb-companion` to restore if needed
+- **`/var/db/xcode_select_link` was removed** — the patched companion doesn't need it (falls back to `xcode-select -p`), but the Homebrew v1.1.8 companion DOES need it. If you reinstall the old companion, recreate with: `sudo ln -sf /Applications/Xcode.app/Contents/Developer /var/db/xcode_select_link`
+
+## Files Changed in the idb Fork (5 files)
+
+1. **`FBSimulatorControl/Commands/FBSimulatorAccessibilityCommands.m`** — THE FIX
+   - Added `probeChildlessGroupsInElements:keys:frontmostPid:collector:` method (~80 lines)
+   - Wired into `FBAXTranslationRequest_FrontmostApplication.run:` after recursive traversal
+   - Fixed sign conversion warnings in `FBAccessibilityCoverageGrid` (pre-existing)
+
+2. **`FBControlCore/Utility/FBXcodeConfiguration.m`** — xcode-select fallback
+   - `findXcodeDeveloperDirectory:` now falls back to `xcodeSelectDeveloperDirectory` subprocess when the `/var/db/xcode_select_link` symlink doesn't exist
+
+3. **`FBControlCore/Utility/FBVideoStream.m`** — build fix
+   - Added `#pragma clang diagnostic ignored "-Wgnu-folding-constant"` for Xcode 26 compat
+
+4. **`FBSimulatorControl/FBSimulatorControl.h`** — umbrella header fix
+   - Added missing `#import` for `FBPeriodicStatsTimer.h` and `FBSimulatorVideoStream_Testing.h`
+
+5. **`FBSimulatorControl/Framebuffer/FBSimulatorVideoStream_Testing.h`** — include fix
+   - Changed double-quoted includes to angle-bracket framework includes
+
+## How the Group Probe Works
+
+The fix is in `FBSimulatorAccessibilityCommands.m` inside `FBAXTranslationRequest_FrontmostApplication`:
+
+1. After the normal recursive tree traversal (`flatRecursiveDescriptionFromElement` / `nestedRecursiveDescriptionFromElement`), the `run:` method has a list of all discovered elements.
+
+2. The new code scans that list for elements where:
+   - `role == "AXGroup"` (Group container)
+   - Frame area > 5000 pt² (not a tiny icon group)
+
+3. For each such group, it probes a 30px grid within the group's frame using `[self.translator objectAtPoint:point displayId:0 bridgeDelegateToken:self.token]` — the same hit-testing API that `idb ui describe-point` uses.
+
+4. Hits that return an element with a DIFFERENT frame than the group itself are new discoveries. They're deduplicated by frame and added to the results with `discovery_method="group_probe"`.
+
+5. This runs BEFORE the remote content discovery step, so it doesn't interfere with cross-process element detection.
+
+**Why this works**: `accessibilityChildren` returns empty for these containers (Apple framework bug), but `objectAtPoint` uses a different code path in `AccessibilityPlatformTranslation` that correctly resolves elements at coordinates. The probe bridges this gap.
+
+**Performance**: A typical empty-list group (400x770 pt) generates ~300 probe points at 30px intervals. Each `objectAtPoint` call is ~0.5ms, so total probe time is ~150ms — imperceptible.
+
+## TODO
+
+1. Fork facebook/idb on GitHub → push branch → submit PR
+2. Upload tarball as GitHub release asset
+3. Update Quern setup to download + install instead of `brew install idb-companion`
+4. Update Quern's `idb.py` to launch companion from `~/.quern/bin/`
+5. Remove `"Group"` workaround from `_PROBEABLE_ROLES` if present (the companion now handles it natively)
+6. Unskip `test_basic_user_premium_cache_cta_C26613` in the search tests
+
+## Source
+
+- Fork branch: `fix/group-children-fallback` at `/Users/jerimiah/Dev/idb`
+- Based on: facebook/idb `main` @ `a571e0b3` (March 23, 2026)
+- Our commit: `7463e76d` — "Probe childless Group elements to discover hidden accessibility children"
+- PR: to be submitted to facebook/idb

--- a/docs/linux-support-plan.md
+++ b/docs/linux-support-plan.md
@@ -1,0 +1,306 @@
+# Linux Support Plan
+
+## Goal
+
+Support Android-only workflows on Linux. iOS features remain macOS-only (fundamental platform constraint — Xcode, simctl, CoreMediaIO don't exist on Linux). The server should detect the platform at startup and expose only the features available on that platform.
+
+## Scope
+
+**In scope (Linux Android-only):**
+- Server startup, daemon mode, API, MCP
+- Android device/emulator management (adb, uiautomator2)
+- Android log capture (logcat)
+- Android live preview (scrcpy)
+- Network proxy (mitmproxy — already cross-platform)
+- System proxy configuration (Linux equivalent)
+- Install script and setup for Linux
+- Certificate management for Android devices
+
+**Out of scope:**
+- iOS simulator/device support on Linux (impossible)
+- CoreMediaIO preview (Apple-only framework)
+- OSLog capture (macOS-only)
+- Windows native support (separate effort, if ever)
+
+## Platform Detection Strategy
+
+Add a `server/platform.py` module that exposes the current platform and available capabilities:
+
+```python
+import platform
+import shutil
+
+MACOS = platform.system() == "Darwin"
+LINUX = platform.system() == "Linux"
+
+HAS_SIMCTL = MACOS and shutil.which("xcrun") is not None
+HAS_ADB = shutil.which("adb") is not None
+HAS_SCRCPY = shutil.which("scrcpy") is not None
+```
+
+Code that currently assumes macOS uses these flags to gate behavior. iOS-specific routers are only mounted when `HAS_SIMCTL` is true (which already happens implicitly in many places, but should be explicit).
+
+## Changes by Component
+
+### 1. Install Script (`quern.dev/public/_install.sh`)
+
+**Current:** Hard-fails on non-Darwin.
+
+**Change:**
+- Accept Linux (`uname -s` == "Linux")
+- On Linux, skip Homebrew check (warn about system packages instead)
+- Use `apt`/`dnf`/`pacman` detection for prerequisite hints
+- Same tarball download mechanism (already platform-agnostic)
+- Same venv creation (Python's `venv` module is cross-platform)
+
+**Effort:** Small. Most of the script is already platform-neutral.
+
+### 2. Setup (`server/lifecycle/setup.py`)
+
+**Current:** Warns on non-Darwin, checks for Xcode/Homebrew, installs iOS deps.
+
+**Changes:**
+| Check | macOS | Linux |
+|-------|-------|-------|
+| `check_platform()` | Accept Darwin | Accept Linux |
+| `check_xcode_cli_tools()` | Keep | Skip |
+| `check_homebrew()` | Keep | Skip (detect `apt`/`dnf`/`pacman` instead) |
+| iOS deps (idb, libimobiledevice, etc.) | Keep | Skip |
+| Android deps (adb, scrcpy) | Keep | Keep (install via system package manager) |
+| `check_vpn()` | `route -n get default` | `ip route show default` |
+| `check_crash_dialog()` | `defaults read` | Skip |
+| `install_wrapper_script()` | Keep (`~/.local/bin`) | Keep (same path) |
+| `_detect_shell_rc()` | Prefers .zshrc | Prefer .bashrc |
+| Node.js install | `brew install node` | `apt install nodejs` / `dnf install nodejs` |
+| mitmproxy install | `pipx install mitmproxy` | Same (pipx is cross-platform) |
+
+**Effort:** Medium. Lots of conditional branches, but each one is straightforward.
+
+### 3. System Proxy (`server/proxy/system_proxy.py`)
+
+**Current:** Entirely macOS-specific — uses `route`, `networksetup`.
+
+**Linux approach:**
+
+```python
+if MACOS:
+    # existing networksetup logic
+elif LINUX:
+    # Option A: environment variables (works everywhere)
+    #   Set http_proxy/https_proxy in the shell
+    # Option B: gsettings (GNOME/GTK apps)
+    #   gsettings set org.gnome.system.proxy mode 'manual'
+    #   gsettings set org.gnome.system.proxy.http host '127.0.0.1'
+    #   gsettings set org.gnome.system.proxy.http port 9101
+    # Option C: Skip system proxy entirely
+    #   On Linux, users typically configure proxy per-app or per-device
+```
+
+**Recommendation:** For Android device proxy setup, the user configures the device's Wi-Fi proxy to point at the host machine — same as macOS physical device setup. System proxy is less relevant on Linux since there's no simulator traffic to transparently capture. Implement a minimal version (environment variables + gsettings for GNOME) and document manual setup for other desktop environments.
+
+**Effort:** Medium. The Android device proxy workflow is the same as macOS physical devices. System-wide proxy for the host machine is the complex part, but it's also less important for the Android use case.
+
+### 4. Local Capture (`mitmproxy-macos` System Extension)
+
+**Current:** macOS System Extension for transparent per-process capture.
+
+**Linux equivalent:** mitmproxy supports `--mode transparent` on Linux using iptables/nftables (requires `CAP_NET_ADMIN`). However, per-process filtering is harder — Linux transparent proxy typically captures all traffic on a network namespace or interface, not per-process.
+
+**Recommendation:** Skip local capture on Linux for now. Android devices are configured to proxy via Wi-Fi settings anyway — local capture is primarily useful for iOS simulators where you can't configure a proxy per-app.
+
+**Effort:** None (skip).
+
+### 5. Daemon Management
+
+#### Server daemon (`server/lifecycle/daemon.py`)
+
+**Current:** Uses `start_new_session=True` (POSIX setsid), double-fork pattern.
+
+**Status:** Already cross-platform. No changes needed.
+
+#### tunneld daemon (`server/device/tunneld.py`)
+
+**Current:** Uses launchd plist (`/Library/LaunchDaemons/com.quern.tunneld.plist`).
+
+**Linux approach:** tunneld is for iOS physical device USB tunneling via pymobiledevice3. This is iOS-only functionality.
+
+**However:** pymobiledevice3 does work on Linux for some device operations (backup, diagnostics). If we want to support iOS device access from Linux in the future (unlikely but possible), we'd use systemd:
+
+```ini
+[Unit]
+Description=Quern tunneld
+After=network.target
+
+[Service]
+ExecStart=/path/to/pymobiledevice3 remote start-tunnel
+Restart=on-failure
+
+[Install]
+WantedBy=default.target
+```
+
+**Recommendation:** Skip tunneld on Linux. It's iOS-only.
+
+**Effort:** None (skip).
+
+### 6. iOS Preview (`tools/ios-preview.swift`, `server/device/preview.py`)
+
+**Current:** Compiles Swift tool using CoreMediaIO/AVFoundation frameworks.
+
+**Linux:** Not applicable. CoreMediaIO is Apple-only.
+
+**Android preview already works:** scrcpy preview (`server/device/scrcpy_preview.py`) is cross-platform and handles Android devices.
+
+**Recommendation:** Gate `PreviewManager` (iOS preview) behind `MACOS`. Scrcpy preview works on Linux as-is.
+
+**Effort:** Minimal (add platform guard).
+
+### 7. Certificate Management (`server/proxy/cert_manager.py`)
+
+**Current:** Installs mitmproxy CA cert into iOS simulator TrustStore.sqlite3.
+
+**Linux:** Simulator cert install is iOS-only (skip). For Android devices, cert installation via adb push is already cross-platform.
+
+**Android cert flow** (already implemented): Push cert to device → install via Settings or `adb shell am start` intent.
+
+**Effort:** None — Android cert path already works.
+
+### 8. MCP Tool Registration
+
+**Current:** All 76 tools are registered regardless of platform.
+
+**Change:** Tools should still all be registered (MCP tools are lazy and don't consume context). But iOS-only tools should return a clear error on Linux: "This tool requires macOS with Xcode installed."
+
+**Alternative:** Only register platform-appropriate tools. This is cleaner but means the tool count varies by platform, which could confuse users reading docs.
+
+**Recommendation:** Register all tools, return helpful errors for iOS-only tools on Linux. This is simpler and self-documenting.
+
+**Effort:** Small. Add a platform check decorator or early return to iOS-only tool handlers.
+
+### 9. MCP Server (`mcp/src/`)
+
+**Current:** TypeScript, Node.js — already cross-platform.
+
+**Status:** No changes needed. `npm install` and `npm run build` work on Linux.
+
+### 10. API Route Registration
+
+**Current:** All routers mounted unconditionally.
+
+**Recommendation:** Keep all routes mounted. iOS-only endpoints return 400 with "iOS features require macOS" on Linux. This keeps the API surface consistent and discoverable (OpenAPI docs show all endpoints with platform notes).
+
+**Effort:** Small.
+
+## Install Script Changes (Detailed)
+
+```bash
+# Current
+if [ "$(uname -s)" != "Darwin" ]; then
+    die "Quern requires macOS."
+fi
+
+# New
+OS="$(uname -s)"
+case "$OS" in
+    Darwin) ok "macOS $(sw_vers -productVersion)" ;;
+    Linux)  ok "Linux $(uname -r)" ;;
+    *)      die "Quern requires macOS or Linux. Detected: $OS" ;;
+esac
+
+# Homebrew check — macOS only
+if [ "$OS" = "Darwin" ]; then
+    # existing brew check
+fi
+
+# Linux package manager detection
+if [ "$OS" = "Linux" ]; then
+    if command -v apt &>/dev/null; then
+        ok "apt (Debian/Ubuntu)"
+    elif command -v dnf &>/dev/null; then
+        ok "dnf (Fedora/RHEL)"
+    elif command -v pacman &>/dev/null; then
+        ok "pacman (Arch)"
+    else
+        warn "No supported package manager found"
+    fi
+fi
+```
+
+## Setup Changes (Detailed)
+
+The `run_setup()` function in `setup.py` needs platform-conditional sections:
+
+```python
+system = platform.system()
+
+# Always check
+report.add(check_platform())        # Accept Darwin and Linux
+report.add(check_python_version())
+report.add(check_node())
+
+# macOS-only
+if system == "Darwin":
+    report.add(check_xcode_cli_tools())
+    if has_ios:
+        # iOS deps: idb, libimobiledevice, etc.
+        ...
+    report.add(check_homebrew())
+
+# Android (both platforms)
+if has_adb:
+    report.add(check_adb())
+    report.add(check_scrcpy())
+
+# Proxy (platform-specific checks)
+report.add(check_vpn())             # Use ip route on Linux
+report.add(check_mitmproxy_cert())   # Cross-platform
+```
+
+## Rollout Plan
+
+### Phase 1: Platform abstraction (no user-facing changes)
+1. Create `server/platform.py` with capability flags
+2. Add platform guards to iOS-specific code paths
+3. Make setup.py accept Linux (but keep macOS as primary)
+4. Verify all Android code paths work without macOS assumptions
+5. Run test suite on Linux (GitHub Actions)
+
+### Phase 2: Linux install support
+1. Update install script to accept Linux
+2. Add Linux package manager detection to setup
+3. Implement Linux system proxy (minimal: env vars + gsettings)
+4. Update README with Linux instructions
+5. Test on Ubuntu 22.04+ and Fedora 38+
+
+### Phase 3: Polish
+1. Linux CI testing (GitHub Actions matrix)
+2. Linux-specific documentation on quern.dev
+3. Address any edge cases found during testing
+
+## Testing Strategy
+
+- Add a `platform` dimension to the test matrix (GitHub Actions: `runs-on: [macos-latest, ubuntu-latest]`)
+- iOS-specific tests should be skipped on Linux (`@pytest.mark.skipif(not MACOS)`)
+- Android tests should run on both platforms
+- Core server tests (API, storage, processing) should run on both platforms
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Android tools behave differently on Linux | Low | Medium | adb/u2 are well-tested cross-platform |
+| System proxy fragmentation across Linux DEs | High | Low | Document manual setup, minimal auto-config |
+| mitmproxy version differences on Linux | Low | Low | Pin version in requirements |
+| Users expect iOS support on Linux | Medium | Low | Clear docs, helpful error messages |
+| Maintenance burden of two platforms | Medium | Medium | Platform abstraction layer, CI matrix |
+
+## Estimated Effort
+
+| Phase | Effort |
+|-------|--------|
+| Phase 1: Platform abstraction | 1-2 days |
+| Phase 2: Linux install support | 1-2 days |
+| Phase 3: Polish | 1 day |
+| **Total** | **3-5 days** |
+
+Most of the work is conditional logic in setup.py and the install script. The server itself is already ~90% cross-platform for Android workflows.

--- a/docs/screen-identification-in-actions.md
+++ b/docs/screen-identification-in-actions.md
@@ -1,0 +1,188 @@
+# Screen Identification in Action Responses
+
+## Problem
+
+The `feature/screen-landmarks` branch ships landmarks (declarative, structured screen identifiers) and exposes identification through `GET /ui/summary?identify=true`. That's useful, but it requires a follow-up call: an agent has to act, then call `get_screen_summary` separately to confirm where they landed.
+
+The high-value pattern is **single round-trip**: agent acts, response tells them where they landed (and whether it matched expectations). This is the assertion side of landmarks — the part that's strictly safer than imperative recipes — and it's a small lift now that the screen-landmarks plumbing exists.
+
+## Goal
+
+When an agent calls an action endpoint that returns screen context, that screen context should include landmark-based identification automatically. Optionally, the agent can declare what screen they expect to land on, and the response tells them whether reality matched.
+
+## Non-goals
+
+- Navigation recipes, retry loops, or any procedural execution. The line drawn during screen-landmarks review stands: **landmarks are assertions, recipes are actions.** This spec is strictly on the assertion side.
+- Auto-recovery on mismatch. The server reports; the agent decides what to do.
+- Probabilistic / fuzzy screen matching beyond what landmarks already do.
+
+## Existing plumbing this builds on
+
+Already in main (predates `feature/screen-landmarks`):
+- `_capture_screen_context()` in `server/api/device_ui.py` — single helper that builds the screen-context dict
+- `include_screen_context: bool` on `tap_element` and `type_text` — opt-in screen capture after a successful action
+- `tap_element` on `not_found` already raises 404 with screen context in the detail (line 357)
+
+Added in `feature/screen-landmarks`:
+- `LandmarkRegistry` on `request.app.state.landmark_registry`
+- `registry.identify(elements) -> {"matched": str|None, "confidence": float, ...}`
+
+The follow-up is mostly wiring these together at one chokepoint.
+
+## Design
+
+### Behavior
+
+1. **Auto-identify when landmarks are loaded.** Inside `_capture_screen_context()`, after fetching elements, if the registry has any landmarks loaded, run `registry.identify(elements)` and add `identified_as` + `confidence` to the screen-context payload. Zero cost when no landmarks are loaded (no-op).
+
+2. **Optional `expected_screen` parameter on action endpoints.** When provided, the response includes `matched_expected: bool` based on whether `identified_as == expected_screen`. `expected_screen` implies `include_screen_context=true` — no point asking what screen you landed on without capturing the screen.
+
+3. **Surface ambiguity honestly.** If `registry.identify()` returns multiple candidate matches (collision), include them as `candidates: [...]` and set `confidence` accordingly. Don't silently pick one.
+
+4. **No new behavior when landmarks aren't loaded.** Endpoints continue to behave exactly as today. This is purely additive.
+
+### API surface
+
+**Affected endpoints** (all existing, all in `server/api/device_ui.py`):
+- `POST /ui/tap-element` — primary use case
+- `POST /ui/type` — for "did I successfully submit?"
+- `POST /ui/swipe` — for paged/carousel navigation
+- `POST /ui/press` — for hardware button transitions (home, volume, etc.)
+- (`POST /ui/clear` — probably skip; clearing text doesn't change screens)
+
+**New request fields** (all optional, all on the existing request models):
+```python
+expected_screen: str | None = None  # screen name to assert against
+# include_screen_context already exists; expected_screen implies True
+```
+
+**New response fields inside `screen_context`:**
+```json
+{
+  "screen_context": {
+    "summary": { ... existing ... },
+    "identified_as": "Login",        // null if no match
+    "confidence": 1.0,                // 0.0-1.0
+    "candidates": ["Login", "Signup"],// only when ambiguous
+    "matched_expected": false,        // only when expected_screen was provided
+    "expected": "Map"                 // echo, only when expected_screen was provided
+  }
+}
+```
+
+### Example exchanges
+
+**Happy path — agent expectation matches reality:**
+```
+POST /ui/tap-element
+{ "label": "Sign In", "expected_screen": "Map" }
+
+200 OK
+{
+  "status": "ok",
+  "tapped": {...},
+  "screen_context": {
+    "identified_as": "Map",
+    "confidence": 1.0,
+    "matched_expected": true,
+    "expected": "Map"
+  }
+}
+```
+
+**Mismatch — agent thought they'd land on Map, but Login still showing:**
+```
+200 OK
+{
+  "status": "ok",
+  "tapped": {...},
+  "screen_context": {
+    "summary": { ... full screen for recovery ... },
+    "identified_as": "Login",
+    "confidence": 1.0,
+    "matched_expected": false,
+    "expected": "Map"
+  }
+}
+```
+
+**Element not found — 404 already returns screen context; identification gets folded in for free:**
+```
+404
+{
+  "status": "not_found",
+  "screen_context": {
+    "identified_as": "Environment Picker",
+    "confidence": 1.0
+  }
+}
+```
+
+## Implementation plan
+
+Estimated total: ~50-80 lines of source change + ~150 lines of tests.
+
+### Files to touch
+
+| File | Change |
+|---|---|
+| `server/api/device_ui.py` | Update `_capture_screen_context()` to call `registry.identify()` when landmarks loaded; add `expected_screen` to relevant request models; thread through to screen_context; raise 400 when `expected_screen` set but registry empty |
+| `server/models.py` | Add optional `expected_screen: str \| None` to `TapElementRequest`, `TypeTextRequest`, `SwipeRequest`, `PressButtonRequest`; add `include_screen_context` to `SwipeRequest` and `PressButtonRequest` |
+| `server/device/landmarks.py` | Update `registry.identify()` to return `1/N` confidence + `candidates` list on ambiguous matches |
+| `mcp/src/tools/device-ui.ts` | Add `expected_screen` to MCP tool input schemas for the matching tools; add `include_screen_context` to swipe/press wrappers |
+| `tests/test_device_api.py` | New cases for: identify when landmarks loaded, no-op when not loaded, `expected_screen` match, `expected_screen` mismatch, `expected_screen` with no landmarks loaded (400), ambiguous identification |
+| `tests/test_landmarks.py` | New cases for ambiguous-match confidence scoring |
+| `docs/screen-landmarks.md` | Add a section on the action-bundled assertion pattern |
+
+### MCP tools updated
+
+- `tap_element` — add `expected_screen`
+- `type_text` — add `expected_screen`
+- `swipe` — add `expected_screen` and `include_screen_context`
+- `press_button` — add `expected_screen` and `include_screen_context`
+
+The MCP wrapper stays thin: parameters pass straight through.
+
+### Order of work
+
+1. Land identification in `_capture_screen_context()` (smallest diff, highest reuse)
+2. Add `expected_screen` to one endpoint (`tap_element`) end-to-end with tests
+3. Replicate to other endpoints
+4. Update MCP wrappers
+5. Doc update
+
+## Test plan
+
+- **Unit:** `_capture_screen_context()` with/without registry populated, with/without `expected_screen`, with ambiguous landmarks; `registry.identify()` ambiguous-match confidence scoring
+- **Integration:** API-level tests posting to each affected endpoint, asserting screen_context shape; 400 when `expected_screen` set but no landmarks loaded
+- **MCP:** schema validation that `expected_screen` is accepted as optional string
+
+## Decisions
+
+1. **`expected_screen` implies `include_screen_context=true`.** Asking what screen you landed on without capturing the screen context is meaningless; promote it automatically rather than erroring on a contradictory combination.
+2. **Error 400 when `expected_screen` is given but no landmarks loaded.** Returning `matched_expected: null` would silently degrade; the agent has stated an expectation that the server cannot evaluate. Response should hint at the fix, e.g.:
+   ```json
+   { "detail": "Cannot evaluate expected_screen=Map: no landmarks loaded. POST /landmarks/load first." }
+   ```
+3. **Add `include_screen_context` to `swipe` and `press` as part of this work.** Keeps the surface coherent — every action that can change the screen should be able to report what it changed to. Trivial addition since `_capture_screen_context()` already exists.
+4. **Parameter name: `expected_screen`.** Matches the house convention of descriptive parameter names (`max_elements`, `include_screen_context`, `skip_stability_check`); `expect` would be jarringly terse next to its neighbors. Pairs naturally with the response field `matched_expected`.
+5. **Confidence scoring for ambiguous matches.** Update `registry.identify()` so that when N landmarks match, confidence becomes `1/N` and `candidates` lists all matches. Single match stays `confidence: 1.0`. No match stays `confidence: 0.0`. This is a small change inside `server/device/landmarks.py` and warrants its own test cases.
+
+## Naming convention check
+
+Response fields use the past-tense / observed framing:
+- `identified_as` — what the server determined (matches existing pattern in screen-landmarks branch)
+- `matched_expected` — boolean, did `identified_as` equal `expected_screen`
+- `expected` — echo of the input (helpful for log inspection)
+- `candidates` — present only on ambiguous match
+- `confidence` — float 0.0-1.0
+
+Request fields use imperative / declarative framing:
+- `expected_screen` — what the agent declares it expects
+- `include_screen_context` — what the agent asks the server to do (existing)
+
+## Out of scope (do not pursue here)
+
+- Navigation recipes (`docs/navigation-recipes.md`) — separate decision, currently in proposal status
+- Server-side retry loops or "wait until expected screen appears" — that's the slippery slope into recipe territory
+- Mutating actions based on identification (e.g., "if landed on unexpected screen, auto-back-out") — same slope

--- a/docs/screen-identification-in-actions.md
+++ b/docs/screen-identification-in-actions.md
@@ -1,5 +1,14 @@
 # Screen Identification in Action Responses
 
+> **Status (v0.13):** the underlying landmark engine — `LandmarkRegistry`,
+> `identify_screen`, `get_screen_summary?identify=true` — is shipped (v0.11
+> with v0.12 refinements). The narrower work this doc proposes is **not**:
+> `_capture_screen_context` does not call `registry.identify()`, and the
+> `expected_screen` request parameter / `matched_expected` response field
+> are not present in the codebase. This remains a forward-looking spec
+> for bundling identification into action responses (`tap_element`,
+> `type_text`, `swipe`, `press_button`) in a single round-trip.
+
 ## Problem
 
 The `feature/screen-landmarks` branch ships landmarks (declarative, structured screen identifiers) and exposes identification through `GET /ui/summary?identify=true`. That's useful, but it requires a follow-up call: an agent has to act, then call `get_screen_summary` separately to confirm where they landed.

--- a/docs/sim-bridge-spec.md
+++ b/docs/sim-bridge-spec.md
@@ -1,5 +1,13 @@
 # sim-bridge: Native Simulator Control for Quern
 
+> **Status: shipped in v0.13.** This doc is the original design spec — kept
+> for the rationale and the technique notes (private-framework dlopen,
+> token dispatcher pattern, IOHIDDigitizer path). The implementation lives
+> in `tools/sim-bridge.swift` and `server/device/sim_bridge.py`. Behavior
+> notes (button name normalization, server-side `objectAtPoint` probing,
+> RadioButton/CheckBox in summaries, installer skip on Xcode 26+) accrued
+> after the spec was written — see `CHANGELOG.md` for the running list.
+
 ## Problem
 
 Quern currently depends on Meta's `idb` (idb_companion) for all simulator UI automation:

--- a/docs/sim-bridge-spec.md
+++ b/docs/sim-bridge-spec.md
@@ -1,0 +1,314 @@
+# sim-bridge: Native Simulator Control for Quern
+
+## Problem
+
+Quern currently depends on Meta's `idb` (idb_companion) for all simulator UI automation:
+accessibility tree queries, tap/swipe/type gestures, and button presses. idb has several
+pain points:
+
+- **Aging project** — Meta's investment has slowed; compatibility with newer Xcode versions is fragile
+- **Companion daemon** — idb_companion must be running and connected; reconnection logic adds complexity
+- **Subprocess per call** — every `idb ui describe-all` or `idb ui tap` spawns a new process
+- **Screenshots via simctl** — separate subprocess for each capture, no streaming capability
+- **Xcode 26 breakage** — some idb operations fail or behave differently on iOS 26 simulators
+- **Empty container bug** — idb's `describe-all --nested` returns empty children for nav/tab/toolbars,
+  requiring Quern's multi-point probing workaround
+
+## Solution
+
+A new Swift helper binary (`sim-bridge`) that replaces idb for simulator control by using Apple's
+private frameworks directly. Runs as a long-lived subprocess communicating via JSON Lines over
+stdin/stdout — the same pattern as Quern's existing `ios-preview` helper.
+
+## Prior Art
+
+The techniques are drawn from [baguette](https://github.com/tddworks/baguette) (MIT license),
+which itself credits [AXe](https://github.com/cameroncooke/AXe) and
+[SilbercueSwift](https://github.com/nicktmro/SilbercueSwift) for the accessibility bridge pattern.
+The IOHIDDigitizer tap/swipe path was developed in baguette to fix Xcode 26 regressions.
+
+## Architecture
+
+```
+Python server (SimBridgeBackend)
+    │
+    ├── stdin  → JSON Lines commands
+    │             {"cmd":"describe-ui", "udid":"...", ...}
+    │
+    └── stdout ← JSON Lines responses
+                  {"ok":true, "tree":{...}}
+
+tools/sim-bridge.swift
+    │
+    ├── AccessibilityPlatformTranslation.framework (dlopen)
+    │     AXPTranslator + TokenDispatcher → accessibility tree via XPC
+    │
+    ├── SimulatorKit.framework (dlopen)
+    │     IndigoHIDMessage* / IOHIDDigitizerDispatch → touch injection
+    │     SimDeviceLegacyHIDClient → HID message transport
+    │
+    ├── CoreSimulator.framework (dlopen)
+    │     SimServiceContext / SimDevice → device discovery and XPC
+    │
+    └── IOSurface + SimulatorKit framebuffer callbacks → screenshots
+```
+
+All private frameworks are loaded via `dlopen`/`dlsym`/`NSClassFromString` at runtime.
+No compile-time linking to private frameworks. The binary compiles with only public
+frameworks: Foundation, IOSurface, CoreGraphics, ImageIO.
+
+## Capabilities
+
+### 1. Accessibility Tree
+
+Query the full accessibility tree or hit-test a point for any booted simulator.
+
+**Command:**
+```json
+{"cmd": "describe-ui", "udid": "XXXX"}
+{"cmd": "describe-ui", "udid": "XXXX", "x": 100, "y": 200}
+```
+
+**Response:**
+```json
+{
+  "ok": true,
+  "tree": {
+    "role": "AXApplication",
+    "label": "MyApp",
+    "frame": {"x": 0, "y": 0, "width": 393, "height": 852},
+    "enabled": true,
+    "children": [...]
+  }
+}
+```
+
+**Node schema:**
+```
+role: string          — AXButton, AXStaticText, etc.
+subrole: string?      — AXSecureTextField, etc.
+label: string?        — accessibilityLabel
+value: string?        — accessibilityValue
+identifier: string?   — accessibilityIdentifier
+title: string?        — accessibilityTitle
+frame: {x, y, width, height}  — device points
+enabled: bool
+focused: bool
+hidden: bool
+children: [node]
+```
+
+**Implementation:** `AXPTranslator.sharedInstance` with a `TokenDispatcher` installed as
+`bridgeTokenDelegate`. Each query registers a UUID token, obtains the frontmost app's
+translation object, stamps the subtree with the token, then walks the tree into `AXNode`
+values. Hit-test fetches the full tree and does client-side recursive point-in-rect search
+(deepest child wins).
+
+### 2. Input Injection
+
+Tap, swipe, type text, press buttons on any booted simulator.
+
+**Commands:**
+```json
+{"cmd": "tap", "udid": "XXXX", "x": 100, "y": 200}
+{"cmd": "tap", "udid": "XXXX", "x": 100, "y": 200, "hold": 0.5}
+{"cmd": "swipe", "udid": "XXXX", "x1": 200, "y1": 400, "x2": 200, "y2": 100, "duration": 0.3}
+{"cmd": "type", "udid": "XXXX", "text": "hello world"}
+{"cmd": "button", "udid": "XXXX", "name": "home"}
+{"cmd": "button", "udid": "XXXX", "name": "lock"}
+{"cmd": "key", "udid": "XXXX", "code": 42}
+```
+
+**Response:**
+```json
+{"ok": true}
+{"ok": false, "error": "Simulator not booted"}
+```
+
+**Supported buttons:** `home`, `lock`, `volumeUp`, `volumeDown`, `swipeToHome`,
+`swipeToAppSwitcher`
+
+**Implementation:**
+- **Single-finger tap/swipe:** IOHIDDigitizer path (Xcode 26+). Build `IOHIDEvent`
+  digitizer parent + finger child, wrap via `IndigoHIDMessageForTrackpadEventFromHIDEventRef`,
+  patch target/edge bytes, dispatch via `SimDeviceLegacyHIDClient`.
+- **Text:** Decompose each character to (keycode, modifiers), send via
+  `IndigoHIDMessageForHIDArbitrary` on HID page 7.
+- **Buttons:** `IndigoHIDMessageForButton` (home/lock) or
+  `IndigoHIDMessageForHIDArbitrary` (volume, power).
+- **Gesture buttons:** Synthesized swipes for swipeToHome, swipeToAppSwitcher.
+
+Coordinates are in device points (same as accessibility tree frames).
+
+### 3. Screenshots
+
+Capture a single frame as JPEG from any booted simulator.
+
+**Command:**
+```json
+{"cmd": "screenshot", "udid": "XXXX"}
+{"cmd": "screenshot", "udid": "XXXX", "quality": 0.8, "scale": 2}
+```
+
+**Response:**
+```json
+{"ok": true, "data": "<base64 JPEG>", "width": 393, "height": 852}
+```
+
+**Implementation:** Register framebuffer callback on `SimDeviceIO` port
+`com.apple.framebuffer.display`, capture first `IOSurface`, encode to JPEG via
+`CGImageDestination`, return as base64. Optionally downscale via `CIContext`.
+
+The framebuffer callback is registered on-demand and torn down after capture.
+No persistent screen subscription for one-shot screenshots. (Streaming is out of
+scope — that's ios-preview's domain for physical devices; simulator streaming could
+be added later.)
+
+### 4. Device Discovery
+
+List booted simulators with state info. Supplementary to simctl — provides a fast
+check without spawning a subprocess.
+
+**Command:**
+```json
+{"cmd": "list"}
+```
+
+**Response:**
+```json
+{
+  "ok": true,
+  "devices": [
+    {"udid": "XXXX", "name": "iPhone 17 Pro", "state": "booted", "runtime": "iOS 26.4"},
+    {"udid": "YYYY", "name": "iPad Air", "state": "shutdown", "runtime": "iOS 26.4"}
+  ]
+}
+```
+
+**Implementation:** `SimServiceContext.sharedServiceContext` → `defaultDeviceSet` →
+`availableDevices`, reading UDID, name, state, runtime via KVC.
+
+## Wire Protocol
+
+- **Transport:** stdin/stdout pipes managed by Python `asyncio.subprocess`
+- **Format:** JSON Lines — one JSON object per line, newline-delimited
+- **Request:** `{"cmd": "<command>", ...params}`
+- **Response:** `{"ok": true, ...data}` or `{"ok": false, "error": "message"}`
+- **Ordering:** Strictly sequential — one request, one response. No interleaving.
+  (Concurrency is handled on the Python side by queuing requests.)
+- **Lifecycle:**
+  - On launch: emit `{"event": "ready"}` after frameworks are loaded
+  - On stdin EOF: exit cleanly
+  - On fatal error: emit `{"ok": false, "error": "..."}` and continue if possible
+
+## Python Integration
+
+### SimBridgeBackend
+
+New file: `server/device/sim_bridge.py`
+
+```python
+class SimBridgeBackend:
+    """Simulator UI backend using the sim-bridge Swift helper."""
+
+    async def describe_all(self, udid: str) -> dict: ...
+    async def describe_point(self, udid: str, x: float, y: float) -> dict: ...
+    async def tap(self, udid: str, x: float, y: float, duration: float = 0.05) -> None: ...
+    async def swipe(self, udid: str, x1, y1, x2, y2, duration: float = 0.3) -> None: ...
+    async def type_text(self, udid: str, text: str) -> None: ...
+    async def press_button(self, udid: str, button: str) -> None: ...
+    async def screenshot(self, udid: str, quality: float = 0.7, scale: int = 1) -> bytes: ...
+```
+
+Manages the sim-bridge subprocess lifecycle:
+- Compile on demand (same mtime-based caching as ios-preview)
+- Launch on first use, keep alive for the server's lifetime
+- Request queue with `asyncio.Lock` to serialize stdin/stdout pairs
+- Auto-restart on process death
+- Compile command: `swiftc -o <binary> sim-bridge.swift -framework Foundation -framework IOSurface -framework CoreGraphics -framework ImageIO`
+
+### Backend Selection
+
+In `server/device/controller_ui.py`, `_ui_backend()` gains a new preference order:
+
+```python
+async def _ui_backend(self, udid: str) -> UIBackend:
+    if is_android(udid):
+        return U2Backend(udid)
+    if is_physical_ios(udid):
+        return WdaBackend(udid)
+    # Simulator
+    if self._sim_bridge_available:
+        return SimBridgeBackend(udid)
+    if self._idb_available:
+        return IdbBackend(udid)
+    raise RuntimeError("No simulator UI backend available")
+```
+
+sim-bridge is preferred when available. idb remains as fallback.
+
+### Screenshot Integration
+
+`DeviceController.take_screenshot()` for simulators currently calls
+`xcrun simctl io <udid> screenshot`. With sim-bridge available, it can route through
+`SimBridgeBackend.screenshot()` instead — zero-copy IOSurface capture instead of
+spawning a subprocess.
+
+## Build Requirements
+
+- macOS 15+ (Sequoia)
+- Apple Silicon
+- Xcode 26+ (for SimulatorKit / CoreSimulator private framework compatibility)
+- Swift 6.1+ (ships with Xcode 26)
+
+The binary will NOT work on Intel Macs or with older Xcode versions. This matches
+baguette's requirements and reflects the reality that Apple's private frameworks
+are architecture-specific.
+
+## File Layout
+
+```
+tools/sim-bridge.swift          — Single-file Swift source (~1000-1200 lines)
+server/device/sim_bridge.py     — Python backend (subprocess manager + protocol)
+server/device/idb.py            — Existing idb backend (kept as fallback)
+```
+
+## Out of Scope
+
+- **Frame streaming** — ios-preview handles physical device video; simulator streaming
+  via IOSurface could be added later but is not needed for UI automation
+- **Two-finger gestures** (pinch, pan) — rarely needed for testing; can be added later
+  using the legacy IndigoHIDMessageForMouseNSEvent path
+- **Keyboard modifiers** (Cmd+C, etc.) — can be added later
+- **Log capture** — Quern already has its own log capture via `xcrun simctl spawn`;
+  baguette uses the same approach so there's nothing to gain
+- **Orientation control** — can be added later via SimulatorKit's orientation APIs
+- **Replacing simctl for device lifecycle** — boot/shutdown/erase/install will continue
+  using simctl; sim-bridge focuses on UI automation and screenshots
+
+## Risks
+
+1. **Private API stability** — Apple can change these frameworks at any Xcode release.
+   Baguette already hit this with Xcode 26 breaking single-finger taps. Mitigation:
+   the idb fallback remains available, and the community (baguette, AXe, XcodeBuildMCP)
+   collectively tracks breakages.
+
+2. **Code signing** — Some private APIs check the caller's code signature. `xcrun simctl
+   spawn` works because simctl is Apple-signed. Our binary is ad-hoc signed.
+   Baguette works fine ad-hoc, so this is likely not an issue for the APIs we use.
+
+3. **Single-file complexity** — ~1200 lines in one Swift file is manageable (ios-preview
+   is 720 lines) but approaching the limit. If it grows significantly, we could split
+   into a small SPM package, but the single-file compile-and-cache approach is much
+   simpler operationally.
+
+## Success Criteria
+
+- `describe-ui` returns equivalent data to `idb ui describe-all --nested` (same fields,
+  same coordinate system)
+- `tap`/`swipe`/`type`/`button` work on iOS 26.4 simulators
+- Screenshots are byte-equivalent quality to simctl screenshots
+- No idb dependency required for simulator UI automation
+- Existing Quern MCP tools (`get_ui_tree`, `tap_element`, `take_screenshot`, etc.)
+  work transparently with the new backend
+- idb fallback works when sim-bridge binary can't be compiled (e.g., no Xcode)

--- a/docs/vision-event-model.md
+++ b/docs/vision-event-model.md
@@ -1,0 +1,190 @@
+# Quern Event Model & Helm Vision
+
+## The core idea
+
+Quern already captures three streams of data: device logs, network traffic, and UI state. Right now these are separate — you query logs in one tool, flows in another, screenshots in a third. The human (or agent) does the correlation mentally.
+
+The event model unifies them into a single timeline where actions, observations, and state changes are linked. Helm visualizes that timeline instead of showing raw streams.
+
+## What we have today
+
+These aren't hypothetical — they're shipping:
+
+- **UI automation** — tap, swipe, type, read accessibility tree
+- **Network capture** — full request/response interception, mocking, replay
+- **Log pipeline** — structured, filterable, multi-source (syslog, logcat, crash, build, plist)
+- **Plist watcher** — real-time state observation with diffs
+- **State checkpoints** — save/restore app state for reproducible starting points
+- **App knowledge base** — persistent graph of screens, navigation, alerts, quirks
+- **`set_location`, `open_url`** — device environment control
+
+The gap: these are independent tools. Nothing ties "agent tapped Login" to "POST /auth fired" to "authToken appeared in plist" to "home screen loaded."
+
+## Phase 1: Unified event stream
+
+**Goal:** Every tool call and every captured signal becomes an event in a shared timeline.
+
+### The event primitive
+
+```python
+class Event:
+    id: str
+    timestamp: datetime
+    type: Literal["action", "observation", "state_change", "anomaly"]
+    source: Literal["agent", "device", "network", "log", "plist"]
+    summary: str              # human-readable one-liner
+    data: dict                # type-specific payload
+    correlation_id: str | None  # groups related events
+    device_id: str | None     # which device
+```
+
+That's it. No inference events, no confidence scores, no hypothesis fields. Just facts with an optional correlation ID to group them.
+
+### What becomes an event
+
+| Source | Event type | Example |
+|--------|-----------|---------|
+| MCP tool call | action | "tap_element label='Login'" |
+| Proxy flow | observation | "POST /api/auth → 500" |
+| Log entry (error+) | observation | "AuthError: invalid token" |
+| Plist change | state_change | "authToken: null → 'abc123'" |
+| Crash report | observation | "EXC_BAD_ACCESS in LoginVC" |
+| Screenshot | observation | "screenshot captured" |
+| Anomaly detector | anomaly | "30 identical requests in 2s" |
+
+### Correlation
+
+When the agent calls a tool, the server assigns a `correlation_id`. Any events that occur within a short time window (1-2s) on the same device get the same ID. This is imperfect but useful — it ties "tap Login" to the network request and state change that follow.
+
+The correlation is best-effort. No causal graphs, no weighted signals. Just temporal proximity on the same device.
+
+### Where this lives
+
+A new event store in the server, similar to the existing ring buffer for logs and FlowStore for proxy. Events are append-only, queryable by time range, device, type, and correlation_id.
+
+### API surface
+
+- `GET /api/v1/events` — query with filters
+- `GET /api/v1/events/summary` — cursor-based summary (same pattern as log/flow summaries)
+- SSE stream for real-time consumption by Helm
+
+## Phase 2: Event bundles
+
+**Goal:** Group related events into human-readable chunks.
+
+### The bundle
+
+```python
+class EventBundle:
+    id: str
+    title: str               # "Login Attempt #3"
+    events: list[str]         # event IDs
+    start_time: datetime
+    end_time: datetime
+    outcome: Literal["success", "failure", "unknown"] | None
+```
+
+### How bundles form
+
+Start simple with two strategies:
+
+1. **Correlation-based** — events sharing a `correlation_id` form a bundle automatically
+2. **Flow-based** — when executing a knowledge base flow, the entire flow execution is a bundle
+
+Don't try to auto-detect bundle boundaries from raw event streams. That's an ML problem disguised as a heuristic problem. Use the correlation IDs and explicit flow execution as natural boundaries.
+
+### What this enables
+
+A bundle like "Login Attempt #3" contains: the tap action, the network request, the response, the plist change (or lack thereof), and the resulting screen. Click it in Helm and you see the whole story instead of hunting through three separate streams.
+
+## Phase 3: Anomaly detection
+
+**Goal:** Automatically surface things that look wrong.
+
+Start with three simple detectors. No ML, no scoring models. Just rules:
+
+### Request bursts
+If the same endpoint is hit N+ times within T seconds, emit an anomaly event.
+- Default: 5+ identical requests in 3 seconds
+- This catches reactive loops, missing debounce, retry storms
+
+### Repeated errors
+If the same error message appears N+ times in T seconds in the log stream, emit an anomaly.
+- Default: 3+ identical errors in 10 seconds
+- This catches error cascades, crash loops
+
+### State contradictions
+If the plist says one thing and the UI says another, flag it.
+- Example: `authToken` exists in plist but login screen is visible
+- This requires checking plist state against screen identity from the knowledge base
+- Only works when the knowledge base is populated — that's fine, it's a progressive enhancement
+
+Each detector runs as a lightweight background task in the server, watching the event stream.
+
+## Phase 4: Helm timeline
+
+**Goal:** Helm's primary view is a timeline, not a device grid.
+
+### Layout
+
+```
+┌─────────────────────────────────────────────────────┐
+│  [Device selector]              [Time range] [Live] │
+├──────────────────────┬──────────────────────────────┤
+│                      │                              │
+│  Timeline            │  Detail panel                │
+│                      │                              │
+│  ▶ Login Attempt #3  │  [Screenshot]                │
+│    tap Login         │                              │
+│    POST /auth → 500  │  Network: POST /auth         │
+│    ⚠ AuthError       │  Status: 500                 │
+│    UI: error banner  │  Body: {"error": "invalid"}  │
+│                      │                              │
+│  ⚠ 30 requests/2s   │  Logs:                       │
+│                      │  AuthError: invalid token    │
+│  ▶ Login Attempt #4  │                              │
+│    ...               │  State:                      │
+│                      │  authToken: (unchanged)      │
+│                      │                              │
+├──────────────────────┴──────────────────────────────┤
+│  [Live device preview]                    (optional) │
+└─────────────────────────────────────────────────────┘
+```
+
+- Left panel: timeline of bundles and standalone events, newest at top
+- Anomalies float to the top with visual emphasis
+- Click a bundle to expand events; click an event to see detail
+- Right panel: context for selected event — network detail, logs, screenshot, state diff
+- Device grid becomes a selector, not the primary view
+
+### What makes this different from DevTools
+
+DevTools shows you raw streams and you correlate mentally. Helm shows you stories (bundles) with correlated data pre-linked. Click a network request and the related log entries, UI change, and state diff are right there.
+
+## What to defer
+
+These are interesting ideas from the conversation that aren't worth building yet:
+
+- **Inference events / agent reasoning display** — Requires hooking into the agent's thought process, which we don't control. The agent's reasoning lives in Claude's context, not in Quern. Revisit if/when MCP adds a way for tools to receive agent reasoning.
+- **Confidence scores on state** — Binary is fine. Either the plist says the user is logged in or it doesn't.
+- **Auto-discovery of state channels** (file system scanning, sqlite watching) — The plist watcher works. Generalize when there's a second concrete use case, not before.
+- **State recipes as a formal system** — We already have checkpoints. They work. Don't abstract them into a recipe framework until the pattern proves itself.
+- **Replay / scrubbing** — Requires recording enough state to recreate the app at any point. That's a massive engineering effort for uncertain value. Capture everything; build replay later if the data proves useful.
+- **Editable history** — Cool concept, no clear use case yet.
+
+## Implementation order
+
+1. **Event primitive + store** — Add to the server. Emit events from existing tool calls and capture pipelines. No new capabilities, just unification.
+2. **Event query API** — `/api/v1/events` with filtering. Expose via MCP tool.
+3. **Correlation** — Assign correlation IDs in tool calls, match nearby events.
+4. **Anomaly detectors** — Request burst and repeated error detectors. Run as background tasks.
+5. **Bundles** — Group by correlation ID. Add flow-execution bundles.
+6. **Helm timeline** — Primary view showing bundles + anomalies. Detail panel with cross-referenced data.
+
+Steps 1-4 are server-side and benefit both CLI agents and Helm. Step 5 is the bridge. Step 6 is Helm-specific.
+
+## The framing
+
+Quern is not a test framework. It's not a debug dashboard. It's an interface layer between AI and mobile apps — execution, observation, and understanding in a closed loop.
+
+Helm is how humans see that loop working.

--- a/mcp/src/tools/device-ui.ts
+++ b/mcp/src/tools/device-ui.ts
@@ -5,7 +5,7 @@ import { strictParams } from "./helpers.js";
 
 export function registerDeviceUITools(server: McpServer): void {
   server.registerTool("get_ui_tree", {
-    description: `Get the full accessibility tree (all UI elements) from the current screen. Optionally scope to children of a specific element using children_of. Requires idb.
+    description: `Get the full accessibility tree (all UI elements) from the current screen. Optionally scope to children of a specific element using children_of.
 
 Pass include_raw=true when debugging the platform normalizer itself — e.g., to see whether an Android node carries selected="true" or some other source attribute that didn't make it into our canonical fields. Each element gains an extra_attrs dict of the raw source attributes from the underlying provider (uiautomator2 XML on Android; iOS not yet populated). Default false to keep payloads small.`,
     inputSchema: strictParams({
@@ -36,7 +36,7 @@ Pass include_raw=true when debugging the platform normalizer itself — e.g., to
       mode: z
         .enum(["flat"])
         .optional()
-        .describe("Use 'flat' for enhanced element discovery with the custom idb companion. Default uses nested mode with probe-based discovery. Simulators only."),
+        .describe("Use 'flat' to engage the patched idb companion's flat-mode output (idb backend only). Rarely needed: the default path (sim-bridge on Xcode 26+/Apple Silicon, idb elsewhere) already probes hidden tab-bar/nav-bar children. Simulators only."),
       include_raw: z
         .coerce.boolean()
         .optional()
@@ -75,7 +75,7 @@ Pass include_raw=true when debugging the platform normalizer itself — e.g., to
   });
 
   server.registerTool("get_element_state", {
-    description: `Get a single element's state without fetching the entire UI tree. More efficient than get_ui_tree when you only need to check one element. Returns the element with its current state (enabled, value, etc.). If multiple elements match, returns the first with a match_count field. Requires idb.`,
+    description: `Get a single element's state without fetching the entire UI tree. More efficient than get_ui_tree when you only need to check one element. Returns the element with its current state (enabled, value, etc.). If multiple elements match, returns the first with a match_count field.`,
     inputSchema: strictParams({
       label: z
         .string()
@@ -132,7 +132,7 @@ Pass include_raw=true when debugging the platform normalizer itself — e.g., to
   });
 
   server.registerTool("wait_for_element", {
-    description: `Wait for an element to satisfy a condition (server-side polling). Eliminates client-side retry loops and reduces API round-trips. Always returns with matched:true/false - timeouts are not errors. Supports conditions: exists, not_exists, visible, enabled, disabled, value_equals, value_contains. Requires idb.`,
+    description: `Wait for an element to satisfy a condition (server-side polling). Eliminates client-side retry loops and reduces API round-trips. Always returns with matched:true/false - timeouts are not errors. Supports conditions: exists, not_exists, visible, enabled, disabled, value_equals, value_contains.`,
     inputSchema: strictParams({
       label: z
         .string()
@@ -184,7 +184,7 @@ Pass include_raw=true when debugging the platform normalizer itself — e.g., to
       mode: z
         .enum(["flat"])
         .optional()
-        .describe("Use 'flat' for enhanced element discovery with the custom idb companion. Simulators only."),
+        .describe("Use 'flat' to engage the patched idb companion's flat-mode output (idb backend only). Rarely needed now — the default path probes hidden tab-bar/nav-bar children automatically. Simulators only."),
     }),
   }, async ({
     label,
@@ -241,7 +241,7 @@ Pass include_raw=true when debugging the platform normalizer itself — e.g., to
   });
 
   server.registerTool("get_screen_summary", {
-    description: `Get an LLM-optimized text description of the current screen, including interactive elements and their locations. Uses smart truncation with prioritization (buttons with identifiers > form inputs > generic buttons > static text). Navigation chrome (tab bars, nav bars) is always included regardless of limit. Requires idb.
+    description: `Get an LLM-optimized text description of the current screen, including interactive elements and their locations. Uses smart truncation with prioritization (buttons with identifiers > form inputs > generic buttons > static text). Navigation chrome (tab bars, nav bars) is always included regardless of limit.
 
 This is the recommended first step before interacting with UI. Use this to discover element labels and identifiers, then use tap_element to tap by name instead of coordinates.`,
     inputSchema: strictParams({
@@ -272,7 +272,7 @@ This is the recommended first step before interacting with UI. Use this to disco
       mode: z
         .enum(["flat"])
         .optional()
-        .describe("Use 'flat' for enhanced element discovery with the custom idb companion. Default uses nested mode with probe-based discovery. Simulators only."),
+        .describe("Use 'flat' to engage the patched idb companion's flat-mode output (idb backend only). Rarely needed: the default path (sim-bridge on Xcode 26+/Apple Silicon, idb elsewhere) already probes hidden tab-bar/nav-bar children. Simulators only."),
       identify: z
         .boolean()
         .optional()
@@ -309,7 +309,7 @@ This is the recommended first step before interacting with UI. Use this to disco
   });
 
   server.registerTool("tap", {
-    description: `Tap at specific screen coordinates on the simulator. Requires idb.
+    description: `Tap at specific screen coordinates on the simulator.
 
 PREFER tap_element over this tool. Use get_screen_summary to find element labels/identifiers, then tap_element to tap by name. Only use coordinate tap as a last resort when tap_element cannot find the element.
 
@@ -353,7 +353,7 @@ If coordinate taps are not landing on the expected element, use take_annotated_s
   });
 
   server.registerTool("tap_element", {
-    description: `Find a UI element by label or accessibility identifier and tap its center. Returns "ambiguous" with match list if multiple elements match — use element_type (e.g., "Button", "TextField", "StaticText") to narrow results. Requires idb.
+    description: `Find a UI element by label or accessibility identifier and tap its center. Returns "ambiguous" with match list if multiple elements match — use element_type (e.g., "Button", "TextField", "StaticText") to narrow results.
 
 This is the PREFERRED way to tap UI elements. Use get_screen_summary first to discover element labels/identifiers, then use this tool. Avoid using coordinate-based tap unless this tool cannot find the element.
 
@@ -452,7 +452,7 @@ Label matching modes (mutually exclusive — use only one):
   });
 
   server.registerTool("swipe", {
-    description: `Perform a swipe gesture from one point to another. Requires idb.`,
+    description: `Perform a swipe gesture from one point to another.`,
     inputSchema: strictParams({
       start_x: z.coerce.number().describe("Starting X coordinate"),
       start_y: z.coerce.number().describe("Starting Y coordinate"),
@@ -504,7 +504,7 @@ Label matching modes (mutually exclusive — use only one):
   });
 
   server.registerTool("type_text", {
-    description: `Type text into the currently focused input field. Requires idb.`,
+    description: `Type text into the currently focused input field.`,
     inputSchema: strictParams({
       text: z.string().describe("Text to type"),
       udid: z
@@ -560,7 +560,7 @@ Label matching modes (mutually exclusive — use only one):
   });
 
   server.registerTool("clear_text", {
-    description: `Clear all text in the currently focused input field (select-all + delete). Use this before type_text when a field has pre-existing content you want to replace. Note: Secure text fields (passwords) may not support select-all. Requires idb.`,
+    description: `Clear all text in the currently focused input field (select-all + delete). Use this before type_text when a field has pre-existing content you want to replace. Note: Secure text fields (passwords) may not support select-all.`,
     inputSchema: strictParams({
       udid: z
         .string()

--- a/server/device/controller.py
+++ b/server/device/controller.py
@@ -12,6 +12,7 @@ from server.device.devicectl import DevicectlBackend
 from server.device.idb import IdbBackend
 from server.device.pmd3 import Pmd3Backend
 from server.device.screenshots import process_screenshot
+from server.device.sim_bridge import SimBridgeBackend, SimBridgeManager
 from server.device.simctl import SimctlBackend
 from server.device.u2_client import U2Backend
 from server.device.usbmux import UsbmuxBackend
@@ -34,6 +35,9 @@ class DeviceController(DeviceControllerUI):
         self.wda_client = WdaBackend()
         self.adb = AdbBackend()
         self.u2 = U2Backend()
+        self.sim_bridge_manager = SimBridgeManager()
+        self.sim_bridge = SimBridgeBackend(self.sim_bridge_manager)
+        self._sim_bridge_ok = False
         self.__active_udid: str | None = None
         self._pool = None  # Set by main.py after pool is created; None = no pool
 
@@ -76,6 +80,7 @@ class DeviceController(DeviceControllerUI):
             "pymobiledevice3": await self.pmd3.is_available(),
             "tunneld": await is_tunneld_running(),
             "adb": await self.adb.is_available(),
+            "sim_bridge": await self.sim_bridge_manager.is_available(),
         }
 
     def _device_type(self, udid: str) -> DeviceType:

--- a/server/device/controller_ui.py
+++ b/server/device/controller_ui.py
@@ -124,12 +124,14 @@ class DeviceControllerUI:
         """Return the appropriate UI automation backend for a device.
 
         Android devices use U2Backend; iOS physical devices use WdaBackend;
-        iOS simulators use IdbBackend.
+        iOS simulators use SimBridgeBackend (preferred) or IdbBackend (fallback).
         """
         if self._is_android(udid):
             return self.u2
         if self._is_physical(udid):
             return self.wda_client
+        if self._sim_bridge_ok:
+            return self.sim_bridge
         return self.idb
 
     async def _get_screen_dimensions(self, udid: str) -> dict | None:

--- a/server/device/idb.py
+++ b/server/device/idb.py
@@ -10,17 +10,10 @@ import shutil
 import sys
 from pathlib import Path
 
+from server.device import probing
 from server.models import DeviceError
 
 logger = logging.getLogger("quern-debug-server.idb")
-
-# Container role_descriptions whose children are often missing from describe-all
-_PROBEABLE_ROLES = frozenset({
-    "Nav bar", "Tab bar", "Toolbar", "Navigation bar",
-})
-
-# Probe interval in points — smaller than iOS minimum tap target (44pt)
-_PROBE_STEP = 20
 
 
 class IdbBackend:
@@ -197,11 +190,11 @@ class IdbBackend:
             )
 
         # Find empty containers before flattening (which pops children)
-        empty_containers = self._find_empty_containers(data)
+        empty_containers = probing.find_empty_containers(data)
 
         # Before flatten
         t5 = time.perf_counter()
-        flat = self._flatten_nested(data)
+        flat = probing.flatten_nested(data)
         t6 = time.perf_counter()
         logger.info(
             f"[PERF] idb.describe_all: flattened to "
@@ -217,7 +210,10 @@ class IdbBackend:
                 f"(+{(t7-t6)*1000:.1f}ms)"
             )
 
-            probe_tasks = [self._probe_container(udid, c) for c in empty_containers]
+            probe_tasks = [
+                probing.probe_container(udid, c, self.describe_point)
+                for c in empty_containers
+            ]
             probe_results = await asyncio.gather(*probe_tasks)
             probed_elements = [el for batch in probe_results for el in batch]
 
@@ -228,26 +224,7 @@ class IdbBackend:
                 f"(+{(t8-t7)*1000:.1f}ms)"
             )
 
-            # Merge probed elements, deduplicating against existing
-            if probed_elements:
-                existing_frames: set[tuple[int, int, int, int]] = set()
-                for item in flat:
-                    f = item.get("frame")
-                    if f:
-                        existing_frames.add((
-                            int(f.get("x", 0)), int(f.get("y", 0)),
-                            int(f.get("width", 0)), int(f.get("height", 0)),
-                        ))
-                for el in probed_elements:
-                    f = el.get("frame")
-                    if f:
-                        key = (
-                            int(f.get("x", 0)), int(f.get("y", 0)),
-                            int(f.get("width", 0)), int(f.get("height", 0)),
-                        )
-                        if key not in existing_frames:
-                            flat.append(el)
-                            existing_frames.add(key)
+            probing.merge_probed_into_flat(flat, probed_elements)
 
         end = time.perf_counter()
         logger.info(
@@ -375,103 +352,6 @@ class IdbBackend:
         except (DeviceError, json.JSONDecodeError):
             return None
 
-    @staticmethod
-    def _is_probeable_container(item: dict) -> bool:
-        """Check if an item is an interactive container with no children."""
-        children = item.get("children", [])
-        if children:
-            return False  # Has children, no need to probe
-
-        role_desc = item.get("role_description", "")
-        if role_desc in _PROBEABLE_ROLES:
-            return True
-
-        label = item.get("AXLabel") or ""
-        if item.get("type") == "Group" and "tab bar" in label.lower():
-            return True
-
-        return False
-
-    @staticmethod
-    def _find_empty_containers(items: list[dict]) -> list[dict]:
-        """Walk the nested tree and find containers that need probing."""
-        containers: list[dict] = []
-        for item in items:
-            if IdbBackend._is_probeable_container(item):
-                containers.append(item)
-            children = item.get("children", [])
-            if children:
-                containers.extend(IdbBackend._find_empty_containers(children))
-        return containers
-
-    async def _probe_container(self, udid: str, container: dict) -> list[dict]:
-        """Probe across a container to discover hidden child elements.
-
-        Sends describe-point calls at regular intervals across the container's
-        width, at its vertical center. Deduplicates results by frame position
-        and filters out hits that match the container itself.
-        """
-        frame = container.get("frame")
-        if not frame:
-            return []
-
-        x_start = float(frame.get("x", 0))
-        y_center = float(frame.get("y", 0)) + float(frame.get("height", 0)) / 2
-        width = float(frame.get("width", 0))
-
-        # Generate probe X positions across the container
-        probe_xs: list[float] = []
-        x = x_start + _PROBE_STEP / 2  # Start half a step in
-        while x < x_start + width:
-            probe_xs.append(x)
-            x += _PROBE_STEP
-
-        if not probe_xs:
-            return []
-
-        # Run all probes concurrently
-        tasks = [self.describe_point(udid, px, y_center) for px in probe_xs]
-        results = await asyncio.gather(*tasks)
-
-        # Deduplicate by frame position
-        container_frame_key = (
-            int(frame.get("x", 0)), int(frame.get("y", 0)),
-            int(frame.get("width", 0)), int(frame.get("height", 0)),
-        )
-        seen_frames: set[tuple[int, int, int, int]] = set()
-        discovered: list[dict] = []
-
-        for element in results:
-            if element is None:
-                continue
-            el_frame = element.get("frame")
-            if not el_frame:
-                continue
-            frame_key = (
-                int(el_frame.get("x", 0)), int(el_frame.get("y", 0)),
-                int(el_frame.get("width", 0)), int(el_frame.get("height", 0)),
-            )
-            # Skip if it's the container itself
-            if frame_key == container_frame_key:
-                continue
-            # Skip if already seen
-            if frame_key in seen_frames:
-                continue
-            seen_frames.add(frame_key)
-            discovered.append(element)
-
-        return discovered
-
-    @staticmethod
-    def _flatten_nested(items: list[dict]) -> list[dict]:
-        """Recursively flatten a nested idb element tree into a flat list."""
-        result: list[dict] = []
-        for item in items:
-            children = item.pop("children", [])
-            result.append(item)
-            if children:
-                result.extend(IdbBackend._flatten_nested(children))
-        return result
 
     async def tap(self, udid: str, x: float, y: float) -> None:
         """Tap at coordinates. Runs: idb ui tap <x> <y> --duration 0.05 --udid <udid>

--- a/server/device/probing.py
+++ b/server/device/probing.py
@@ -1,0 +1,137 @@
+"""Shared accessibility-tree probing helpers.
+
+Both idb and sim-bridge surface UI containers (tab bars, nav bars, toolbars)
+whose `children` array is empty even though the container clearly has
+interactive subviews visible on screen. The workaround is to issue a series
+of hit-test queries across the container's bounds and treat each unique
+result as a discovered child.
+
+The probing logic here is backend-agnostic — it takes a `describe_point`
+callable so the caller can plug in either `IdbBackend.describe_point`
+(subprocess to `idb ui describe-point`) or
+`SimBridgeBackend.describe_point` (AXPTranslator's `objectAtPoint:` via
+the sim-bridge subprocess).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+
+# Container role_descriptions whose children are often missing from describe-all
+PROBEABLE_ROLES = frozenset({
+    "Nav bar", "Tab bar", "Toolbar", "Navigation bar",
+})
+
+# Probe interval in points — smaller than iOS minimum tap target (44pt)
+PROBE_STEP = 20
+
+
+def is_probeable_container(item: dict) -> bool:
+    """Check if an item is an interactive container with no enumerated children."""
+    children = item.get("children", [])
+    if children:
+        return False
+
+    role_desc = item.get("role_description", "")
+    if role_desc in PROBEABLE_ROLES:
+        return True
+
+    label = item.get("AXLabel") or ""
+    if item.get("type") == "Group" and "tab bar" in label.lower():
+        return True
+
+    return False
+
+
+def find_empty_containers(items: list[dict]) -> list[dict]:
+    """Walk the nested tree and find containers that need probing."""
+    containers: list[dict] = []
+    for item in items:
+        if is_probeable_container(item):
+            containers.append(item)
+        children = item.get("children", [])
+        if children:
+            containers.extend(find_empty_containers(children))
+    return containers
+
+
+def flatten_nested(items: list[dict]) -> list[dict]:
+    """Flatten a nested element tree, mutating items to drop their children key."""
+    result: list[dict] = []
+    for item in items:
+        children = item.pop("children", [])
+        result.append(item)
+        if children:
+            result.extend(flatten_nested(children))
+    return result
+
+
+def _frame_key(frame: dict | None) -> tuple[int, int, int, int] | None:
+    if not frame:
+        return None
+    return (
+        int(frame.get("x", 0)), int(frame.get("y", 0)),
+        int(frame.get("width", 0)), int(frame.get("height", 0)),
+    )
+
+
+DescribePointFn = Callable[[str, float, float], Awaitable[dict | None]]
+
+
+async def probe_container(
+    udid: str, container: dict, describe_point: DescribePointFn,
+) -> list[dict]:
+    """Probe a single container's interior to discover hidden children.
+
+    Calls `describe_point` at a regular X interval across the container's
+    width (at its vertical center) and returns deduplicated hits, excluding
+    the container itself.
+    """
+    frame = container.get("frame")
+    if not frame:
+        return []
+
+    x_start = float(frame.get("x", 0))
+    width = float(frame.get("width", 0))
+    y_center = float(frame.get("y", 0)) + float(frame.get("height", 0)) / 2
+
+    probe_xs: list[float] = []
+    x = x_start + PROBE_STEP / 2
+    while x < x_start + width:
+        probe_xs.append(x)
+        x += PROBE_STEP
+    if not probe_xs:
+        return []
+
+    results = await asyncio.gather(*(describe_point(udid, px, y_center) for px in probe_xs))
+
+    container_key = _frame_key(frame)
+    seen: set[tuple[int, int, int, int]] = set()
+    discovered: list[dict] = []
+    for element in results:
+        if element is None:
+            continue
+        key = _frame_key(element.get("frame"))
+        if key is None or key == container_key or key in seen:
+            continue
+        seen.add(key)
+        discovered.append(element)
+    return discovered
+
+
+def merge_probed_into_flat(flat: list[dict], probed: list[dict]) -> None:
+    """Append probed elements to `flat`, skipping ones whose frame already exists."""
+    if not probed:
+        return
+    existing: set[tuple[int, int, int, int]] = set()
+    for item in flat:
+        key = _frame_key(item.get("frame"))
+        if key is not None:
+            existing.add(key)
+    for el in probed:
+        key = _frame_key(el.get("frame"))
+        if key is None or key in existing:
+            continue
+        flat.append(el)
+        existing.add(key)

--- a/server/device/sim_bridge.py
+++ b/server/device/sim_bridge.py
@@ -1,0 +1,350 @@
+"""SimBridge — native simulator control via Apple private frameworks.
+
+Uses a long-running sim-bridge Swift subprocess communicating via JSON
+Lines on stdin/stdout. Replaces idb for simulator UI automation:
+accessibility tree queries, tap/swipe/type gestures, button presses,
+and IOSurface screenshots.
+
+Follows the same subprocess management pattern as preview.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import shutil
+from pathlib import Path
+
+logger = logging.getLogger("quern-debug-server.sim-bridge")
+
+QUERN_BIN_DIR = Path.home() / ".quern" / "bin"
+BINARY_NAME = "sim-bridge"
+_SOURCE_CANDIDATES = [
+    Path(__file__).resolve().parent.parent.parent / "tools" / "sim-bridge.swift",
+]
+
+
+def _find_source() -> Path | None:
+    for p in _SOURCE_CANDIDATES:
+        if p.exists():
+            return p
+    return None
+
+
+class SimBridgeManager:
+    """Manages the sim-bridge subprocess lifecycle and communication."""
+
+    def __init__(self) -> None:
+        self._process: asyncio.subprocess.Process | None = None
+        self._ready = asyncio.Event()
+        self._reader_task: asyncio.Task | None = None
+        self._lock = asyncio.Lock()
+        self._binary_path = QUERN_BIN_DIR / BINARY_NAME
+        self._pending_response: asyncio.Future | None = None
+
+    async def is_available(self) -> bool:
+        """Check if sim-bridge can be compiled and used."""
+        if shutil.which("swiftc") is None:
+            return False
+        if _find_source() is None:
+            return False
+        # Check for Xcode (need private frameworks)
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "xcode-select", "-p",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            stdout, _ = await proc.communicate()
+            dev_dir = stdout.decode().strip()
+            if not dev_dir:
+                return False
+            sim_kit = Path(dev_dir) / "Library" / "PrivateFrameworks" / "SimulatorKit.framework"
+            return sim_kit.exists()
+        except Exception:
+            return False
+
+    async def ensure_binary(self) -> Path:
+        """Lazy-compile sim-bridge if needed. Returns path to binary."""
+        source = _find_source()
+        if source is None:
+            raise RuntimeError(
+                "sim-bridge.swift source not found. "
+                "Expected at tools/sim-bridge.swift relative to the project root."
+            )
+
+        if self._binary_path.exists():
+            src_mtime = source.stat().st_mtime
+            bin_mtime = self._binary_path.stat().st_mtime
+            if bin_mtime >= src_mtime:
+                return self._binary_path
+
+        swiftc = shutil.which("swiftc")
+        if swiftc is None:
+            raise RuntimeError(
+                "swiftc not found. Install Xcode: xcode-select --install"
+            )
+
+        QUERN_BIN_DIR.mkdir(parents=True, exist_ok=True)
+        logger.info("Compiling sim-bridge: %s → %s", source, self._binary_path)
+
+        proc = await asyncio.create_subprocess_exec(
+            swiftc,
+            "-o", str(self._binary_path),
+            str(source),
+            "-framework", "Foundation",
+            "-framework", "IOSurface",
+            "-framework", "CoreGraphics",
+            "-framework", "ImageIO",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+
+        if proc.returncode != 0:
+            err = stderr.decode().strip() or stdout.decode().strip()
+            raise RuntimeError(f"Failed to compile sim-bridge:\n{err}")
+
+        logger.info("sim-bridge compiled successfully")
+        return self._binary_path
+
+    # ------------------------------------------------------------------
+    # Process lifecycle
+    # ------------------------------------------------------------------
+
+    async def _ensure_process(self) -> None:
+        """Launch the subprocess if not running."""
+        if self._process is not None and self._process.returncode is None:
+            return
+
+        self._cleanup_state()
+
+        binary = await self.ensure_binary()
+        logger.info("Starting sim-bridge")
+
+        self._ready.clear()
+        self._process = await asyncio.create_subprocess_exec(
+            str(binary),
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        self._reader_task = asyncio.create_task(self._stdout_reader())
+
+        try:
+            await asyncio.wait_for(self._ready.wait(), timeout=15.0)
+        except TimeoutError:
+            logger.error("sim-bridge did not become ready in 15s")
+            await self._kill_process()
+            raise RuntimeError("sim-bridge failed to start (timeout)")
+
+    async def _stdout_reader(self) -> None:
+        """Background task: reads JSON lines from subprocess stdout."""
+        proc = self._process
+        if proc is None or proc.stdout is None:
+            return
+
+        try:
+            while True:
+                line = await proc.stdout.readline()
+                if not line:
+                    break
+                try:
+                    msg = json.loads(line)
+                except json.JSONDecodeError:
+                    logger.warning("sim-bridge: non-JSON output: %s", line[:200])
+                    continue
+
+                self._dispatch(msg)
+        except Exception:
+            logger.exception("sim-bridge stdout reader error")
+        finally:
+            self._cleanup_state()
+
+    def _dispatch(self, msg: dict) -> None:
+        """Route a parsed JSON message from the subprocess."""
+        if "event" in msg:
+            event = msg["event"]
+            if event == "ready":
+                logger.info("sim-bridge ready")
+                self._ready.set()
+            return
+
+        # It's a command response — resolve the pending future
+        if self._pending_response is not None and not self._pending_response.done():
+            self._pending_response.set_result(msg)
+
+    async def send(self, cmd: dict) -> dict:
+        """Send a command and wait for the response. Thread-safe via lock."""
+        async with self._lock:
+            await self._ensure_process()
+
+            if self._process is None or self._process.stdin is None:
+                raise RuntimeError("sim-bridge process not available")
+
+            loop = asyncio.get_event_loop()
+            self._pending_response = loop.create_future()
+
+            line = json.dumps(cmd, separators=(",", ":")) + "\n"
+            self._process.stdin.write(line.encode())
+            await self._process.stdin.drain()
+
+            try:
+                result = await asyncio.wait_for(self._pending_response, timeout=30.0)
+            except TimeoutError:
+                raise RuntimeError(f"sim-bridge command timed out: {cmd.get('cmd')}")
+
+            return result
+
+    async def stop(self) -> None:
+        """Stop the subprocess."""
+        if self._process is None:
+            return
+        if self._process.returncode is None:
+            if self._process.stdin:
+                try:
+                    self._process.stdin.close()
+                except Exception:
+                    pass
+            try:
+                await asyncio.wait_for(self._process.wait(), timeout=5.0)
+            except TimeoutError:
+                await self._kill_process()
+        self._cleanup_state()
+
+    async def _kill_process(self) -> None:
+        if self._process is None:
+            return
+        if self._process.returncode is None:
+            self._process.terminate()
+            try:
+                await asyncio.wait_for(self._process.wait(), timeout=3.0)
+            except TimeoutError:
+                self._process.kill()
+
+    def _cleanup_state(self) -> None:
+        if self._reader_task and not self._reader_task.done():
+            self._reader_task.cancel()
+        self._reader_task = None
+        self._process = None
+        self._ready.clear()
+        if self._pending_response and not self._pending_response.done():
+            self._pending_response.cancel()
+        self._pending_response = None
+
+
+class SimBridgeBackend:
+    """Simulator UI backend using the sim-bridge Swift helper.
+
+    Implements the same interface as IdbBackend for use by controller_ui.py.
+    """
+
+    def __init__(self, manager: SimBridgeManager) -> None:
+        self._mgr = manager
+
+    async def _send(self, cmd: dict) -> dict:
+        result = await self._mgr.send(cmd)
+        if not result.get("ok", False):
+            error = result.get("error", "unknown error")
+            raise RuntimeError(f"sim-bridge: {error}")
+        return result
+
+    async def describe_all(
+        self, udid: str, *, snapshot_depth: int | None = None,
+        source_timeout: float | None = None,
+    ) -> list[dict]:
+        """Return flat list of UI elements (no children key)."""
+        result = await self._send({
+            "cmd": "describe-ui",
+            "udid": udid,
+            "nested": False,
+        })
+        tree = result.get("tree", [])
+        if isinstance(tree, list):
+            return tree
+        # If it's a single dict (shouldn't happen for non-nested), wrap it
+        return [tree]
+
+    async def describe_all_nested(
+        self, udid: str, *, snapshot_depth: int | None = None,
+    ) -> list[dict]:
+        """Return nested tree with children arrays preserved."""
+        result = await self._send({
+            "cmd": "describe-ui",
+            "udid": udid,
+            "nested": True,
+        })
+        tree = result.get("tree")
+        if isinstance(tree, dict):
+            return [tree]
+        if isinstance(tree, list):
+            return tree
+        return []
+
+    async def describe_all_flat(
+        self, udid: str, *, snapshot_depth: int | None = None,
+        source_timeout: float | None = None,
+    ) -> list[dict]:
+        """Same as describe_all — sim-bridge always returns flat for non-nested."""
+        return await self.describe_all(udid, snapshot_depth=snapshot_depth,
+                                       source_timeout=source_timeout)
+
+    async def describe_point(
+        self, udid: str, x: float, y: float,
+    ) -> dict | None:
+        """Return the element at a specific point."""
+        result = await self._send({
+            "cmd": "describe-ui",
+            "udid": udid,
+            "x": x,
+            "y": y,
+        })
+        return result.get("element")
+
+    async def tap(self, udid: str, x: float, y: float) -> None:
+        await self._send({"cmd": "tap", "udid": udid, "x": x, "y": y})
+
+    async def swipe(
+        self, udid: str,
+        start_x: float, start_y: float,
+        end_x: float, end_y: float,
+        duration: float = 0.3,
+    ) -> None:
+        await self._send({
+            "cmd": "swipe", "udid": udid,
+            "x1": start_x, "y1": start_y,
+            "x2": end_x, "y2": end_y,
+            "duration": duration,
+        })
+
+    async def type_text(self, udid: str, text: str) -> None:
+        await self._send({"cmd": "type", "udid": udid, "text": text})
+
+    async def press_button(self, udid: str, button: str) -> None:
+        await self._send({"cmd": "button", "udid": udid, "name": button})
+
+    async def select_all_and_delete(
+        self, udid: str, x: float, y: float,
+        element_type: str | None = None,
+    ) -> None:
+        """Select all text and delete it. Triple-tap to select, then backspace."""
+        # Triple-tap to select all
+        for _ in range(3):
+            await self._send({"cmd": "tap", "udid": udid, "x": x, "y": y})
+            await asyncio.sleep(0.05)
+        await asyncio.sleep(0.1)
+        # Send backspace (HID usage 0x2A on page 7)
+        await self._send({"cmd": "type", "udid": udid, "text": "\x08"})
+
+    async def screenshot(
+        self, udid: str, quality: float = 0.8, scale: int = 1,
+    ) -> bytes:
+        """Capture a screenshot via IOSurface. Returns raw JPEG bytes."""
+        result = await self._send({
+            "cmd": "screenshot", "udid": udid,
+            "quality": quality, "scale": scale,
+        })
+        b64 = result.get("data", "")
+        return base64.b64decode(b64)

--- a/server/device/sim_bridge.py
+++ b/server/device/sim_bridge.py
@@ -15,7 +15,10 @@ import base64
 import json
 import logging
 import shutil
+import time
 from pathlib import Path
+
+from server.device import probing
 
 logger = logging.getLogger("quern-debug-server.sim-bridge")
 
@@ -255,26 +258,49 @@ class SimBridgeBackend:
         self, udid: str, *, snapshot_depth: int | None = None,
         source_timeout: float | None = None,
     ) -> list[dict]:
-        """Return flat list of UI elements (no children key)."""
-        result = await self._send({
-            "cmd": "describe-ui",
-            "udid": udid,
-            "nested": False,
-        })
-        tree = result.get("tree", [])
-        if isinstance(tree, list):
-            return tree
-        # If it's a single dict (shouldn't happen for non-nested), wrap it
-        return [tree]
+        """Return flat list of UI elements.
+
+        Fetches the nested tree, finds containers that the static walk
+        reports as childless (tab bars, nav bars, toolbars with hidden
+        SwiftUI subviews), probes each via server-side AXPTranslator
+        hit-tests, then flattens and merges. Mirrors the behavior of
+        `IdbBackend.describe_all` so downstream consumers don't need to
+        care which backend is active.
+        """
+        start = time.perf_counter()
+
+        nested = await self._fetch_nested(udid)
+        empty_containers = probing.find_empty_containers(nested)
+        flat = probing.flatten_nested(nested)
+
+        if empty_containers:
+            logger.info(
+                "[PERF] sim-bridge.describe_all: probing %d empty containers",
+                len(empty_containers),
+            )
+            probe_tasks = [
+                probing.probe_container(udid, c, self.describe_point)
+                for c in empty_containers
+            ]
+            probe_results = await asyncio.gather(*probe_tasks)
+            probed = [el for batch in probe_results for el in batch]
+            probing.merge_probed_into_flat(flat, probed)
+
+        logger.info(
+            "[PERF] sim-bridge.describe_all COMPLETE: total=%.1fms elements=%d",
+            (time.perf_counter() - start) * 1000, len(flat),
+        )
+        return flat
 
     async def describe_all_nested(
         self, udid: str, *, snapshot_depth: int | None = None,
     ) -> list[dict]:
-        """Return nested tree with children arrays preserved."""
+        """Return nested tree with children arrays preserved (no probing)."""
+        return await self._fetch_nested(udid)
+
+    async def _fetch_nested(self, udid: str) -> list[dict]:
         result = await self._send({
-            "cmd": "describe-ui",
-            "udid": udid,
-            "nested": True,
+            "cmd": "describe-ui", "udid": udid, "nested": True,
         })
         tree = result.get("tree")
         if isinstance(tree, dict):
@@ -287,21 +313,35 @@ class SimBridgeBackend:
         self, udid: str, *, snapshot_depth: int | None = None,
         source_timeout: float | None = None,
     ) -> list[dict]:
-        """Same as describe_all — sim-bridge always returns flat for non-nested."""
+        """Same as describe_all — sim-bridge has only one tree-fetch path."""
         return await self.describe_all(udid, snapshot_depth=snapshot_depth,
                                        source_timeout=source_timeout)
 
     async def describe_point(
         self, udid: str, x: float, y: float,
     ) -> dict | None:
-        """Return the element at a specific point."""
-        result = await self._send({
-            "cmd": "describe-ui",
-            "udid": udid,
-            "x": x,
-            "y": y,
+        """Server-side hit-test via AXPTranslator's objectAtPoint.
+
+        Returns the deepest accessibility element at the given device-point
+        coordinate. Unlike a client-side tree hit-test, this can return
+        elements that the tree walk missed (the SwiftUI tab-bar case), so
+        it's the foundation for `probing.probe_container`.
+
+        Misses (no element under the point) return None rather than raising.
+        """
+        result = await self._mgr.send({
+            "cmd": "probe-point", "udid": udid,
+            "x": float(x), "y": float(y), "nested": False,
         })
-        return result.get("element")
+        if not result.get("ok"):
+            return None
+        tree = result.get("tree")
+        # nested=false yields a flat list whose first entry is the hit element.
+        if isinstance(tree, list):
+            return tree[0] if tree else None
+        if isinstance(tree, dict):
+            return tree
+        return None
 
     async def tap(self, udid: str, x: float, y: float) -> None:
         await self._send({"cmd": "tap", "udid": udid, "x": x, "y": y})

--- a/server/device/ui_elements.py
+++ b/server/device/ui_elements.py
@@ -248,8 +248,13 @@ def get_tap_point(element: UIElement) -> tuple[float, float]:
     return get_center(element)
 
 
-# Element types considered interactive for screen summaries
-_INTERACTIVE_TYPES = {"button", "textfield", "switch", "slider", "link", "searchfield"}
+# Element types considered interactive for screen summaries.
+# RadioButton covers iOS tab-bar items and form radio selections;
+# CheckBox covers toggle-like selections that aren't UISwitch.
+_INTERACTIVE_TYPES = {
+    "button", "textfield", "switch", "slider", "link", "searchfield",
+    "radiobutton", "checkbox",
+}
 
 
 def _is_navigation_chrome(el: UIElement) -> bool:
@@ -259,6 +264,7 @@ def _is_navigation_chrome(el: UIElement) -> bool:
     always be included in summaries regardless of truncation limits.
     """
     el_type_lower = el.type.lower()
+    role_desc_lower = (el.role_description or "").lower()
     # Common navigation types
     if el_type_lower in {"tabbar", "navigationbar", "toolbar", "navbar"}:
         return True
@@ -267,6 +273,9 @@ def _is_navigation_chrome(el: UIElement) -> bool:
         return True
     # Tab bar items
     if "tab" in el_type_lower:
+        return True
+    # iOS tab buttons exposed as RadioButton with role_description="AXTabButton"
+    if el_type_lower == "radiobutton" and "tabbutton" in role_desc_lower.replace(" ", ""):
         return True
     return False
 
@@ -282,16 +291,16 @@ def _prioritize_element(el: UIElement) -> int:
     """
     el_type_lower = el.type.lower()
 
-    # Buttons with identifiers = primary actions
-    if el_type_lower == "button" and el.identifier:
+    # Buttons / radio / checkboxes with identifiers = primary actions
+    if el_type_lower in {"button", "radiobutton", "checkbox"} and el.identifier:
         return 60
 
     # Form inputs
     if el_type_lower in {"textfield", "switch", "slider", "searchfield", "picker"}:
         return 40
 
-    # Buttons without identifiers
-    if el_type_lower == "button":
+    # Buttons / radio / checkboxes without identifiers
+    if el_type_lower in {"button", "radiobutton", "checkbox"}:
         return 20
 
     # Everything else (static text, labels)

--- a/server/lifecycle/setup.py
+++ b/server/lifecycle/setup.py
@@ -110,6 +110,45 @@ def _which(name: str) -> str | None:
     return shutil.which(name)
 
 
+def _is_apple_silicon() -> bool:
+    """True on arm64 Macs (Apple Silicon). Sim-bridge requires it."""
+    import platform
+    return platform.machine() == "arm64"
+
+
+def _xcode_major_version() -> int | None:
+    """Return Xcode's major version (e.g. 26 for Xcode 26.0), or None.
+
+    Parses the first line of `xcodebuild -version`, which reads
+    `Xcode <major>.<minor>`. Returns None if xcodebuild is missing,
+    fails, or the output is unrecognized.
+    """
+    rc, stdout, _ = _run(["xcodebuild", "-version"], timeout=5)
+    if rc != 0 or not stdout:
+        return None
+    first_line = stdout.splitlines()[0]
+    parts = first_line.split()
+    if len(parts) >= 2 and parts[0] == "Xcode":
+        try:
+            return int(parts[1].split(".")[0])
+        except ValueError:
+            return None
+    return None
+
+
+def _sim_bridge_supported() -> bool:
+    """True when sim-bridge can run — i.e. idb is not required.
+
+    Sim-bridge needs Apple Silicon and Xcode 26+ (for the SimulatorKit /
+    CoreSimulator private symbols it dlopens). When both hold, simulator
+    UI automation runs natively and idb is redundant.
+    """
+    if not _is_apple_silicon():
+        return False
+    major = _xcode_major_version()
+    return major is not None and major >= 26
+
+
 def _fix_developer_dir_for_setup() -> str | None:
     """Auto-fix DEVELOPER_DIR if xcode-select doesn't provide simctl.
 
@@ -1544,66 +1583,86 @@ def run_setup() -> int:
                     )
         report.add(ideviceinstaller_result)
 
-        # idb (for simulator UI automation)
+        # Simulator UI automation:
+        #   - Xcode 26+ on Apple Silicon → sim-bridge runs natively, idb not needed
+        #   - Older Xcode or Intel → fall back to the patched idb + fb-idb
 
-        idb_companion_result = check_idb_companion()
-        if idb_companion_result.status == CheckStatus.MISSING:
-            if _prompt_yn("    idb_companion not found. Download patched build?"):
-                if _install_patched_companion():
-                    idb_companion_result = check_idb_companion()
-                else:
-                    idb_companion_result = CheckResult(
-                        name="idb_companion",
-                        status=CheckStatus.WARNING,
-                        message="Download failed (UI automation unavailable)",
-                        detail="Try manually: https://github.com/quern-dev/idb/releases",
-                    )
-        elif idb_companion_result.message.startswith("installed (system"):
-            if _prompt_yn(
-                "    Patched idb_companion available "
-                "(fixes Group element detection). Install?"
-            ):
-                if _install_patched_companion():
-                    idb_companion_result = check_idb_companion()
-        report.add(idb_companion_result)
-
-        idb_result = check_idb()
-        if idb_result.status == CheckStatus.MISSING:
-            print("    idb CLI not found. This is the Python client for idb_companion.")
-            if _prompt_yn("    Install fb-idb via pip?"):
-                if sys.prefix != sys.base_prefix:
-                    pip_cmd = str(Path(sys.prefix) / "bin" / "pip")
-                else:
-                    pip_cmd = "pip" if _which("pip") else "pip3"
-                print("    Installing fb-idb...")
-                try:
-                    result = subprocess.run(
-                        [pip_cmd, "install", "fb-idb"],
-                        stdin=subprocess.DEVNULL, timeout=120,
-                    )
-                    if result.returncode == 0:
-                        _record_install("pip", "fb-idb")
-                        if _which("pyenv"):
-                            subprocess.run(
-                                ["pyenv", "rehash"],
-                                stdin=subprocess.DEVNULL, timeout=10,
-                            )
-                        idb_result = check_idb()  # re-check
+        if _sim_bridge_supported():
+            print(
+                "    Xcode 26+ on Apple Silicon detected — "
+                "sim-bridge handles simulator UI natively. Skipping idb."
+            )
+            report.add(CheckResult(
+                name="idb_companion",
+                status=CheckStatus.SKIPPED,
+                message="Not required (sim-bridge active)",
+                detail="Xcode 26+ on Apple Silicon: simulator UI runs through "
+                       "sim-bridge. Existing idb installs still work as a fallback.",
+            ))
+            report.add(CheckResult(
+                name="idb (fb-idb)",
+                status=CheckStatus.SKIPPED,
+                message="Not required (sim-bridge active)",
+            ))
+        else:
+            idb_companion_result = check_idb_companion()
+            if idb_companion_result.status == CheckStatus.MISSING:
+                if _prompt_yn("    idb_companion not found. Download patched build?"):
+                    if _install_patched_companion():
+                        idb_companion_result = check_idb_companion()
                     else:
+                        idb_companion_result = CheckResult(
+                            name="idb_companion",
+                            status=CheckStatus.WARNING,
+                            message="Download failed (UI automation unavailable)",
+                            detail="Try manually: https://github.com/quern-dev/idb/releases",
+                        )
+            elif idb_companion_result.message.startswith("installed (system"):
+                if _prompt_yn(
+                    "    Patched idb_companion available "
+                    "(fixes Group element detection). Install?"
+                ):
+                    if _install_patched_companion():
+                        idb_companion_result = check_idb_companion()
+            report.add(idb_companion_result)
+
+            idb_result = check_idb()
+            if idb_result.status == CheckStatus.MISSING:
+                print("    idb CLI not found. This is the Python client for idb_companion.")
+                if _prompt_yn("    Install fb-idb via pip?"):
+                    if sys.prefix != sys.base_prefix:
+                        pip_cmd = str(Path(sys.prefix) / "bin" / "pip")
+                    else:
+                        pip_cmd = "pip" if _which("pip") else "pip3"
+                    print("    Installing fb-idb...")
+                    try:
+                        result = subprocess.run(
+                            [pip_cmd, "install", "fb-idb"],
+                            stdin=subprocess.DEVNULL, timeout=120,
+                        )
+                        if result.returncode == 0:
+                            _record_install("pip", "fb-idb")
+                            if _which("pyenv"):
+                                subprocess.run(
+                                    ["pyenv", "rehash"],
+                                    stdin=subprocess.DEVNULL, timeout=10,
+                                )
+                            idb_result = check_idb()  # re-check
+                        else:
+                            idb_result = CheckResult(
+                                name="idb (fb-idb)",
+                                status=CheckStatus.ERROR,
+                                message="pip install failed",
+                                detail="Try manually: pip install fb-idb",
+                            )
+                    except (FileNotFoundError, subprocess.TimeoutExpired):
                         idb_result = CheckResult(
                             name="idb (fb-idb)",
                             status=CheckStatus.ERROR,
                             message="pip install failed",
                             detail="Try manually: pip install fb-idb",
                         )
-                except (FileNotFoundError, subprocess.TimeoutExpired):
-                    idb_result = CheckResult(
-                        name="idb (fb-idb)",
-                        status=CheckStatus.ERROR,
-                        message="pip install failed",
-                        detail="Try manually: pip install fb-idb",
-                    )
-        report.add(idb_result)
+            report.add(idb_result)
 
         # Physical device support (pymobiledevice3 + tunneld)
 

--- a/server/main.py
+++ b/server/main.py
@@ -290,6 +290,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     app.state.device_controller = device_controller
     tools = await device_controller.check_tools()
     logger.info("Device tools: %s", tools)
+    device_controller._sim_bridge_ok = tools.get("sim_bridge", False)
+    if tools.get("sim_bridge"):
+        logger.info("sim-bridge available — using native simulator UI backend")
+    else:
+        logger.info("sim-bridge not available — using idb for simulator UI")
 
     # Warn about missing tools
     if not tools.get("simctl"):
@@ -299,10 +304,12 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             "Fix with: sudo xcode-select -s /path/to/Xcode.app/Contents/Developer  "
             "Otherwise install Xcode Command Line Tools: xcode-select --install"
         )
-    if not tools.get("idb"):
+    if not tools.get("idb") and not tools.get("sim_bridge"):
         logger.warning(
-            "idb not available — UI automation (tap, swipe, accessibility tree) disabled. "
-            "Install with: pip install fb-idb && brew install idb-companion"
+            "Neither sim-bridge nor idb available — simulator UI automation "
+            "(tap, swipe, accessibility tree) disabled. "
+            "sim-bridge requires Xcode 26+ with Apple Silicon. "
+            "idb fallback: pip install fb-idb && brew install idb-companion"
         )
     if not tools.get("adb"):
         logger.info(

--- a/tests/test_device_controller.py
+++ b/tests/test_device_controller.py
@@ -108,6 +108,7 @@ class TestCheckTools:
         ctrl.devicectl.is_available = AsyncMock(return_value=True)
         ctrl.pmd3.is_available = AsyncMock(return_value=True)
         ctrl.adb.is_available = AsyncMock(return_value=True)
+        ctrl.sim_bridge_manager.is_available = AsyncMock(return_value=True)
         with patch("server.device.tunneld.is_tunneld_running", return_value=True):
             tools = await ctrl.check_tools()
         assert tools == {
@@ -117,6 +118,7 @@ class TestCheckTools:
             "pymobiledevice3": True,
             "tunneld": True,
             "adb": True,
+            "sim_bridge": True,
         }
 
     async def test_simctl_only(self):
@@ -126,6 +128,7 @@ class TestCheckTools:
         ctrl.devicectl.is_available = AsyncMock(return_value=False)
         ctrl.pmd3.is_available = AsyncMock(return_value=False)
         ctrl.adb.is_available = AsyncMock(return_value=False)
+        ctrl.sim_bridge_manager.is_available = AsyncMock(return_value=False)
         with patch("server.device.tunneld.is_tunneld_running", return_value=False):
             tools = await ctrl.check_tools()
         assert tools == {
@@ -135,6 +138,7 @@ class TestCheckTools:
             "pymobiledevice3": False,
             "tunneld": False,
             "adb": False,
+            "sim_bridge": False,
         }
 
     async def test_none_available(self):
@@ -144,6 +148,7 @@ class TestCheckTools:
         ctrl.devicectl.is_available = AsyncMock(return_value=False)
         ctrl.pmd3.is_available = AsyncMock(return_value=False)
         ctrl.adb.is_available = AsyncMock(return_value=False)
+        ctrl.sim_bridge_manager.is_available = AsyncMock(return_value=False)
         with patch("server.device.tunneld.is_tunneld_running", return_value=False):
             tools = await ctrl.check_tools()
         assert tools == {
@@ -153,6 +158,7 @@ class TestCheckTools:
             "pymobiledevice3": False,
             "tunneld": False,
             "adb": False,
+            "sim_bridge": False,
         }
 
 

--- a/tests/test_idb_backend.py
+++ b/tests/test_idb_backend.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from server.device import probing
 from server.device.idb import IdbBackend
 from server.models import DeviceError
 
@@ -379,15 +380,15 @@ class TestDescribePoint:
 class TestIsProbeableContainer:
     def test_nav_bar_empty(self):
         item = {"type": "Group", "role_description": "Nav bar", "children": []}
-        assert IdbBackend._is_probeable_container(item) is True
+        assert probing.is_probeable_container(item) is True
 
     def test_tab_bar_by_label(self):
         item = {"type": "Group", "AXLabel": "Tab Bar", "role_description": "group", "children": []}
-        assert IdbBackend._is_probeable_container(item) is True
+        assert probing.is_probeable_container(item) is True
 
     def test_toolbar_empty(self):
         item = {"type": "Group", "role_description": "Toolbar", "children": []}
-        assert IdbBackend._is_probeable_container(item) is True
+        assert probing.is_probeable_container(item) is True
 
     def test_container_with_children_not_probeable(self):
         item = {
@@ -395,20 +396,20 @@ class TestIsProbeableContainer:
             "role_description": "Nav bar",
             "children": [{"type": "Button", "AXLabel": "Back"}],
         }
-        assert IdbBackend._is_probeable_container(item) is False
+        assert probing.is_probeable_container(item) is False
 
     def test_regular_group_not_probeable(self):
         item = {"type": "Group", "AXLabel": "Content", "role_description": "group", "children": []}
-        assert IdbBackend._is_probeable_container(item) is False
+        assert probing.is_probeable_container(item) is False
 
     def test_button_not_probeable(self):
         item = {"type": "Button", "AXLabel": "Submit", "children": []}
-        assert IdbBackend._is_probeable_container(item) is False
+        assert probing.is_probeable_container(item) is False
 
     def test_no_children_key_is_probeable(self):
         """Container with no children key at all (missing, not empty list)."""
         item = {"type": "Group", "role_description": "Nav bar"}
-        assert IdbBackend._is_probeable_container(item) is True
+        assert probing.is_probeable_container(item) is True
 
 
 # ---------------------------------------------------------------------------
@@ -419,7 +420,7 @@ class TestIsProbeableContainer:
 class TestFindEmptyContainers:
     def test_finds_containers_in_nested_tree(self):
         data = json.loads((FIXTURES / "idb_describe_all_nested_output.json").read_text())
-        containers = IdbBackend._find_empty_containers(data)
+        containers = probing.find_empty_containers(data)
         assert len(containers) == 2
         # Nav bar
         assert containers[0]["role_description"] == "Nav bar"
@@ -428,7 +429,7 @@ class TestFindEmptyContainers:
 
     def test_no_containers_in_flat_list(self):
         data = json.loads((FIXTURES / "idb_describe_all_output.json").read_text())
-        containers = IdbBackend._find_empty_containers(data)
+        containers = probing.find_empty_containers(data)
         assert len(containers) == 0
 
     def test_deeply_nested_container(self):
@@ -452,7 +453,7 @@ class TestFindEmptyContainers:
                 ],
             }
         ]
-        containers = IdbBackend._find_empty_containers(data)
+        containers = probing.find_empty_containers(data)
         assert len(containers) == 1
         assert containers[0]["role_description"] == "Toolbar"
 
@@ -481,7 +482,7 @@ class TestProbeContainer:
             return None
 
         with patch.object(backend, "describe_point", side_effect=mock_describe_point):
-            await backend._probe_container("AAAA-1111", container)
+            await probing.probe_container("AAAA-1111", container, backend.describe_point)
 
         assert len(call_xs) == 5
         assert call_xs == [10.0, 30.0, 50.0, 70.0, 90.0]
@@ -504,7 +505,7 @@ class TestProbeContainer:
         }
 
         with patch.object(backend, "describe_point", return_value=element):
-            discovered = await backend._probe_container("X", container)
+            discovered = await probing.probe_container("X", container, backend.describe_point)
 
         # Should be deduplicated to 1 element even though 5 probes hit it
         assert len(discovered) == 1
@@ -528,7 +529,7 @@ class TestProbeContainer:
         }
 
         with patch.object(backend, "describe_point", return_value=container_hit):
-            discovered = await backend._probe_container("X", container)
+            discovered = await probing.probe_container("X", container, backend.describe_point)
 
         assert len(discovered) == 0
 
@@ -565,7 +566,7 @@ class TestProbeContainer:
             }  # container itself
 
         with patch.object(backend, "describe_point", side_effect=mock_describe_point):
-            discovered = await backend._probe_container("X", container)
+            discovered = await probing.probe_container("X", container, backend.describe_point)
 
         assert len(discovered) == 2
         labels = {d["AXLabel"] for d in discovered}
@@ -582,14 +583,14 @@ class TestProbeContainer:
         }
 
         with patch.object(backend, "describe_point", return_value=None):
-            discovered = await backend._probe_container("X", container)
+            discovered = await probing.probe_container("X", container, backend.describe_point)
 
         assert len(discovered) == 0
 
     async def test_no_frame_returns_empty(self):
         backend = IdbBackend()
         container = {"type": "Group", "role_description": "Nav bar"}
-        discovered = await backend._probe_container("X", container)
+        discovered = await probing.probe_container("X", container, backend.describe_point)
         assert discovered == []
 
     async def test_probes_at_vertical_center(self):
@@ -609,7 +610,7 @@ class TestProbeContainer:
             return None
 
         with patch.object(backend, "describe_point", side_effect=mock_describe_point):
-            await backend._probe_container("X", container)
+            await probing.probe_container("X", container, backend.describe_point)
 
         # y_center = 56 + 44/2 = 78.0
         assert all(y == 78.0 for y in call_ys)
@@ -649,7 +650,7 @@ class TestDescribeAllWithProbing:
             "frame": {"x": 160, "y": 791, "width": 80, "height": 83},
         }
 
-        async def mock_probe(udid, container):
+        async def mock_probe(udid, container, _describe_point):
             role_desc = container.get("role_description", "")
             if role_desc == "Nav bar":
                 return [gear_btn]
@@ -657,7 +658,7 @@ class TestDescribeAllWithProbing:
                 return [home_tab, profile_tab]
 
         with patch("asyncio.create_subprocess_exec", return_value=proc):
-            with patch.object(backend, "_probe_container", side_effect=mock_probe):
+            with patch("server.device.probing.probe_container", side_effect=mock_probe):
                 result = await backend.describe_all("AAAA-1111")
 
         # Fixture has: Application, Nav bar, StaticText, Button(Submit), Tab Bar = 5 elements
@@ -677,7 +678,7 @@ class TestDescribeAllWithProbing:
         proc = _mock_proc(stdout=fixture_data)
 
         with patch("asyncio.create_subprocess_exec", return_value=proc):
-            with patch.object(backend, "_probe_container") as mock_probe:
+            with patch("server.device.probing.probe_container") as mock_probe:
                 result = await backend.describe_all("AAAA-1111")
 
         # No containers to probe
@@ -722,11 +723,11 @@ class TestDescribeAllWithProbing:
             "frame": {"x": 351, "y": 56, "width": 43, "height": 44},
         }
 
-        async def mock_probe(udid, container):
+        async def mock_probe(udid, container, _describe_point):
             return [duplicate]
 
         with patch("asyncio.create_subprocess_exec", return_value=proc):
-            with patch.object(backend, "_probe_container", side_effect=mock_probe):
+            with patch("server.device.probing.probe_container", side_effect=mock_probe):
                 result = await backend.describe_all("X")
 
         # Application + Nav bar + Existing button = 3 (no duplicate)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -15,9 +15,12 @@ from server.lifecycle.setup import (
     SetupReport,
     _diagnose_developer_dir,
     _fix_developer_dir_for_setup,
+    _is_apple_silicon,
     _read_manifest,
     _record_install,
+    _sim_bridge_supported,
     _write_manifest,
+    _xcode_major_version,
     check_booted_simulators,
     check_homebrew,
     check_libimobiledevice,
@@ -312,6 +315,60 @@ class TestCheckLibimobiledevice:
 
 
 # ── Xcode CLI Tools check ───────────────────────────────────────────────
+
+
+class TestXcodeMajorVersion:
+    def test_parses_xcode_26(self):
+        out = "Xcode 26.0\nBuild version 17A1234\n"
+        with _patch_run(_mock_run(stdout=out, returncode=0)):
+            assert _xcode_major_version() == 26
+
+    def test_parses_older_xcode(self):
+        out = "Xcode 15.4\nBuild version 15F31d\n"
+        with _patch_run(_mock_run(stdout=out, returncode=0)):
+            assert _xcode_major_version() == 15
+
+    def test_missing_xcodebuild_returns_none(self):
+        with _patch_run(_mock_run(stdout="", returncode=127)):
+            assert _xcode_major_version() is None
+
+    def test_unrecognized_output_returns_none(self):
+        with _patch_run(_mock_run(stdout="something else\n", returncode=0)):
+            assert _xcode_major_version() is None
+
+
+class TestSimBridgeSupported:
+    def test_xcode_26_apple_silicon(self):
+        with patch("server.lifecycle.setup._is_apple_silicon", return_value=True):
+            with patch(
+                "server.lifecycle.setup._xcode_major_version", return_value=26
+            ):
+                assert _sim_bridge_supported() is True
+
+    def test_xcode_25_apple_silicon(self):
+        with patch("server.lifecycle.setup._is_apple_silicon", return_value=True):
+            with patch(
+                "server.lifecycle.setup._xcode_major_version", return_value=25
+            ):
+                assert _sim_bridge_supported() is False
+
+    def test_intel_mac_with_xcode_26(self):
+        with patch("server.lifecycle.setup._is_apple_silicon", return_value=False):
+            with patch(
+                "server.lifecycle.setup._xcode_major_version", return_value=26
+            ):
+                assert _sim_bridge_supported() is False
+
+    def test_xcodebuild_missing(self):
+        with patch("server.lifecycle.setup._is_apple_silicon", return_value=True):
+            with patch(
+                "server.lifecycle.setup._xcode_major_version", return_value=None
+            ):
+                assert _sim_bridge_supported() is False
+
+    def test_real_platform_machine_call_does_not_crash(self):
+        # Sanity check on the actual host — we just want this not to raise.
+        assert isinstance(_is_apple_silicon(), bool)
 
 
 class TestCheckXcodeCliTools:

--- a/tests/test_sim_bridge.py
+++ b/tests/test_sim_bridge.py
@@ -1,0 +1,205 @@
+"""Tests for SimBridgeBackend — mock SimBridgeManager.send."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from server.device.sim_bridge import SimBridgeBackend, SimBridgeManager
+
+
+def _backend_with_send(send_impl):
+    """Build a SimBridgeBackend whose underlying manager has a mocked send."""
+    mgr = SimBridgeManager()
+    mgr.send = AsyncMock(side_effect=send_impl)  # type: ignore[method-assign]
+    return SimBridgeBackend(mgr), mgr
+
+
+# ---------------------------------------------------------------------------
+# describe_point
+# ---------------------------------------------------------------------------
+
+
+class TestDescribePoint:
+    async def test_returns_hit_element(self):
+        async def send(cmd):
+            assert cmd["cmd"] == "probe-point"
+            assert cmd["x"] == 100.0
+            assert cmd["y"] == 200.0
+            return {
+                "ok": True,
+                "tree": [{"type": "Button", "AXLabel": "Tap"}],
+            }
+
+        backend, _ = _backend_with_send(send)
+        element = await backend.describe_point("X", 100, 200)
+        assert element == {"type": "Button", "AXLabel": "Tap"}
+
+    async def test_miss_returns_none(self):
+        async def send(cmd):
+            return {"ok": False, "error": "probe-point returned nil"}
+
+        backend, _ = _backend_with_send(send)
+        element = await backend.describe_point("X", 100, 200)
+        assert element is None
+
+    async def test_dict_tree_unwrapped(self):
+        async def send(cmd):
+            return {"ok": True, "tree": {"type": "Button", "AXLabel": "Tap"}}
+
+        backend, _ = _backend_with_send(send)
+        element = await backend.describe_point("X", 100, 200)
+        assert element == {"type": "Button", "AXLabel": "Tap"}
+
+
+# ---------------------------------------------------------------------------
+# describe_all probing integration
+# ---------------------------------------------------------------------------
+
+
+class TestDescribeAllWithProbing:
+    async def test_probes_empty_tab_bar(self):
+        """describe_all should probe a childless tab bar and merge its hits."""
+        tab_button = {
+            "type": "RadioButton",
+            "AXLabel": "Timelines",
+            "frame": {"x": 0, "y": 770, "width": 80, "height": 48},
+        }
+
+        async def send(cmd):
+            if cmd["cmd"] == "describe-ui":
+                # Nested tree with an empty tab bar group
+                return {
+                    "ok": True,
+                    "tree": [
+                        {
+                            "type": "Application",
+                            "AXLabel": "App",
+                            "frame": {"x": 0, "y": 0, "width": 393, "height": 852},
+                            "children": [
+                                {
+                                    "type": "Group",
+                                    "AXLabel": "Tab Bar",
+                                    "role_description": "group",
+                                    "frame": {"x": 0, "y": 769, "width": 393, "height": 83},
+                                    "children": [],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            if cmd["cmd"] == "probe-point":
+                # Every grid hit returns the single tab button
+                return {"ok": True, "tree": [tab_button]}
+            raise AssertionError(f"unexpected cmd: {cmd}")
+
+        backend, _ = _backend_with_send(send)
+        result = await backend.describe_all("X")
+
+        labels = [item.get("AXLabel") for item in result]
+        assert "App" in labels
+        assert "Tab Bar" in labels
+        assert "Timelines" in labels
+        # Tab Bar's children key was popped during flatten
+        for item in result:
+            assert "children" not in item
+
+    async def test_no_probing_when_all_full(self):
+        """No probe-point calls when every container has enumerated children."""
+
+        async def send(cmd):
+            assert cmd["cmd"] != "probe-point", "should not probe — no empty containers"
+            return {
+                "ok": True,
+                "tree": [
+                    {
+                        "type": "Application",
+                        "AXLabel": "App",
+                        "frame": {"x": 0, "y": 0, "width": 393, "height": 852},
+                        "children": [
+                            {
+                                "type": "Button",
+                                "AXLabel": "Hello",
+                                "frame": {"x": 0, "y": 0, "width": 50, "height": 50},
+                            }
+                        ],
+                    }
+                ],
+            }
+
+        backend, _ = _backend_with_send(send)
+        result = await backend.describe_all("X")
+        assert len(result) == 2
+
+    async def test_dedup_against_existing(self):
+        """Probed elements with same frame as something already in the flat list are skipped."""
+        existing_button = {
+            "type": "Button",
+            "AXLabel": "Existing",
+            "frame": {"x": 50, "y": 770, "width": 80, "height": 48},
+        }
+        # Same frame as existing_button → should be deduped out.
+        duplicate = {
+            "type": "RadioButton",
+            "AXLabel": "Duplicate",
+            "frame": {"x": 50, "y": 770, "width": 80, "height": 48},
+        }
+
+        async def send(cmd):
+            if cmd["cmd"] == "describe-ui":
+                return {
+                    "ok": True,
+                    "tree": [
+                        {
+                            "type": "Application",
+                            "AXLabel": "App",
+                            "frame": {"x": 0, "y": 0, "width": 393, "height": 852},
+                            "children": [
+                                {
+                                    "type": "Group",
+                                    "AXLabel": "Tab Bar",
+                                    "frame": {"x": 0, "y": 769, "width": 393, "height": 83},
+                                    "children": [],
+                                },
+                                existing_button,
+                            ],
+                        }
+                    ],
+                }
+            if cmd["cmd"] == "probe-point":
+                return {"ok": True, "tree": [duplicate]}
+            raise AssertionError(f"unexpected cmd: {cmd}")
+
+        backend, _ = _backend_with_send(send)
+        result = await backend.describe_all("X")
+        labels = [item.get("AXLabel") for item in result]
+        assert labels.count("Existing") == 1
+        assert "Duplicate" not in labels
+
+
+# ---------------------------------------------------------------------------
+# describe_all_nested — no probing
+# ---------------------------------------------------------------------------
+
+
+class TestDescribeAllNested:
+    async def test_returns_nested_without_probing(self):
+        async def send(cmd):
+            assert cmd["cmd"] == "describe-ui"
+            assert cmd["nested"] is True
+            return {
+                "ok": True,
+                "tree": {
+                    "type": "Application",
+                    "AXLabel": "App",
+                    "children": [{"type": "Button", "AXLabel": "Hi"}],
+                },
+            }
+
+        backend, mgr = _backend_with_send(send)
+        result = await backend.describe_all_nested("X")
+        # Single dict tree gets wrapped in a list
+        assert len(result) == 1
+        assert result[0]["AXLabel"] == "App"
+        assert result[0]["children"][0]["AXLabel"] == "Hi"
+        # Only one call — no probing path
+        assert mgr.send.await_count == 1

--- a/tools/sim-bridge.swift
+++ b/tools/sim-bridge.swift
@@ -760,34 +760,46 @@ func doButton(udid: String, name: String) -> Bool {
     guard let client = ensureHIDClient(udid: udid) else { return false }
     let holdUs: UInt32 = 100_000
 
-    switch name {
+    // Normalize: lowercase, drop underscores/hyphens so "SIDE_BUTTON",
+    // "side-button", "sideButton" all resolve. Matches idb's name set
+    // (HOME, LOCK, SIDE_BUTTON, SIRI, APPLE_PAY) plus our existing names.
+    let n = name.lowercased()
+        .replacingOccurrences(of: "_", with: "")
+        .replacingOccurrences(of: "-", with: "")
+
+    switch n {
     case "home":
-        guard let bfn = buttonFn else { return false }
-        guard let down = bfn(0x0, 1, 0x33) else { return false }
-        sendHIDMessage(down, to: client)
-        usleep(holdUs)
-        guard let up = bfn(0x0, 2, 0x33) else { return false }
-        sendHIDMessage(up, to: client)
-        return true
-
-    case "lock":
-        guard let bfn = buttonFn else { return false }
-        guard let down = bfn(0x1, 1, 0x33) else { return false }
-        sendHIDMessage(down, to: client)
-        usleep(holdUs)
-        guard let up = bfn(0x1, 2, 0x33) else { return false }
-        sendHIDMessage(up, to: client)
-        return true
-
-    case "volumeUp":
+        return pressIndigoButton(code: 0x0, holdUs: holdUs, client: client)
+    case "lock", "sidebutton":
+        return pressIndigoButton(code: 0x1, holdUs: holdUs, client: client)
+    case "siri":
+        // Long-press side button — the Siri gesture on Face ID iPhones.
+        // Simulators generally don't run Siri, but the event matches idb's behavior.
+        return pressIndigoButton(code: 0x1, holdUs: 1_500_000, client: client)
+    case "applepay":
+        // Double-press side/lock button.
+        guard pressIndigoButton(code: 0x1, holdUs: 80_000, client: client) else { return false }
+        usleep(120_000)
+        return pressIndigoButton(code: 0x1, holdUs: 80_000, client: client)
+    case "volumeup":
         return pressArbitraryHID(page: 12, usage: 233, holdUs: holdUs, client: client)
-    case "volumeDown":
+    case "volumedown":
         return pressArbitraryHID(page: 12, usage: 234, holdUs: holdUs, client: client)
 
     default:
         logErr("[hid] unknown button: \(name)")
         return false
     }
+}
+
+func pressIndigoButton(code: UInt32, holdUs: UInt32, client: AnyObject) -> Bool {
+    guard let bfn = buttonFn else { return false }
+    guard let down = bfn(code, 1, 0x33) else { return false }
+    sendHIDMessage(down, to: client)
+    usleep(holdUs)
+    guard let up = bfn(code, 2, 0x33) else { return false }
+    sendHIDMessage(up, to: client)
+    return true
 }
 
 func pressArbitraryHID(page: UInt32, usage: UInt32, holdUs: UInt32, client: AnyObject) -> Bool {
@@ -904,6 +916,8 @@ func decomposeCharacter(_ c: Character) -> (UInt32, [UInt32])? {
         0x09: (0x2B, false), // tab
         0x0A: (0x28, false), // newline -> enter
         0x0D: (0x28, false), // carriage return -> enter
+        0x08: (0x2A, false), // backspace -> delete
+        0x7F: (0x2A, false), // DEL -> delete
     ]
 
     if let (usage, shifted) = punctuation[v] {

--- a/tools/sim-bridge.swift
+++ b/tools/sim-bridge.swift
@@ -1,0 +1,1136 @@
+#!/usr/bin/env swift
+// sim-bridge.swift — Native simulator control for Quern
+//
+// Long-lived subprocess that exposes accessibility tree queries,
+// HID input injection, and IOSurface screenshots via a JSON Lines
+// protocol over stdin/stdout. Replaces idb for simulator UI automation.
+//
+// Uses Apple's private frameworks (CoreSimulator, SimulatorKit,
+// AccessibilityPlatformTranslation) loaded at runtime via dlopen.
+// Requires Xcode 26+ and Apple Silicon.
+//
+// Techniques ported from github.com/tddworks/baguette (MIT),
+// which credits cameroncooke/AXe and Silbercue/SilbercueSwift.
+
+import Foundation
+import ObjectiveC
+import CoreGraphics
+import IOSurface
+import ImageIO
+
+// MARK: - Logging
+
+func logErr(_ message: String) {
+    fputs("[sim-bridge] \(message)\n", stderr)
+}
+
+func dlerrorString() -> String {
+    guard let err = dlerror() else { return "(null)" }
+    return String(cString: err)
+}
+
+// MARK: - Framework Loading
+
+nonisolated(unsafe) private var frameworksLoaded = false
+
+func loadFrameworks() {
+    guard !frameworksLoaded else { return }
+    frameworksLoaded = true
+
+    let coreSim = "/Library/Developer/PrivateFrameworks/CoreSimulator.framework/CoreSimulator"
+    if dlopen(coreSim, RTLD_NOW | RTLD_GLOBAL) == nil {
+        logErr("CoreSimulator load failed: \(dlerrorString())")
+    }
+
+    let dev = developerDir()
+    let simKit = (dev as NSString)
+        .appendingPathComponent("Library/PrivateFrameworks/SimulatorKit.framework/SimulatorKit")
+    if dlopen(simKit, RTLD_NOW | RTLD_GLOBAL) == nil {
+        logErr("SimulatorKit load failed: \(dlerrorString())")
+    }
+
+    let axPath = "/System/Library/PrivateFrameworks/AccessibilityPlatformTranslation.framework/AccessibilityPlatformTranslation"
+    if dlopen(axPath, RTLD_NOW | RTLD_GLOBAL) == nil {
+        logErr("AccessibilityPlatformTranslation load failed: \(dlerrorString())")
+    }
+}
+
+func developerDir() -> String {
+    if let dev = xcodeSelectDir(), hasSimulatorKit(at: dev) { return dev }
+    if let dev = scanApplications() { return dev }
+    return xcodeSelectDir() ?? "/Applications/Xcode.app/Contents/Developer"
+}
+
+private func xcodeSelectDir() -> String? {
+    let pipe = Pipe()
+    let task = Process()
+    task.executableURL = URL(fileURLWithPath: "/usr/bin/xcode-select")
+    task.arguments = ["-p"]
+    task.standardOutput = pipe
+    do { try task.run() } catch { return nil }
+    task.waitUntilExit()
+    let out = String(
+        data: pipe.fileHandleForReading.readDataToEndOfFile(),
+        encoding: .utf8
+    )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    return out.isEmpty ? nil : out
+}
+
+private func hasSimulatorKit(at dev: String) -> Bool {
+    let path = (dev as NSString)
+        .appendingPathComponent("Library/PrivateFrameworks/SimulatorKit.framework/SimulatorKit")
+    return FileManager.default.fileExists(atPath: path)
+}
+
+private func scanApplications() -> String? {
+    let canonical = "/Applications/Xcode.app/Contents/Developer"
+    if hasSimulatorKit(at: canonical) { return canonical }
+    let entries = (try? FileManager.default.contentsOfDirectory(atPath: "/Applications")) ?? []
+    for app in entries.sorted()
+    where app.hasPrefix("Xcode") && app.hasSuffix(".app") && app != "Xcode.app" {
+        let dev = "/Applications/\(app)/Contents/Developer"
+        if hasSimulatorKit(at: dev) { return dev }
+    }
+    return nil
+}
+
+// MARK: - ObjC Runtime Helpers
+
+func invokeClassObjWithObjAndError(
+    _ cls: AnyClass, _ sel: Selector, _ arg: AnyObject, _ err: inout NSError?
+) -> NSObject? {
+    guard let metaCls = object_getClass(cls),
+          let imp = class_getMethodImplementation(metaCls, sel) else { return nil }
+    typealias Fn = @convention(c) (AnyClass, Selector, AnyObject, AutoreleasingUnsafeMutablePointer<NSError?>) -> AnyObject?
+    return unsafeBitCast(imp, to: Fn.self)(cls, sel, arg, &err) as? NSObject
+}
+
+func invokeObjWithError(
+    _ target: NSObject, _ sel: Selector, _ err: inout NSError?
+) -> NSObject? {
+    guard let imp = class_getMethodImplementation(type(of: target), sel) else { return nil }
+    typealias Fn = @convention(c) (AnyObject, Selector, AutoreleasingUnsafeMutablePointer<NSError?>) -> AnyObject?
+    return unsafeBitCast(imp, to: Fn.self)(target, sel, &err) as? NSObject
+}
+
+// MARK: - Device Discovery
+
+func sharedServiceContext() -> NSObject? {
+    guard let cls = NSClassFromString("SimServiceContext") else { return nil }
+    let sel = NSSelectorFromString("sharedServiceContextForDeveloperDir:error:")
+    var err: NSError?
+    let ctx = invokeClassObjWithObjAndError(cls, sel, developerDir() as NSString, &err)
+    if ctx == nil, let err { logErr("sharedServiceContext: \(err)") }
+    return ctx
+}
+
+func defaultDeviceSet() -> NSObject? {
+    guard let ctx = sharedServiceContext() else { return nil }
+    let sel = NSSelectorFromString("defaultDeviceSetWithError:")
+    guard ctx.responds(to: sel) else { return nil }
+    var err: NSError?
+    return invokeObjWithError(ctx, sel, &err)
+}
+
+func availableDevices() -> [NSObject] {
+    guard let set = defaultDeviceSet() else { return [] }
+    return (set.value(forKey: "availableDevices") as? [NSObject]) ?? []
+}
+
+func resolveDevice(udid: String) -> NSObject? {
+    for device in availableDevices() {
+        if (device.value(forKey: "UDID") as? NSUUID)?.uuidString == udid {
+            return device
+        }
+    }
+    return nil
+}
+
+func listDevices() -> [[String: Any]] {
+    availableDevices().map { device in
+        let udid = (device.value(forKey: "UDID") as? NSUUID)?.uuidString ?? ""
+        let name = (device.value(forKey: "name") as? String) ?? "Unknown"
+        let rawState = (device.value(forKey: "state") as? NSNumber)?.uintValue ?? 1
+        let state: String
+        switch rawState {
+        case 3: state = "booted"
+        default: state = "shutdown"
+        }
+        let runtimeName = (device.value(forKey: "runtime") as? NSObject).flatMap { rt -> String? in
+            (rt.value(forKey: "name") as? String) ?? (rt.value(forKey: "versionString") as? String)
+        } ?? ""
+        return ["udid": udid, "name": name, "state": state, "runtime": runtimeName]
+    }
+}
+
+func devicePointSize(for device: NSObject) -> CGSize {
+    let fallback = CGSize(width: 393, height: 852)
+    guard let deviceType = device.value(forKey: "deviceType") as? NSObject else { return fallback }
+    let pixelSize: CGSize
+    if let raw = deviceType.value(forKey: "mainScreenSize") as? CGSize {
+        pixelSize = raw
+    } else if let nsv = deviceType.value(forKey: "mainScreenSize") as? NSValue {
+        pixelSize = nsv.sizeValue
+    } else {
+        return fallback
+    }
+    let scale = (deviceType.value(forKey: "mainScreenScale") as? NSNumber)?.doubleValue ?? 3.0
+    guard scale > 0 else { return fallback }
+    return CGSize(width: pixelSize.width / scale, height: pixelSize.height / scale)
+}
+
+// MARK: - Accessibility Bridge
+
+/// TokenDispatcher — bridge-token delegate for AXPTranslator.
+/// Routes XPC requests to the correct SimDevice.
+final class TokenDispatcher: NSObject, @unchecked Sendable {
+    private let lock = NSLock()
+    private var deviceForToken: [String: NSObject] = [:]
+    private var deadlineForToken: [String: Date] = [:]
+
+    func register(device: NSObject, token: String, deadline: Date) {
+        lock.lock(); defer { lock.unlock() }
+        deviceForToken[token] = device
+        deadlineForToken[token] = deadline
+    }
+
+    func unregister(token: String) {
+        lock.lock(); defer { lock.unlock() }
+        deviceForToken.removeValue(forKey: token)
+        deadlineForToken.removeValue(forKey: token)
+    }
+
+    private func lookup(token: String) -> (NSObject, Date)? {
+        lock.lock(); defer { lock.unlock() }
+        guard let dev = deviceForToken[token] else { return nil }
+        return (dev, deadlineForToken[token] ?? Date.distantFuture)
+    }
+
+    @objc dynamic func accessibilityTranslationDelegateBridgeCallbackWithToken(
+        _ token: NSString
+    ) -> Any {
+        let key = token as String
+        let entry = self.lookup(token: key)
+        let block: @convention(block) (AnyObject) -> AnyObject = { [weak self] request in
+            guard let self else { return TokenDispatcher.emptyResponse() }
+            guard let (device, deadline) = entry else {
+                return TokenDispatcher.emptyResponse()
+            }
+            let remaining = max(0, deadline.timeIntervalSinceNow)
+            if remaining <= 0 { return TokenDispatcher.emptyResponse() }
+            let timeout = min(remaining, 10.0)
+            return self.sendAccessibilityRequest(
+                request, to: device, timeout: timeout
+            ) ?? TokenDispatcher.emptyResponse()
+        }
+        return block
+    }
+
+    @objc dynamic func accessibilityTranslationConvertPlatformFrameToSystem(
+        _ rect: CGRect, withToken token: NSString
+    ) -> CGRect {
+        rect
+    }
+
+    @objc dynamic func accessibilityTranslationRootParentWithToken(
+        _ token: NSString
+    ) -> AnyObject? {
+        nil
+    }
+
+    private func sendAccessibilityRequest(
+        _ request: AnyObject, to device: NSObject, timeout: Double
+    ) -> AnyObject? {
+        let sel = NSSelectorFromString("sendAccessibilityRequestAsync:completionQueue:completionHandler:")
+        guard let imp = class_getMethodImplementation(type(of: device), sel) else {
+            logErr("[ax] SimDevice.sendAccessibilityRequestAsync not found")
+            return nil
+        }
+        typealias Fn = @convention(c) (AnyObject, Selector, AnyObject, DispatchQueue, Any) -> Void
+        let send = unsafeBitCast(imp, to: Fn.self)
+
+        let group = DispatchGroup()
+        group.enter()
+        let queue = DispatchQueue(label: "sim-bridge.ax.xpc")
+        final class Box: @unchecked Sendable { var value: AnyObject? }
+        let box = Box()
+        let completion: @convention(block) (AnyObject?) -> Void = { response in
+            box.value = response
+            group.leave()
+        }
+        send(device, sel, request, queue, completion as Any)
+        if group.wait(timeout: .now() + timeout) == .timedOut {
+            logErr("[ax] XPC request timed out after \(timeout)s")
+            return nil
+        }
+        return box.value
+    }
+
+    static func emptyResponse() -> AnyObject {
+        if let cls = NSClassFromString("AXPTranslatorResponse") {
+            let sel = NSSelectorFromString("emptyResponse")
+            if let metaCls = object_getClass(cls),
+               let imp = class_getMethodImplementation(metaCls, sel) {
+                typealias Fn = @convention(c) (AnyClass, Selector) -> AnyObject?
+                if let resp = unsafeBitCast(imp, to: Fn.self)(cls, sel) {
+                    return resp
+                }
+            }
+        }
+        return NSNull()
+    }
+}
+
+let sharedDispatcher = TokenDispatcher()
+
+nonisolated(unsafe) let sharedTranslator: NSObject? = {
+    // Ensure frameworks are loaded before attempting class lookup
+    loadFrameworks()
+    guard let cls = NSClassFromString("AXPTranslator") else {
+        logErr("[ax] AXPTranslator class not found")
+        return nil
+    }
+    let sel = NSSelectorFromString("sharedInstance")
+    guard let metaCls = object_getClass(cls),
+          let imp = class_getMethodImplementation(metaCls, sel) else {
+        logErr("[ax] +sharedInstance not found")
+        return nil
+    }
+    typealias Fn = @convention(c) (AnyClass, Selector) -> AnyObject?
+    guard let inst = unsafeBitCast(imp, to: Fn.self)(cls, sel) as? NSObject else {
+        logErr("[ax] +sharedInstance returned nil")
+        return nil
+    }
+    inst.setValue(sharedDispatcher, forKey: "bridgeTokenDelegate")
+    logErr("[ax] AXPTranslator wired with bridgeTokenDelegate")
+    return inst
+}()
+
+// MARK: - AX Element Reading
+
+func axString(_ obj: NSObject, _ key: String) -> String? {
+    guard let s = obj.value(forKey: key) as? String, !s.isEmpty else { return nil }
+    return s
+}
+
+func axStringOrNumber(_ obj: NSObject, _ key: String) -> String? {
+    let raw = obj.value(forKey: key)
+    if let s = raw as? String { return s.isEmpty ? nil : s }
+    if let n = raw as? NSNumber { return n.stringValue }
+    return nil
+}
+
+func axBool(_ obj: NSObject, _ key: String, default fallback: Bool) -> Bool {
+    if let n = obj.value(forKey: key) as? NSNumber { return n.boolValue }
+    return fallback
+}
+
+func axFrame(of element: NSObject) -> CGRect {
+    let sel = NSSelectorFromString("accessibilityFrame")
+    guard element.responds(to: sel),
+          let imp = class_getMethodImplementation(type(of: element), sel) else {
+        return .zero
+    }
+    typealias Fn = @convention(c) (AnyObject, Selector) -> CGRect
+    return unsafeBitCast(imp, to: Fn.self)(element, sel)
+}
+
+func axChildren(of element: NSObject) -> [NSObject] {
+    guard let raw = element.value(forKey: "accessibilityChildren") else { return [] }
+    if let arr = raw as? [NSObject] { return arr }
+    return []
+}
+
+// MARK: - AX Frame Transform
+
+struct AXFrameTransform {
+    let rootFrame: CGRect
+    let pointSize: CGSize
+
+    func map(_ macFrame: CGRect) -> CGRect {
+        guard rootFrame.width > 0, rootFrame.height > 0,
+              pointSize.width > 0, pointSize.height > 0 else { return macFrame }
+        let scale = pointSize.width / rootFrame.width
+        let yOffset = (pointSize.height - rootFrame.height * scale) / 2
+        return CGRect(
+            x: (macFrame.origin.x - rootFrame.origin.x) * scale,
+            y: (macFrame.origin.y - rootFrame.origin.y) * scale + yOffset,
+            width: macFrame.size.width * scale,
+            height: macFrame.size.height * scale
+        )
+    }
+}
+
+// MARK: - AX Tree Walking
+
+let maxDepth = 60
+let xpcTimeout: Double = 5.0
+
+/// Walk an AXPMacPlatformElement tree into idb-compatible dicts.
+func walkElement(
+    _ element: NSObject,
+    transform: AXFrameTransform,
+    depth: Int,
+    deadline: Date,
+    nested: Bool
+) -> [String: Any] {
+    let role = axString(element, "accessibilityRole") ?? "AXUnknown"
+    let macFrame = axFrame(of: element)
+    let projected = transform.map(macFrame)
+
+    // Strip "AX" prefix for the "type" field (idb convention)
+    let type: String
+    if role.hasPrefix("AX") {
+        type = String(role.dropFirst(2))
+    } else {
+        type = role
+    }
+
+    let label = axString(element, "accessibilityLabel") ?? axString(element, "accessibilityTitle")
+
+    var dict: [String: Any] = [
+        "type": type,
+        "role": role,
+        "role_description": axString(element, "accessibilitySubrole") ?? "",
+        "AXLabel": label ?? "",
+        "AXValue": axStringOrNumber(element, "accessibilityValue") as Any,
+        "AXUniqueId": axString(element, "accessibilityIdentifier") as Any,
+        "frame": [
+            "x": Double(projected.origin.x),
+            "y": Double(projected.origin.y),
+            "width": Double(projected.size.width),
+            "height": Double(projected.size.height),
+        ],
+        "enabled": axBool(element, "accessibilityEnabled", default: true)
+                || axBool(element, "isAccessibilityEnabled", default: false),
+        "help": axString(element, "accessibilityHelp") as Any,
+        "custom_actions": [] as [Any],
+    ]
+
+    if nested && depth < maxDepth && Date() < deadline {
+        let kids = axChildren(of: element)
+        dict["children"] = kids.map { kid in
+            stampElementTranslation(token: currentToken, on: kid)
+            return walkElement(kid, transform: transform, depth: depth + 1,
+                             deadline: deadline, nested: true)
+        }
+    }
+
+    return dict
+}
+
+/// Flatten a nested tree into a flat list of element dicts (no children key).
+func flattenTree(_ dict: [String: Any]) -> [[String: Any]] {
+    var result: [[String: Any]] = []
+    var flat = dict
+    let children = flat.removeValue(forKey: "children") as? [[String: Any]] ?? []
+    result.append(flat)
+    for child in children {
+        result.append(contentsOf: flattenTree(child))
+    }
+    return result
+}
+
+/// Hit-test: find the deepest element containing the point.
+func hitTest(_ dict: [String: Any], x: Double, y: Double) -> [String: Any]? {
+    guard let frame = dict["frame"] as? [String: Double],
+          let fx = frame["x"], let fy = frame["y"],
+          let fw = frame["width"], let fh = frame["height"] else { return nil }
+    guard x >= fx && x < fx + fw && y >= fy && y < fy + fh else { return nil }
+    if let children = dict["children"] as? [[String: Any]] {
+        for child in children {
+            if let hit = hitTest(child, x: x, y: y) { return hit }
+        }
+    }
+    return dict
+}
+
+// Thread-local token for the current AX query
+nonisolated(unsafe) var currentToken = ""
+
+func stampTranslation(token: String, on translation: NSObject) {
+    translation.setValue(token, forKey: "bridgeDelegateToken")
+}
+
+func stampElementTranslation(token: String, on element: NSObject) {
+    if let trans = element.value(forKey: "translation") as? NSObject {
+        stampTranslation(token: token, on: trans)
+    }
+}
+
+func stampSubtree(_ element: NSObject, token: String, depth: Int = 0) {
+    guard depth < maxDepth else { return }
+    let kids = axChildren(of: element)
+    for kid in kids {
+        stampElementTranslation(token: token, on: kid)
+        stampSubtree(kid, token: token, depth: depth + 1)
+    }
+}
+
+func frontmostApplication(translator: NSObject, token: String) -> NSObject? {
+    let sel = NSSelectorFromString("frontmostApplicationWithDisplayId:bridgeDelegateToken:")
+    guard translator.responds(to: sel),
+          let imp = class_getMethodImplementation(type(of: translator), sel) else {
+        logErr("[ax] -frontmostApplicationWithDisplayId:bridgeDelegateToken: not found")
+        return nil
+    }
+    typealias Fn = @convention(c) (AnyObject, Selector, UInt32, AnyObject) -> AnyObject?
+    return unsafeBitCast(imp, to: Fn.self)(translator, sel, 0, token as NSString) as? NSObject
+}
+
+func macPlatformElement(translator: NSObject, translation: NSObject) -> NSObject? {
+    let sel = NSSelectorFromString("macPlatformElementFromTranslation:")
+    guard translator.responds(to: sel),
+          let imp = class_getMethodImplementation(type(of: translator), sel) else {
+        logErr("[ax] -macPlatformElementFromTranslation: not found")
+        return nil
+    }
+    typealias Fn = @convention(c) (AnyObject, Selector, AnyObject) -> AnyObject?
+    return unsafeBitCast(imp, to: Fn.self)(translator, sel, translation) as? NSObject
+}
+
+func describeUI(udid: String, nested: Bool, hitX: Double? = nil, hitY: Double? = nil) -> Any? {
+    guard sharedTranslator != nil else {
+        logErr("[ax] translator not available")
+        return nil
+    }
+    guard let device = resolveDevice(udid: udid) else {
+        logErr("[ax] device not found: \(udid)")
+        return nil
+    }
+
+    let token = UUID().uuidString
+    currentToken = token
+    let deadline = Date().addingTimeInterval(xpcTimeout)
+    sharedDispatcher.register(device: device, token: token, deadline: deadline)
+    defer {
+        sharedDispatcher.unregister(token: token)
+        currentToken = ""
+    }
+
+    guard let translator = sharedTranslator else { return nil }
+    guard let translation = frontmostApplication(translator: translator, token: token) else {
+        logErr("[ax] no frontmost application for udid=\(udid)")
+        return nil
+    }
+    stampTranslation(token: token, on: translation)
+
+    guard let rootElement = macPlatformElement(translator: translator, translation: translation) else {
+        logErr("[ax] no mac platform element from translation")
+        return nil
+    }
+    stampElementTranslation(token: token, on: rootElement)
+    stampSubtree(rootElement, token: token)
+
+    let pointSize = devicePointSize(for: device)
+    let rootFrame = axFrame(of: rootElement)
+    let transform = AXFrameTransform(rootFrame: rootFrame, pointSize: pointSize)
+
+    let tree = walkElement(rootElement, transform: transform, depth: 0,
+                          deadline: deadline, nested: true)
+
+    if let hx = hitX, let hy = hitY {
+        return hitTest(tree, x: hx, y: hy) ?? tree
+    }
+
+    if nested {
+        return tree
+    } else {
+        return flattenTree(tree)
+    }
+}
+
+// MARK: - HID Input Injection
+
+// IOHIDDigitizer types
+typealias CreateDigitizerFn = @convention(c) (
+    CFAllocator?, UInt64, UInt32, UInt32, UInt32, UInt32, UInt32,
+    Double, Double, Double, Double, Double, Bool, Bool, UInt32
+) -> Unmanaged<CFTypeRef>?
+
+typealias CreateFingerFn = @convention(c) (
+    CFAllocator?, UInt64, UInt32, UInt32, UInt32,
+    Double, Double, Double, Double, Double, Bool, Bool, UInt32
+) -> Unmanaged<CFTypeRef>?
+
+typealias AppendEventFn = @convention(c) (CFTypeRef, CFTypeRef, UInt32) -> Void
+typealias TrackpadWrapFn = @convention(c) (UnsafeRawPointer) -> UnsafeMutableRawPointer?
+typealias ButtonFn = @convention(c) (UInt32, UInt32, UInt32) -> UnsafeMutableRawPointer?
+typealias HIDArbitraryFn = @convention(c) (UInt32, UInt32, UInt32, UInt32) -> UnsafeMutableRawPointer?
+typealias ServiceFn = @convention(c) () -> UnsafeMutableRawPointer?
+
+nonisolated(unsafe) var createDigitizerFn: CreateDigitizerFn?
+nonisolated(unsafe) var createFingerFn: CreateFingerFn?
+nonisolated(unsafe) var appendEventFn: AppendEventFn?
+nonisolated(unsafe) var trackpadWrapFn: TrackpadWrapFn?
+nonisolated(unsafe) var buttonFn: ButtonFn?
+nonisolated(unsafe) var hidArbFn: HIDArbitraryFn?
+nonisolated(unsafe) var createPointerSvc: ServiceFn?
+nonisolated(unsafe) var createMouseSvc: ServiceFn?
+nonisolated(unsafe) var hidSymbolsResolved = false
+nonisolated(unsafe) var touchIdCounter: UInt32 = 0
+
+let touchDigitizer: UInt32 = 0x32
+
+func nextTouchId() -> UInt32 {
+    touchIdCounter &+= 1
+    if touchIdCounter == 0 { touchIdCounter = 1 }
+    return touchIdCounter
+}
+
+func resolveHIDSymbols() -> Bool {
+    if hidSymbolsResolved { return true }
+    let dev = developerDir()
+    let kitPath = (dev as NSString).appendingPathComponent(
+        "Library/PrivateFrameworks/SimulatorKit.framework/SimulatorKit"
+    )
+    guard let kit = dlopen(kitPath, RTLD_NOW) else { return false }
+    let dyld = UnsafeMutableRawPointer(bitPattern: -2)
+    guard let pCreateDig = dlsym(dyld, "IOHIDEventCreateDigitizerEvent"),
+          let pCreateFin = dlsym(dyld, "IOHIDEventCreateDigitizerFingerEvent"),
+          let pAppend    = dlsym(dyld, "IOHIDEventAppendEvent"),
+          let pWrap      = dlsym(kit, "IndigoHIDMessageForTrackpadEventFromHIDEventRef")
+    else { return false }
+    createDigitizerFn = unsafeBitCast(pCreateDig, to: CreateDigitizerFn.self)
+    createFingerFn    = unsafeBitCast(pCreateFin, to: CreateFingerFn.self)
+    appendEventFn     = unsafeBitCast(pAppend, to: AppendEventFn.self)
+    trackpadWrapFn    = unsafeBitCast(pWrap, to: TrackpadWrapFn.self)
+    buttonFn = dlsym(kit, "IndigoHIDMessageForButton").map { unsafeBitCast($0, to: ButtonFn.self) }
+    hidArbFn = dlsym(kit, "IndigoHIDMessageForHIDArbitrary").map { unsafeBitCast($0, to: HIDArbitraryFn.self) }
+    createPointerSvc = dlsym(kit, "IndigoHIDMessageToCreatePointerService").map { unsafeBitCast($0, to: ServiceFn.self) }
+    createMouseSvc = dlsym(kit, "IndigoHIDMessageToCreateMouseService").map { unsafeBitCast($0, to: ServiceFn.self) }
+    hidSymbolsResolved = true
+    return true
+}
+
+// Per-device HID client cache
+nonisolated(unsafe) var hidClients: [String: AnyObject] = [:]
+
+func ensureHIDClient(udid: String) -> AnyObject? {
+    if let existing = hidClients[udid] { return existing }
+    guard resolveHIDSymbols() else {
+        logErr("[hid] symbol resolution failed")
+        return nil
+    }
+    guard let device = resolveDevice(udid: udid) else {
+        logErr("[hid] device not found: \(udid)")
+        return nil
+    }
+    guard let cls = NSClassFromString("_TtC12SimulatorKit24SimDeviceLegacyHIDClient") else {
+        logErr("[hid] SimDeviceLegacyHIDClient class not found")
+        return nil
+    }
+    let initSel = NSSelectorFromString("initWithDevice:error:")
+    guard let imp = class_getMethodImplementation(cls, initSel) else { return nil }
+    typealias InitFn = @convention(c) (AnyObject, Selector, AnyObject, AutoreleasingUnsafeMutablePointer<NSError?>) -> AnyObject?
+    let initFn = unsafeBitCast(imp, to: InitFn.self)
+    guard let metaCls = object_getClass(cls),
+          let allocImp = class_getMethodImplementation(metaCls, NSSelectorFromString("alloc")) else { return nil }
+    typealias AllocFn = @convention(c) (AnyClass, Selector) -> AnyObject?
+    guard let allocated = unsafeBitCast(allocImp, to: AllocFn.self)(cls, NSSelectorFromString("alloc")) else { return nil }
+
+    var err: NSError?
+    guard let client = initFn(allocated, initSel, device, &err) else {
+        if let err { logErr("[hid] SimDeviceLegacyHIDClient init failed: \(err)") }
+        return nil
+    }
+
+    // Warm up services
+    if let create = createPointerSvc, let msg = create() {
+        sendHIDMessage(msg, to: client)
+        usleep(20_000)
+    }
+    if let create = createMouseSvc, let msg = create() {
+        sendHIDMessage(msg, to: client)
+        usleep(20_000)
+    }
+
+    hidClients[udid] = client
+    return client
+}
+
+func sendHIDMessage(_ message: UnsafeMutableRawPointer, to client: AnyObject) {
+    let sel = NSSelectorFromString("sendWithMessage:freeWhenDone:completionQueue:completion:")
+    guard let cls = object_getClass(client),
+          let imp = class_getMethodImplementation(cls, sel) else { return }
+    typealias Fn = @convention(c) (AnyObject, Selector, UnsafeMutableRawPointer, ObjCBool, AnyObject?, AnyObject?) -> Void
+    unsafeBitCast(imp, to: Fn.self)(client, sel, message, ObjCBool(true), nil, nil)
+}
+
+// IOHIDDigitizer dispatch — Xcode 26 tap/swipe path
+
+func makeDigitizerEvent(point: CGPoint, identifier: UInt32, isDown: Bool) -> CFTypeRef? {
+    guard let createParent = createDigitizerFn,
+          let createFinger = createFingerFn,
+          let appendFn = appendEventFn else { return nil }
+
+    let mask: UInt32 = isDown ? 0x07 : 0x06
+    let range = isDown
+    let touch = isDown
+    let now = mach_absolute_time()
+    let transducerFinger: UInt32 = 2
+
+    guard let parentUM = createParent(nil, now, transducerFinger, 0, identifier, mask, 0,
+                                      point.x, point.y, 0.0, 0.0, 0.0, range, touch, 0)
+    else { return nil }
+    let parent = parentUM.takeRetainedValue()
+
+    guard let fingerUM = createFinger(nil, now, 0, identifier, mask,
+                                      point.x, point.y, 0.0, 0.0, 0.0, range, touch, 0)
+    else { return parent }
+    let finger = fingerUM.takeRetainedValue()
+    appendFn(parent, finger, 0)
+    return parent
+}
+
+func wrapAndPatch(event: CFTypeRef, edgeBit: UInt8 = 0) -> UnsafeMutableRawPointer? {
+    guard let wrapFn = trackpadWrapFn else { return nil }
+    let raw = Unmanaged.passUnretained(event as AnyObject).toOpaque()
+    guard let msg = wrapFn(raw) else { return nil }
+    let target: UInt32 = 0x32
+    msg.storeBytes(of: target, toByteOffset: 0x6c, as: UInt32.self)
+    let size = malloc_size(msg)
+    if size >= 0x110 {
+        msg.storeBytes(of: target, toByteOffset: 0x10c, as: UInt32.self)
+    }
+    let edgePresent: UInt8 = edgeBit == 0 ? 0 : 0x04
+    msg.storeBytes(of: edgePresent, toByteOffset: 0x3a, as: UInt8.self)
+    msg.storeBytes(of: edgeBit, toByteOffset: 0x3b, as: UInt8.self)
+    if size >= 0xdc {
+        msg.storeBytes(of: edgePresent, toByteOffset: 0xda, as: UInt8.self)
+        msg.storeBytes(of: edgeBit, toByteOffset: 0xdb, as: UInt8.self)
+    }
+    return msg
+}
+
+func sendDigitizerEvent(point: CGPoint, identifier: UInt32, isDown: Bool,
+                        edgeBit: UInt8 = 0, client: AnyObject) -> Bool {
+    guard let event = makeDigitizerEvent(point: point, identifier: identifier, isDown: isDown) else {
+        return false
+    }
+    let msg: UnsafeMutableRawPointer? = withExtendedLifetime(event) {
+        wrapAndPatch(event: event, edgeBit: edgeBit)
+    }
+    guard let msg else { return false }
+    sendHIDMessage(msg, to: client)
+    return true
+}
+
+func clamp01(_ v: Double) -> Double { v < 0 ? 0 : (v > 1 ? 1 : v) }
+
+func doTap(udid: String, x: Double, y: Double, hold: Double = 0.05) -> Bool {
+    guard let client = ensureHIDClient(udid: udid) else { return false }
+    let size = devicePointSize(for: resolveDevice(udid: udid)!)
+    let nx = CGFloat(clamp01(x / Double(size.width)))
+    let ny = CGFloat(clamp01(y / Double(size.height)))
+    let point = CGPoint(x: nx, y: ny)
+    let id = nextTouchId()
+    guard sendDigitizerEvent(point: point, identifier: id, isDown: true, client: client) else { return false }
+    let holdUs = UInt32(max(0.02, hold) * 1_000_000)
+    usleep(holdUs)
+    return sendDigitizerEvent(point: point, identifier: id, isDown: false, client: client)
+}
+
+func doSwipe(udid: String, x1: Double, y1: Double, x2: Double, y2: Double, duration: Double = 0.3) -> Bool {
+    guard let client = ensureHIDClient(udid: udid) else { return false }
+    let size = devicePointSize(for: resolveDevice(udid: udid)!)
+    let start = CGPoint(x: CGFloat(clamp01(x1 / Double(size.width))),
+                        y: CGFloat(clamp01(y1 / Double(size.height))))
+    let end = CGPoint(x: CGFloat(clamp01(x2 / Double(size.width))),
+                      y: CGFloat(clamp01(y2 / Double(size.height))))
+    let steps = 10
+    let stepMs = UInt32(max(8, (duration * 1000) / Double(steps + 2)))
+    let id = nextTouchId()
+
+    guard sendDigitizerEvent(point: start, identifier: id, isDown: true, client: client) else { return false }
+    var ok = 0
+    for i in 1...steps {
+        usleep(stepMs * 1000)
+        let t = Double(i) / Double(steps)
+        let p = CGPoint(x: start.x + (end.x - start.x) * CGFloat(t),
+                        y: start.y + (end.y - start.y) * CGFloat(t))
+        // Move events: use isDown=true for sustained touch (mask 0x07)
+        if sendDigitizerEvent(point: p, identifier: id, isDown: true, client: client) { ok += 1 }
+    }
+    usleep(stepMs * 1000)
+    return sendDigitizerEvent(point: end, identifier: id, isDown: false, client: client) && ok >= steps / 2
+}
+
+func doButton(udid: String, name: String) -> Bool {
+    guard let client = ensureHIDClient(udid: udid) else { return false }
+    let holdUs: UInt32 = 100_000
+
+    switch name {
+    case "home":
+        guard let bfn = buttonFn else { return false }
+        guard let down = bfn(0x0, 1, 0x33) else { return false }
+        sendHIDMessage(down, to: client)
+        usleep(holdUs)
+        guard let up = bfn(0x0, 2, 0x33) else { return false }
+        sendHIDMessage(up, to: client)
+        return true
+
+    case "lock":
+        guard let bfn = buttonFn else { return false }
+        guard let down = bfn(0x1, 1, 0x33) else { return false }
+        sendHIDMessage(down, to: client)
+        usleep(holdUs)
+        guard let up = bfn(0x1, 2, 0x33) else { return false }
+        sendHIDMessage(up, to: client)
+        return true
+
+    case "volumeUp":
+        return pressArbitraryHID(page: 12, usage: 233, holdUs: holdUs, client: client)
+    case "volumeDown":
+        return pressArbitraryHID(page: 12, usage: 234, holdUs: holdUs, client: client)
+
+    default:
+        logErr("[hid] unknown button: \(name)")
+        return false
+    }
+}
+
+func pressArbitraryHID(page: UInt32, usage: UInt32, holdUs: UInt32, client: AnyObject) -> Bool {
+    guard let kfn = hidArbFn else { return false }
+    guard let down = kfn(touchDigitizer, page, usage, 1) else { return false }
+    sendHIDMessage(down, to: client)
+    usleep(holdUs)
+    guard let up = kfn(touchDigitizer, page, usage, 2) else { return false }
+    sendHIDMessage(up, to: client)
+    return true
+}
+
+// Text typing — decompose ASCII to HID keycodes
+
+func doTypeText(udid: String, text: String) -> Bool {
+    guard let client = ensureHIDClient(udid: udid) else { return false }
+    guard let kfn = hidArbFn else {
+        logErr("[hid] IndigoHIDMessageForHIDArbitrary unresolved")
+        return false
+    }
+
+    for c in text {
+        guard let (keyUsage, modifiers) = decomposeCharacter(c) else {
+            logErr("[hid] unsupported character: \(c)")
+            continue
+        }
+
+        // Modifier-down
+        for mod in modifiers {
+            guard let down = kfn(touchDigitizer, 7, mod, 1) else { continue }
+            sendHIDMessage(down, to: client)
+        }
+
+        // Key down
+        guard let keyDown = kfn(touchDigitizer, 7, keyUsage, 1) else { continue }
+        sendHIDMessage(keyDown, to: client)
+        usleep(20_000)
+
+        // Key up
+        guard let keyUp = kfn(touchDigitizer, 7, keyUsage, 2) else { continue }
+        sendHIDMessage(keyUp, to: client)
+
+        // Modifier-up (reverse order)
+        for mod in modifiers.reversed() {
+            guard let up = kfn(touchDigitizer, 7, mod, 2) else { continue }
+            sendHIDMessage(up, to: client)
+        }
+
+        usleep(30_000) // 30ms between characters
+    }
+    return true
+}
+
+/// Decompose an ASCII character into (HID usage on page 7, [modifier usages]).
+/// Returns nil for unsupported characters.
+func decomposeCharacter(_ c: Character) -> (UInt32, [UInt32])? {
+    guard let scalar = c.unicodeScalars.first,
+          c.unicodeScalars.count == 1,
+          scalar.isASCII else { return nil }
+    let v = Int(scalar.value)
+
+    let shiftUsage: UInt32 = 0xE1
+
+    // Lowercase letters
+    if v >= 0x61 && v <= 0x7A {
+        return (UInt32(0x04 + v - 0x61), [])
+    }
+    // Uppercase letters
+    if v >= 0x41 && v <= 0x5A {
+        return (UInt32(0x04 + v - 0x41), [shiftUsage])
+    }
+    // Digits 1-9
+    if v >= 0x31 && v <= 0x39 {
+        return (UInt32(0x1E + v - 0x31), [])
+    }
+    // Digit 0
+    if v == 0x30 { return (0x27, []) }
+
+    // Punctuation map: char -> (usage, shifted?)
+    let punctuation: [Int: (UInt32, Bool)] = [
+        0x20: (0x2C, false), // space
+        0x2D: (0x2D, false), // -
+        0x5F: (0x2D, true),  // _
+        0x3D: (0x2E, false), // =
+        0x2B: (0x2E, true),  // +
+        0x5B: (0x2F, false), // [
+        0x7B: (0x2F, true),  // {
+        0x5D: (0x30, false), // ]
+        0x7D: (0x30, true),  // }
+        0x5C: (0x31, false), // backslash
+        0x7C: (0x31, true),  // |
+        0x3B: (0x33, false), // ;
+        0x3A: (0x33, true),  // :
+        0x27: (0x34, false), // '
+        0x22: (0x34, true),  // "
+        0x60: (0x35, false), // `
+        0x7E: (0x35, true),  // ~
+        0x2C: (0x36, false), // ,
+        0x3C: (0x36, true),  // <
+        0x2E: (0x37, false), // .
+        0x3E: (0x37, true),  // >
+        0x2F: (0x38, false), // /
+        0x3F: (0x38, true),  // ?
+        0x21: (0x1E, true),  // !
+        0x40: (0x1F, true),  // @
+        0x23: (0x20, true),  // #
+        0x24: (0x21, true),  // $
+        0x25: (0x22, true),  // %
+        0x5E: (0x23, true),  // ^
+        0x26: (0x24, true),  // &
+        0x2A: (0x25, true),  // *
+        0x28: (0x26, true),  // (
+        0x29: (0x27, true),  // )
+        0x09: (0x2B, false), // tab
+        0x0A: (0x28, false), // newline -> enter
+        0x0D: (0x28, false), // carriage return -> enter
+    ]
+
+    if let (usage, shifted) = punctuation[v] {
+        return (usage, shifted ? [shiftUsage] : [])
+    }
+    return nil
+}
+
+// MARK: - Screenshot via IOSurface
+
+func doScreenshot(udid: String, quality: Double = 0.8, scale: Int = 1) -> (Data, Int, Int)? {
+    guard let device = resolveDevice(udid: udid) else {
+        logErr("[screenshot] device not found: \(udid)")
+        return nil
+    }
+
+    // Get IO client
+    guard let ioObj = device.perform(NSSelectorFromString("io"))?.takeUnretainedValue() as? NSObject else {
+        logErr("[screenshot] io unavailable")
+        return nil
+    }
+
+    // Update ports
+    ioObj.perform(NSSelectorFromString("updateIOPorts"))
+
+    guard let ports = ioObj.value(forKey: "deviceIOPorts") as? [NSObject] else {
+        logErr("[screenshot] no IO ports")
+        return nil
+    }
+
+    let pidSel = NSSelectorFromString("portIdentifier")
+    let descSel = NSSelectorFromString("descriptor")
+    let surfSel = NSSelectorFromString("framebufferSurface")
+
+    // Find framebuffer descriptor
+    var descriptor: NSObject?
+    for port in ports where port.responds(to: pidSel) {
+        guard let pid = port.perform(pidSel)?.takeUnretainedValue(),
+              "\(pid)" == "com.apple.framebuffer.display",
+              port.responds(to: descSel),
+              let desc = port.perform(descSel)?.takeUnretainedValue() as? NSObject,
+              desc.responds(to: surfSel) else { continue }
+        descriptor = desc
+        break
+    }
+
+    guard let desc = descriptor else {
+        logErr("[screenshot] no framebuffer descriptor")
+        return nil
+    }
+
+    // Get the current surface directly
+    guard let surfObj = desc.perform(surfSel)?.takeUnretainedValue() else {
+        logErr("[screenshot] no framebuffer surface")
+        return nil
+    }
+    let surface = unsafeBitCast(surfObj, to: IOSurface.self)
+    let width = IOSurfaceGetWidth(surface)
+    let height = IOSurfaceGetHeight(surface)
+
+    // Lock and create CGImage
+    IOSurfaceLock(surface, .readOnly, nil)
+    defer { IOSurfaceUnlock(surface, .readOnly, nil) }
+
+    let bpr = IOSurfaceGetBytesPerRow(surface)
+    let base = IOSurfaceGetBaseAddress(surface)
+
+    guard let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) else { return nil }
+    guard let ctx = CGContext(
+        data: base,
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bytesPerRow: bpr,
+        space: colorSpace,
+        bitmapInfo: CGBitmapInfo.byteOrder32Little.rawValue | CGImageAlphaInfo.premultipliedFirst.rawValue
+    ) else { return nil }
+
+    guard let cgImage = ctx.makeImage() else { return nil }
+
+    // Encode JPEG
+    let data = NSMutableData()
+    guard let dest = CGImageDestinationCreateWithData(data, "public.jpeg" as CFString, 1, nil) else { return nil }
+    let options: [CFString: Any] = [kCGImageDestinationLossyCompressionQuality: quality]
+    CGImageDestinationAddImage(dest, cgImage, options as CFDictionary)
+    guard CGImageDestinationFinalize(dest) else { return nil }
+
+    return (data as Data, width, height)
+}
+
+// MARK: - JSON Lines Protocol
+
+func respond(_ dict: [String: Any]) {
+    guard let data = try? JSONSerialization.data(withJSONObject: dict, options: []) else {
+        let fallback = #"{"ok":false,"error":"JSON serialization failed"}"#
+        print(fallback)
+        return
+    }
+    print(String(data: data, encoding: .utf8)!)
+}
+
+func handleCommand(_ dict: [String: Any]) {
+    guard let cmd = dict["cmd"] as? String else {
+        respond(["ok": false, "error": "missing 'cmd' field"])
+        return
+    }
+
+    switch cmd {
+    case "list":
+        respond(["ok": true, "devices": listDevices()])
+
+    case "describe-ui":
+        guard let udid = dict["udid"] as? String else {
+            respond(["ok": false, "error": "missing 'udid'"])
+            return
+        }
+        let nested = dict["nested"] as? Bool ?? false
+        let hitX = dict["x"] as? Double
+        let hitY = dict["y"] as? Double
+
+        if let result = describeUI(udid: udid, nested: nested, hitX: hitX, hitY: hitY) {
+            if hitX != nil && hitY != nil {
+                respond(["ok": true, "element": result])
+            } else {
+                respond(["ok": true, "tree": result])
+            }
+        } else {
+            respond(["ok": false, "error": "Failed to query accessibility tree. Is the simulator booted with a frontmost app?"])
+        }
+
+    case "tap":
+        guard let udid = dict["udid"] as? String,
+              let x = dict["x"] as? Double,
+              let y = dict["y"] as? Double else {
+            respond(["ok": false, "error": "missing 'udid', 'x', or 'y'"])
+            return
+        }
+        let hold = dict["hold"] as? Double ?? 0.05
+        if doTap(udid: udid, x: x, y: y, hold: hold) {
+            respond(["ok": true])
+        } else {
+            respond(["ok": false, "error": "tap failed"])
+        }
+
+    case "swipe":
+        guard let udid = dict["udid"] as? String,
+              let x1 = dict["x1"] as? Double,
+              let y1 = dict["y1"] as? Double,
+              let x2 = dict["x2"] as? Double,
+              let y2 = dict["y2"] as? Double else {
+            respond(["ok": false, "error": "missing swipe parameters"])
+            return
+        }
+        let duration = dict["duration"] as? Double ?? 0.3
+        if doSwipe(udid: udid, x1: x1, y1: y1, x2: x2, y2: y2, duration: duration) {
+            respond(["ok": true])
+        } else {
+            respond(["ok": false, "error": "swipe failed"])
+        }
+
+    case "type":
+        guard let udid = dict["udid"] as? String,
+              let text = dict["text"] as? String else {
+            respond(["ok": false, "error": "missing 'udid' or 'text'"])
+            return
+        }
+        if doTypeText(udid: udid, text: text) {
+            respond(["ok": true])
+        } else {
+            respond(["ok": false, "error": "type failed"])
+        }
+
+    case "button":
+        guard let udid = dict["udid"] as? String,
+              let name = dict["name"] as? String else {
+            respond(["ok": false, "error": "missing 'udid' or 'name'"])
+            return
+        }
+        if doButton(udid: udid, name: name) {
+            respond(["ok": true])
+        } else {
+            respond(["ok": false, "error": "button '\(name)' failed"])
+        }
+
+    case "screenshot":
+        guard let udid = dict["udid"] as? String else {
+            respond(["ok": false, "error": "missing 'udid'"])
+            return
+        }
+        let quality = dict["quality"] as? Double ?? 0.8
+        let scale = dict["scale"] as? Int ?? 1
+        if let (data, width, height) = doScreenshot(udid: udid, quality: quality, scale: scale) {
+            respond([
+                "ok": true,
+                "data": data.base64EncodedString(),
+                "width": width,
+                "height": height,
+            ])
+        } else {
+            respond(["ok": false, "error": "screenshot failed"])
+        }
+
+    default:
+        respond(["ok": false, "error": "unknown command: \(cmd)"])
+    }
+}
+
+// MARK: - Main
+
+setlinebuf(stdout)
+
+// Load frameworks first
+loadFrameworks()
+
+// Initialize the AXP translator (triggers lazy init)
+_ = sharedTranslator
+
+// Signal ready
+respond(["event": "ready"])
+
+// Read commands from stdin
+while let line = readLine() {
+    guard !line.isEmpty else { continue }
+    guard let data = line.data(using: .utf8),
+          let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        respond(["ok": false, "error": "invalid JSON"])
+        continue
+    }
+    handleCommand(dict)
+}

--- a/tools/sim-bridge.swift
+++ b/tools/sim-bridge.swift
@@ -359,6 +359,19 @@ struct AXFrameTransform {
             height: macFrame.size.height * scale
         )
     }
+
+    /// Invert: device point -> Mac AX point. AXPTranslator's
+    /// objectAtPoint expects Mac coordinates, not device points.
+    func unmap(_ devicePoint: CGPoint) -> CGPoint {
+        guard rootFrame.width > 0, rootFrame.height > 0,
+              pointSize.width > 0, pointSize.height > 0 else { return devicePoint }
+        let scale = pointSize.width / rootFrame.width
+        let yOffset = (pointSize.height - rootFrame.height * scale) / 2
+        return CGPoint(
+            x: devicePoint.x / scale + rootFrame.origin.x,
+            y: (devicePoint.y - yOffset) / scale + rootFrame.origin.y
+        )
+    }
 }
 
 // MARK: - AX Tree Walking
@@ -489,6 +502,31 @@ func macPlatformElement(translator: NSObject, translation: NSObject) -> NSObject
     return unsafeBitCast(imp, to: Fn.self)(translator, sel, translation) as? NSObject
 }
 
+/// Server-side hit-test via AXPTranslator. Returns the AXPTranslationObject
+/// at the given Mac AX point, or nil if nothing is there.
+///
+/// idb uses this same selector
+/// (`FBSimulatorAccessibilityCommands.m`:885) to drive its describe-point
+/// path. The token is passed as a parameter — not via the dispatcher's
+/// pre-set bridge delegate — which sidesteps the chicken/egg that the
+/// upstream baguette implementation hit.
+func objectAtPointOnTranslator(
+    translator: NSObject, point: CGPoint, displayId: UInt32, token: String
+) -> NSObject? {
+    let sel = NSSelectorFromString("objectAtPoint:displayId:bridgeDelegateToken:")
+    guard translator.responds(to: sel),
+          let imp = class_getMethodImplementation(type(of: translator), sel) else {
+        logErr("[ax] -objectAtPoint:displayId:bridgeDelegateToken: not found")
+        return nil
+    }
+    typealias Fn = @convention(c) (
+        AnyObject, Selector, CGPoint, UInt32, AnyObject
+    ) -> AnyObject?
+    return unsafeBitCast(imp, to: Fn.self)(
+        translator, sel, point, displayId, token as NSString
+    ) as? NSObject
+}
+
 func describeUI(udid: String, nested: Bool, hitX: Double? = nil, hitY: Double? = nil) -> Any? {
     guard sharedTranslator != nil else {
         logErr("[ax] translator not available")
@@ -537,6 +575,73 @@ func describeUI(udid: String, nested: Bool, hitX: Double? = nil, hitY: Double? =
         return tree
     } else {
         return flattenTree(tree)
+    }
+}
+
+/// Server-side point probe: hit-test via AXPTranslator's objectAtPoint
+/// rather than walking a static tree. Used to discover elements inside
+/// containers that AXP's tree walk reports as childless (e.g. SwiftUI
+/// tab bars). Coordinates are device points; converted to Mac AX coords
+/// for the underlying API call, and projected back to device points
+/// in the returned dict.
+func probePoint(udid: String, x: Double, y: Double, nested: Bool) -> Any? {
+    guard sharedTranslator != nil else {
+        logErr("[ax] translator not available")
+        return nil
+    }
+    guard let device = resolveDevice(udid: udid) else {
+        logErr("[ax] device not found: \(udid)")
+        return nil
+    }
+
+    let token = UUID().uuidString
+    currentToken = token
+    let deadline = Date().addingTimeInterval(xpcTimeout)
+    sharedDispatcher.register(device: device, token: token, deadline: deadline)
+    defer {
+        sharedDispatcher.unregister(token: token)
+        currentToken = ""
+    }
+
+    guard let translator = sharedTranslator else { return nil }
+
+    // We need the frontmost app's root frame to invert device-point -> Mac.
+    guard let frontmost = frontmostApplication(translator: translator, token: token) else {
+        logErr("[ax] no frontmost application for udid=\(udid)")
+        return nil
+    }
+    stampTranslation(token: token, on: frontmost)
+    guard let frontmostRoot = macPlatformElement(translator: translator, translation: frontmost) else {
+        logErr("[ax] no mac platform element for frontmost translation")
+        return nil
+    }
+    let pointSize = devicePointSize(for: device)
+    let rootFrame = axFrame(of: frontmostRoot)
+    let transform = AXFrameTransform(rootFrame: rootFrame, pointSize: pointSize)
+
+    let macPoint = transform.unmap(CGPoint(x: x, y: y))
+
+    guard let hitTranslation = objectAtPointOnTranslator(
+        translator: translator, point: macPoint, displayId: 0, token: token
+    ) else {
+        logErr("[ax] objectAtPoint returned nil for device=(\(x),\(y)) mac=(\(macPoint.x),\(macPoint.y))")
+        return nil
+    }
+    stampTranslation(token: token, on: hitTranslation)
+    guard let hitElement = macPlatformElement(translator: translator, translation: hitTranslation) else {
+        logErr("[ax] no mac platform element for hit translation")
+        return nil
+    }
+    stampElementTranslation(token: token, on: hitElement)
+    stampSubtree(hitElement, token: token)
+
+    let subtree = walkElement(hitElement, transform: transform, depth: 0,
+                              deadline: deadline, nested: true)
+
+    if nested {
+        return subtree
+    } else {
+        return flattenTree(subtree)
     }
 }
 
@@ -1028,6 +1133,20 @@ func handleCommand(_ dict: [String: Any]) {
     switch cmd {
     case "list":
         respond(["ok": true, "devices": listDevices()])
+
+    case "probe-point":
+        guard let udid = dict["udid"] as? String,
+              let x = dict["x"] as? Double,
+              let y = dict["y"] as? Double else {
+            respond(["ok": false, "error": "missing 'udid', 'x', or 'y'"])
+            return
+        }
+        let nested = dict["nested"] as? Bool ?? false
+        if let result = probePoint(udid: udid, x: x, y: y, nested: nested) {
+            respond(["ok": true, "tree": result])
+        } else {
+            respond(["ok": false, "error": "probe-point returned nil"])
+        }
 
     case "describe-ui":
         guard let udid = dict["udid"] as? String else {


### PR DESCRIPTION
## Summary

Replaces idb for simulator UI automation with **sim-bridge**, a native Swift helper that talks to `CoreSimulator` / `SimulatorKit` / `AccessibilityPlatformTranslation` directly via `dlopen`. No daemon, no subprocess-per-call, no Homebrew dependency. idb remains as the automatic fallback for Intel Macs and pre-Xcode-26 hosts; `quern setup` skips the idb install entirely when sim-bridge is supported.

The non-obvious part: closing the **empty-group-children gap** — the bug behind facebook/idb#767 and the reason we ship a patched idb companion. Upstream baguette (the project we draw the AXP+dispatcher pattern from) explicitly punted on a server-side hit-test, citing a chicken/egg with `bridgeDelegateToken`. Reading idb's source surfaced that `AXPTranslator` exposes a 3-arg variant — `objectAtPoint:displayId:bridgeDelegateToken:` — that takes the token as a parameter and works fine with the dispatcher. Wired into sim-bridge, it lets us grid-probe empty containers (SwiftUI tab bars, nav bars, toolbars) and surface their hidden subviews. End-to-end parity with the patched companion, no idb required.

## What's in this PR (9 commits, by area)

### Backend behavior
- **`67f5a10` clear_text + button-name parity** — `clear_text`'s triple-tap-then-backspace was silently dropping the backspace because `0x08` wasn't in sim-bridge's char→HID map. `press_button HOME` (and `LOCK`, `SIDE_BUTTON`, `SIRI`, `APPLE_PAY`) failed because `doButton` matched lowercase Swift names only while the MCP contract uses idb's uppercase set. Normalized names, mapped backspace/DEL → HID `0x2A`.
- **`5af55c9` server-side `objectAtPoint` + group-children probing** — adds `objectAtPointOnTranslator` via the 3-arg AXP selector, a `probe-point` cmd, an `AXFrameTransform.unmap` for device-point → Mac-AX coords, and extracts probing logic into a shared `server/device/probing.py` consumed by both `IdbBackend` and `SimBridgeBackend`. Verified on Metatext / iOS 17.5 / 18.6 / 26.4: `tap_element(identifier='tab.notifications')` now routes a real tap.
- **`fb6be64` RadioButton / CheckBox in screen summaries** — once probing surfaced the tab buttons, `get_screen_summary` was still dropping them because `_INTERACTIVE_TYPES` didn't include `radiobutton` / `checkbox`. Added both, plus a chrome rule for `RadioButton` with `role_description=AXTabButton` so tab buttons bypass the truncation limit.

### Setup
- **`dbcd049` installer skips idb on Xcode 26+ Apple Silicon** — new `_sim_bridge_supported()` helper (`_is_apple_silicon()` + `_xcode_major_version() >= 26`). When true, the two idb prompts (`idb_companion` and `fb-idb`) are short-circuited to `SKIPPED` with a one-line note. Existing idb installs are left alone; older Xcode / Intel hosts keep the existing flow.

### Documentation
- **`43d8850`** — `Requires idb.` removed from all 9 MCP tool descriptions in `mcp/src/tools/device-ui.ts` (the string was already misleading once `WdaBackend` / `U2Backend` landed; now actively wrong with sim-bridge). `mode: 'flat'` descriptions re-framed as the patched-idb-only path. `CHANGELOG.md` gains an Unreleased section covering everything in this PR.
- **`4b57dec`** — README, `docs/agent-guide.md`, and `docs/sim-bridge-spec.md` spot-checked and refreshed to reflect the new default. Sim-bridge-spec gains a "shipped" banner.
- **`09f6087`** — start tracking two writeups that were in the working tree as drafts (`idb-companion-distribution.md`, `feature-request-group-children-probe.md`), both with "superseded by sim-bridge on Xcode 26+" banners.
- **`d44ee1f`** — track three planning docs as forward-looking specs (`linux-support-plan.md`, `screen-identification-in-actions.md`, `vision-event-model.md`). Verified none are implemented; committed as plans, not status reports.
- **`07dff5b`** — clarifying banner on `screen-identification-in-actions.md` distinguishing what shipped (landmark engine in v0.11/v0.12) from what didn't (auto-identify in action responses, `expected_screen` parameter).

## Test plan

- [x] Full pytest suite passes (1306 tests, 16 deselected — no regressions)
- [x] sim-bridge compiles cleanly with Xcode 26 / Swift 6.3 on Apple Silicon
- [x] Live end-to-end against Metatext on iOS 17.5, 18.6, 26.4: tap_element, tap (coordinates), swipe, type_text, clear_text, press_button (HOME, LOCK, SIDE_BUTTON, SIRI, APPLE_PAY, volumeUp, volumeDown), take_screenshot, take_annotated_screenshot, get_ui_tree, get_screen_summary
- [x] Group-children probing verified — Metatext's four SwiftUI tab buttons (`tab.timelines` / `tab.explore` / `tab.notifications` / `tab.messages`) resolve via `tap_element` and route real taps on all three iOS versions
- [x] Installer behavior verified on host (Xcode 26.0 / Apple Silicon): `_sim_bridge_supported()` returns True; idb prompts would be skipped
- [x] MCP TypeScript wrapper builds clean after description updates
- [ ] Cross-check on an Intel Mac or pre-Xcode-26 host (idb fallback path) — don't have one handy, but the gate is a single `if` and the legacy install flow is unchanged