### PR TITLE
probing: discover SwiftUI ToolbarItems on pushed nav controllers

### DIFF
--- a/server/device/probing.py
+++ b/server/device/probing.py
@@ -26,6 +26,13 @@ PROBEABLE_ROLES = frozenset({
 # Probe interval in points — smaller than iOS minimum tap target (44pt)
 PROBE_STEP = 20
 
+# Geometry thresholds for recognizing nav-bar-shaped Groups whose
+# role_description is empty (SwiftUI pushed-nav screens hit this case).
+# A standard iOS nav bar sits below the safe-area top (~44-100pt y) with a
+# height of 44-60pt; we allow some slack on both ends.
+NAV_BAR_MAX_Y = 120
+NAV_BAR_MAX_HEIGHT = 80
+
 
 def is_probeable_container(item: dict) -> bool:
     """Check if an item is an interactive container with no enumerated children."""
@@ -40,6 +47,19 @@ def is_probeable_container(item: dict) -> bool:
     label = item.get("AXLabel") or ""
     if item.get("type") == "Group" and "tab bar" in label.lower():
         return True
+
+    # SwiftUI pushed-nav screens (`UIHostingController` inside a
+    # `UINavigationController`) expose their nav-bar accessibility container
+    # as a plain `AXGroup` with empty role_description but a non-empty
+    # identifier (set to the screen's nav title), and report no enumerated
+    # children. Recognize it by the nav-bar geometry so toolbar items inside
+    # get probed.
+    if item.get("type") == "Group" and (item.get("AXUniqueId") or item.get("identifier")):
+        frame = item.get("frame") or {}
+        y = frame.get("y", 0)
+        height = frame.get("height", 0)
+        if y < NAV_BAR_MAX_Y and 0 < height <= NAV_BAR_MAX_HEIGHT:
+            return True
 
     return False
 

--- a/tests/test_idb_backend.py
+++ b/tests/test_idb_backend.py
@@ -411,6 +411,69 @@ class TestIsProbeableContainer:
         item = {"type": "Group", "role_description": "Nav bar"}
         assert probing.is_probeable_container(item) is True
 
+    def test_swiftui_pushed_nav_group_via_identifier_and_geometry(self):
+        """Empty Group at nav-bar y/height with an identifier is probeable.
+
+        SwiftUI's `UIHostingController` in a `UINavigationController` exposes
+        the nav-bar accessibility container as an AXGroup with empty
+        role_description, an identifier set to the screen's nav title, and no
+        enumerated children. ToolbarItems live inside but are invisible
+        unless we probe.
+        """
+        item = {
+            "type": "Group",
+            "AXLabel": "",
+            "identifier": "My Lodestones",
+            "role_description": "",
+            "frame": {"x": 0, "y": 62, "width": 402, "height": 54},
+            "children": [],
+        }
+        assert probing.is_probeable_container(item) is True
+
+    def test_swiftui_pushed_nav_group_via_axuniqueid(self):
+        """Same case but identifier is exposed under AXUniqueId."""
+        item = {
+            "type": "Group",
+            "AXLabel": "",
+            "AXUniqueId": "Shareables",
+            "role_description": "",
+            "frame": {"x": 0, "y": 62, "width": 402, "height": 54},
+            "children": [],
+        }
+        assert probing.is_probeable_container(item) is True
+
+    def test_top_group_without_identifier_not_probeable(self):
+        """Identical geometry but no identifier — likely just a layout group, skip."""
+        item = {
+            "type": "Group",
+            "role_description": "",
+            "frame": {"x": 0, "y": 62, "width": 402, "height": 54},
+            "children": [],
+        }
+        assert probing.is_probeable_container(item) is False
+
+    def test_group_with_identifier_outside_nav_bar_zone_not_probeable(self):
+        """Group with identifier but below the nav-bar zone — content card, skip."""
+        item = {
+            "type": "Group",
+            "identifier": "Some Card",
+            "role_description": "",
+            "frame": {"x": 0, "y": 400, "width": 402, "height": 54},
+            "children": [],
+        }
+        assert probing.is_probeable_container(item) is False
+
+    def test_group_with_identifier_too_tall_not_probeable(self):
+        """Group near top but too tall to be a nav bar — full-screen overlay, skip."""
+        item = {
+            "type": "Group",
+            "identifier": "Modal",
+            "role_description": "",
+            "frame": {"x": 0, "y": 0, "width": 402, "height": 600},
+            "children": [],
+        }
+        assert probing.is_probeable_container(item) is False
+
 
 # ---------------------------------------------------------------------------
 # _find_empty_containers


### PR DESCRIPTION
When a SwiftUI view in a UIHostingController is pushed onto a UINavigationController, the nav-bar accessibility container is exposed as a plain AXGroup with empty role_description, an identifier set to the screen's nav title, and no enumerated children — so its toolbar items (.topBarTrailing / .topBarLeading buttons) never appeared in describe_all output, even when the developer added an explicit .accessibilityIdentifier(...).

The existing is_probeable_container only matched role_description ∈ {"Nav bar", "Tab bar", "Toolbar", "Navigation bar"} or AXLabel containing "tab bar". The pushed-nav Group matches neither, so find_empty_containers skipped it.

Extend the predicate to also probe AXGroups at the top of the screen (y < 120pt, height ≤ 80pt) that carry an identifier (either `identifier` or `AXUniqueId`) and have no children — the SwiftUI nav-bar signature. The geometry thresholds align with iOS nav-bar safe-area height (44-60pt) plus slack for the safe-area top inset.

Verified live against an iOS 26.5 simulator on the Geocaching app: the Profile screen's gear icon (`_Settings button`), Friends button, and a new Lodestone List's "+" toolbar item all surface now without coordinate-based fallbacks.

Adds 5 unit tests covering the positive cases (`identifier` and `AXUniqueId` flavors) and explicit negatives (no identifier, below the nav-bar zone, too tall to be a nav bar).
