### PR TITLE
fix(sim-bridge): keyboard modifiers drop on synthetic typing — attach hardware keyboard + harden HID path

### DIFF
--- a/mcp/src/tools/device-ui.ts
+++ b/mcp/src/tools/device-ui.ts
@@ -504,7 +504,7 @@ Label matching modes (mutually exclusive — use only one):
   });
 
   server.registerTool("type_text", {
-    description: `Type text into the currently focused input field.`,
+    description: `Type text into the currently focused input field. On iOS simulators this attaches the simulated hardware keyboard before typing (required for shifted characters to retain their modifier), which hides the software keyboard — use set_hardware_keyboard with enabled=false afterward if a later step expects the software keyboard to be visible.`,
     inputSchema: strictParams({
       text: z.string().describe("Text to type"),
       udid: z

--- a/mcp/src/tools/device.ts
+++ b/mcp/src/tools/device.ts
@@ -802,6 +802,27 @@ Examples:
     }
   });
 
+  server.registerTool("set_hardware_keyboard", {
+    description: `Attach or detach the simulated hardware keyboard on an iOS simulator — the same switch as Simulator.app's "Connect Hardware Keyboard" (shift-cmd-K) toggle. enabled=true hides the software keyboard (smaller UI trees, unobstructed screenshots during form filling); enabled=false restores the software keyboard for focused text fields. NOTE: type_text flips the simulator into hardware-keyboard mode as a side effect of sending key events — call this with enabled=false afterward if a later step expects the software keyboard to be visible.`,
+    inputSchema: strictParams({
+      enabled: z.boolean().describe("true = attach hardware keyboard (software keyboard hidden), false = detach (software keyboard shows for focused fields)"),
+      udid: z.string().optional().describe("Target device UDID (defaults to active device)"),
+    }),
+  }, async ({ enabled, udid }) => {
+    try {
+      const body: Record<string, unknown> = { enabled };
+      if (udid) body.udid = udid;
+
+      const data = await apiRequest("POST", "/api/v1/device/keyboard", undefined, body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
+    } catch (e) {
+      return {
+        content: [{ type: "text" as const, text: `Error: ${e instanceof Error ? e.message : String(e)}` }],
+        isError: true,
+      };
+    }
+  });
+
   server.registerTool("set_font_scale", {
     description: `Set the font scale on an Android device or emulator. Takes effect immediately. Standard values: 0.85 (small), 1.0 (default), 1.15 (large), 1.30 (largest). Any float value is accepted.`,
     inputSchema: strictParams({

--- a/server/api/device.py
+++ b/server/api/device.py
@@ -21,6 +21,7 @@ from server.models import (
     PreviewStopRequest,
     SetDisplayDensityRequest,
     SetFontScaleRequest,
+    SetHardwareKeyboardRequest,
     SetLocaleRequest,
     SetLocationRequest,
     ShutdownDeviceRequest,
@@ -509,6 +510,19 @@ async def set_locale(request: Request, body: SetLocaleRequest):
         )
         locale_tag = f"{body.lang}-{body.country}" if body.country else body.lang
         return {"status": "ok", "udid": udid, "locale": locale_tag}
+    except DeviceError as e:
+        raise _handle_device_error(e)
+
+
+@router.post("/keyboard")
+async def set_hardware_keyboard(request: Request, body: SetHardwareKeyboardRequest):
+    """Attach or detach the simulated hardware keyboard (iOS simulators only)."""
+    controller = _get_controller(request)
+    try:
+        udid = await controller.set_hardware_keyboard(
+            enabled=body.enabled, udid=body.udid,
+        )
+        return {"status": "ok", "udid": udid, "hardware_keyboard": body.enabled}
     except DeviceError as e:
         raise _handle_device_error(e)
 

--- a/server/device/controller.py
+++ b/server/device/controller.py
@@ -549,6 +549,27 @@ class DeviceController(DeviceControllerUI):
             )
         return resolved
 
+    async def set_hardware_keyboard(
+        self, enabled: bool, udid: str | None = None,
+    ) -> str:
+        """Attach/detach the simulated hardware keyboard. Returns the resolved udid.
+
+        iOS simulators only; requires the sim-bridge backend. While the
+        hardware keyboard is attached the software keyboard stays hidden,
+        which keeps UI trees small and screenshots unobstructed. Detaching
+        restores the software keyboard for focused text fields.
+        """
+        resolved = await self.resolve_udid(udid)
+        self._require_simulator(resolved, "Set hardware keyboard")
+        if not self._sim_bridge_ok:
+            raise DeviceError(
+                "set_hardware_keyboard requires the sim-bridge backend "
+                "(Xcode with SimulatorKit private frameworks)",
+                tool="sim-bridge",
+            )
+        await self.sim_bridge.set_hardware_keyboard(resolved, enabled)
+        return resolved
+
     async def set_font_scale(
         self, scale: float, udid: str | None = None,
     ) -> str:

--- a/server/device/sim_bridge.py
+++ b/server/device/sim_bridge.py
@@ -28,6 +28,12 @@ _SOURCE_CANDIDATES = [
     Path(__file__).resolve().parent.parent.parent / "tools" / "sim-bridge.swift",
 ]
 
+# Max length of one stdout JSON line from the subprocess. asyncio's default
+# StreamReader limit is 64 KiB; a describe-ui response for a dense screen
+# (e.g. a map with hundreds of annotations) easily exceeds that, which made
+# readline() raise LimitOverrunError and killed the reader task.
+STREAM_LIMIT = 32 * 1024 * 1024
+
 
 def _find_source() -> Path | None:
     for p in _SOURCE_CANDIDATES:
@@ -43,6 +49,7 @@ class SimBridgeManager:
         self._process: asyncio.subprocess.Process | None = None
         self._ready = asyncio.Event()
         self._reader_task: asyncio.Task | None = None
+        self._stderr_task: asyncio.Task | None = None
         self._lock = asyncio.Lock()
         self._binary_path = QUERN_BIN_DIR / BINARY_NAME
         self._pending_response: asyncio.Future | None = None
@@ -133,8 +140,10 @@ class SimBridgeManager:
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            limit=STREAM_LIMIT,
         )
         self._reader_task = asyncio.create_task(self._stdout_reader())
+        self._stderr_task = asyncio.create_task(self._stderr_reader())
 
         try:
             await asyncio.wait_for(self._ready.wait(), timeout=15.0)
@@ -164,7 +173,34 @@ class SimBridgeManager:
         except Exception:
             logger.exception("sim-bridge stdout reader error")
         finally:
+            # The subprocess itself is usually still healthy when the reader
+            # dies (e.g. an oversized line). Kill it before dropping our
+            # reference — otherwise each respawn leaks an orphaned binary.
+            await self._kill_process()
             self._cleanup_state()
+
+    async def _stderr_reader(self) -> None:
+        """Background task: drains subprocess stderr into the debug log.
+
+        The Swift helper writes [PERF]/[ax]/[hid] diagnostics to stderr; if
+        nobody reads the pipe, the 64 KiB buffer eventually fills and the
+        subprocess blocks mid-write, hanging every subsequent command.
+        """
+        proc = self._process
+        if proc is None or proc.stderr is None:
+            return
+
+        try:
+            while True:
+                line = await proc.stderr.readline()
+                if not line:
+                    break
+                text = line.decode(errors="replace").rstrip()
+                if text.startswith("[sim-bridge] "):
+                    text = text[len("[sim-bridge] "):]
+                logger.debug("sim-bridge stderr: %s", text)
+        except Exception:
+            logger.debug("sim-bridge stderr reader stopped", exc_info=True)
 
     def _dispatch(self, msg: dict) -> None:
         """Route a parsed JSON message from the subprocess."""
@@ -231,6 +267,9 @@ class SimBridgeManager:
         if self._reader_task and not self._reader_task.done():
             self._reader_task.cancel()
         self._reader_task = None
+        if self._stderr_task and not self._stderr_task.done():
+            self._stderr_task.cancel()
+        self._stderr_task = None
         self._process = None
         self._ready.clear()
         if self._pending_response and not self._pending_response.done():

--- a/server/device/sim_bridge.py
+++ b/server/device/sim_bridge.py
@@ -365,6 +365,11 @@ class SimBridgeBackend:
     async def press_button(self, udid: str, button: str) -> None:
         await self._send({"cmd": "button", "udid": udid, "name": button})
 
+    async def set_hardware_keyboard(self, udid: str, enabled: bool) -> None:
+        await self._send({
+            "cmd": "set-hardware-keyboard", "udid": udid, "enabled": enabled,
+        })
+
     async def select_all_and_delete(
         self, udid: str, x: float, y: float,
         element_type: str | None = None,

--- a/server/models.py
+++ b/server/models.py
@@ -1031,6 +1031,13 @@ class SetLocaleRequest(BaseModel):
     udid: str | None = None
 
 
+class SetHardwareKeyboardRequest(BaseModel):
+    """Request body for POST /device/keyboard."""
+
+    enabled: bool
+    udid: str | None = None
+
+
 class SetFontScaleRequest(BaseModel):
     """Request body for POST /device/font-scale."""
 

--- a/skills/quern-api/SKILL.md
+++ b/skills/quern-api/SKILL.md
@@ -82,6 +82,7 @@ from REST paths in non-obvious ways — this reference gives you the correct map
 | `shutdown_device` | POST | `/api/v1/device/shutdown` |
 | `grant_permission` | POST | `/api/v1/device/permission` |
 | `set_locale` | POST | `/api/v1/device/locale` |
+| `set_hardware_keyboard` | POST | `/api/v1/device/keyboard` |
 | `set_location` | POST | `/api/v1/device/location` |
 | `set_display_density` | POST | `/api/v1/device/display-density` |
 | `set_font_scale` | POST | `/api/v1/device/font-scale` |

--- a/tools/sim-bridge.swift
+++ b/tools/sim-bridge.swift
@@ -1045,6 +1045,14 @@ func modifierBit(forUsage usage: UInt32) -> UInt32? {
 func doTypeText(udid: String, text: String) -> Bool {
     guard let client = ensureHIDClient(udid: udid) else { return false }
 
+    // backboardd only honors modifier state while the simulated hardware
+    // keyboard is attached; with it detached (the default on a fresh boot),
+    // shifted characters silently lose their modifier. Attach before typing —
+    // the same call Simulator.app makes when its window takes focus. Side
+    // effect: the software keyboard hides; callers that need it visible
+    // afterward can detach via the set-hardware-keyboard command.
+    _ = setHardwareKeyboard(udid: udid, enabled: true)
+
     // Preferred path: dedicated keyboard messages (same class Simulator.app's own
     // keyboard passthrough emits). The generic HIDArbitrary path drops modifier
     // state on freshly-booted or heavily-loaded simulators — keys land unshifted.

--- a/tools/sim-bridge.swift
+++ b/tools/sim-bridge.swift
@@ -662,6 +662,8 @@ typealias AppendEventFn = @convention(c) (CFTypeRef, CFTypeRef, UInt32) -> Void
 typealias TrackpadWrapFn = @convention(c) (UnsafeRawPointer) -> UnsafeMutableRawPointer?
 typealias ButtonFn = @convention(c) (UInt32, UInt32, UInt32) -> UnsafeMutableRawPointer?
 typealias HIDArbitraryFn = @convention(c) (UInt32, UInt32, UInt32, UInt32) -> UnsafeMutableRawPointer?
+typealias KeyboardArbitraryFn = @convention(c) (UInt32, UInt32) -> UnsafeMutableRawPointer?
+typealias ModifierKeyBitFn = @convention(c) (UInt32, UInt32) -> UnsafeMutableRawPointer?
 typealias ServiceFn = @convention(c) () -> UnsafeMutableRawPointer?
 
 nonisolated(unsafe) var createDigitizerFn: CreateDigitizerFn?
@@ -670,6 +672,8 @@ nonisolated(unsafe) var appendEventFn: AppendEventFn?
 nonisolated(unsafe) var trackpadWrapFn: TrackpadWrapFn?
 nonisolated(unsafe) var buttonFn: ButtonFn?
 nonisolated(unsafe) var hidArbFn: HIDArbitraryFn?
+nonisolated(unsafe) var keyboardArbFn: KeyboardArbitraryFn?
+nonisolated(unsafe) var modifierBitFn: ModifierKeyBitFn?
 nonisolated(unsafe) var createPointerSvc: ServiceFn?
 nonisolated(unsafe) var createMouseSvc: ServiceFn?
 nonisolated(unsafe) var hidSymbolsResolved = false
@@ -702,6 +706,8 @@ func resolveHIDSymbols() -> Bool {
     trackpadWrapFn    = unsafeBitCast(pWrap, to: TrackpadWrapFn.self)
     buttonFn = dlsym(kit, "IndigoHIDMessageForButton").map { unsafeBitCast($0, to: ButtonFn.self) }
     hidArbFn = dlsym(kit, "IndigoHIDMessageForHIDArbitrary").map { unsafeBitCast($0, to: HIDArbitraryFn.self) }
+    keyboardArbFn = dlsym(kit, "IndigoHIDMessageForKeyboardArbitrary").map { unsafeBitCast($0, to: KeyboardArbitraryFn.self) }
+    modifierBitFn = dlsym(kit, "IndigoHIDMessageForModifierKeyBit").map { unsafeBitCast($0, to: ModifierKeyBitFn.self) }
     createPointerSvc = dlsym(kit, "IndigoHIDMessageToCreatePointerService").map { unsafeBitCast($0, to: ServiceFn.self) }
     createMouseSvc = dlsym(kit, "IndigoHIDMessageToCreateMouseService").map { unsafeBitCast($0, to: ServiceFn.self) }
     hidSymbolsResolved = true
@@ -919,8 +925,72 @@ func pressArbitraryHID(page: UInt32, usage: UInt32, holdUs: UInt32, client: AnyO
 
 // Text typing — decompose ASCII to HID keycodes
 
+/// NSEvent modifier-flag bit index for a HID modifier usage (page 7).
+/// IndigoHIDMessageForModifierKeyBit accepts bits 16-20:
+/// 16 = caps lock, 17 = shift, 18 = control, 19 = option, 20 = command.
+func modifierBit(forUsage usage: UInt32) -> UInt32? {
+    switch usage {
+    case 0xE1, 0xE5: return 17 // left/right shift
+    case 0xE0, 0xE4: return 18 // left/right control
+    case 0xE2, 0xE6: return 19 // left/right option
+    case 0xE3, 0xE7: return 20 // left/right command
+    case 0x39:       return 16 // caps lock
+    default:         return nil
+    }
+}
+
 func doTypeText(udid: String, text: String) -> Bool {
     guard let client = ensureHIDClient(udid: udid) else { return false }
+
+    // Preferred path: dedicated keyboard messages (same class Simulator.app's own
+    // keyboard passthrough emits). The generic HIDArbitrary path drops modifier
+    // state on freshly-booted or heavily-loaded simulators — keys land unshifted.
+    if keyboardArbFn != nil && modifierBitFn != nil {
+        return typeTextViaKeyboardMessages(text: text, client: client)
+    }
+    return typeTextViaArbitraryHID(text: text, client: client)
+}
+
+func typeTextViaKeyboardMessages(text: String, client: AnyObject) -> Bool {
+    guard let keyFn = keyboardArbFn, let modFn = modifierBitFn else { return false }
+
+    for c in text {
+        guard let (keyUsage, modifiers) = decomposeCharacter(c) else {
+            logErr("[hid] unsupported character: \(c)")
+            continue
+        }
+        let modifierBits = modifiers.compactMap { modifierBit(forUsage: $0) }
+
+        // Modifier-down (stateful modifier bit, survives event batching)
+        for bit in modifierBits {
+            guard let down = modFn(bit, 1) else { continue }
+            sendHIDMessage(down, to: client)
+        }
+        if !modifierBits.isEmpty {
+            usleep(10_000)
+        }
+
+        // Key down
+        guard let keyDown = keyFn(keyUsage, 1) else { continue }
+        sendHIDMessage(keyDown, to: client)
+        usleep(20_000)
+
+        // Key up
+        guard let keyUp = keyFn(keyUsage, 2) else { continue }
+        sendHIDMessage(keyUp, to: client)
+
+        // Modifier-up (reverse order)
+        for bit in modifierBits.reversed() {
+            guard let up = modFn(bit, 0) else { continue }
+            sendHIDMessage(up, to: client)
+        }
+
+        usleep(30_000) // 30ms between characters
+    }
+    return true
+}
+
+func typeTextViaArbitraryHID(text: String, client: AnyObject) -> Bool {
     guard let kfn = hidArbFn else {
         logErr("[hid] IndigoHIDMessageForHIDArbitrary unresolved")
         return false

--- a/tools/sim-bridge.swift
+++ b/tools/sim-bridge.swift
@@ -996,6 +996,36 @@ func pressArbitraryHID(page: UInt32, usage: UInt32, holdUs: UInt32, client: AnyO
     return true
 }
 
+// Hardware keyboard toggle
+
+/// Attach or detach the simulated hardware keyboard. Same CoreSimulator call
+/// Simulator.app's "Connect Hardware Keyboard" (shift-cmd-K) toggle uses.
+/// With the hardware keyboard enabled the software keyboard stays hidden;
+/// disabling it restores the software keyboard for focused text fields.
+func setHardwareKeyboard(udid: String, enabled: Bool) -> Bool {
+    guard let device = resolveDevice(udid: udid) else {
+        logErr("[kb] device not found: \(udid)")
+        return false
+    }
+    let sel = NSSelectorFromString("setHardwareKeyboardEnabled:keyboardType:error:")
+    guard device.responds(to: sel),
+          let cls = object_getClass(device),
+          let imp = class_getMethodImplementation(cls, sel) else {
+        logErr("[kb] SimDevice does not respond to setHardwareKeyboardEnabled:keyboardType:error:")
+        return false
+    }
+    typealias Fn = @convention(c) (
+        AnyObject, Selector, ObjCBool, UInt32,
+        AutoreleasingUnsafeMutablePointer<NSError?>
+    ) -> ObjCBool
+    var err: NSError?
+    let ok = unsafeBitCast(imp, to: Fn.self)(device, sel, ObjCBool(enabled), 0, &err)
+    if ok.boolValue == false, let err {
+        logErr("[kb] setHardwareKeyboardEnabled failed: \(err)")
+    }
+    return ok.boolValue
+}
+
 // Text typing — decompose ASCII to HID keycodes
 
 /// NSEvent modifier-flag bit index for a HID modifier usage (page 7).
@@ -1364,6 +1394,18 @@ func handleCommand(_ dict: [String: Any]) {
             respond(["ok": true])
         } else {
             respond(["ok": false, "error": "button '\(name)' failed"])
+        }
+
+    case "set-hardware-keyboard":
+        guard let udid = dict["udid"] as? String,
+              let enabled = dict["enabled"] as? Bool else {
+            respond(["ok": false, "error": "missing 'udid' or 'enabled'"])
+            return
+        }
+        if setHardwareKeyboard(udid: udid, enabled: enabled) {
+            respond(["ok": true, "enabled": enabled])
+        } else {
+            respond(["ok": false, "error": "set-hardware-keyboard failed"])
         }
 
     case "screenshot":

--- a/tools/sim-bridge.swift
+++ b/tools/sim-bridge.swift
@@ -717,8 +717,81 @@ func resolveHIDSymbols() -> Bool {
 // Per-device HID client cache
 nonisolated(unsafe) var hidClients: [String: AnyObject] = [:]
 
+final class HIDSendResult {
+    let semaphore = DispatchSemaphore(value: 0)
+    var error: NSError?
+}
+
+/// Send a message and wait for delivery confirmation. Returns false when the
+/// client's connection is dead (e.g. the device rebooted after the client was
+/// created) or no completion arrives in time.
+func sendHIDMessageChecked(_ message: UnsafeMutableRawPointer,
+                           to client: AnyObject,
+                           timeout: TimeInterval = 1.0) -> Bool {
+    let sel = NSSelectorFromString("sendWithMessage:freeWhenDone:completionQueue:completion:")
+    guard let cls = object_getClass(client),
+          let imp = class_getMethodImplementation(cls, sel) else { return false }
+
+    let result = HIDSendResult()
+    let completion: @convention(block) (NSError?) -> Void = { error in
+        result.error = error
+        result.semaphore.signal()
+    }
+    typealias Fn = @convention(c) (
+        AnyObject, Selector, UnsafeMutableRawPointer, ObjCBool,
+        AnyObject?, (@convention(block) (NSError?) -> Void)?
+    ) -> Void
+    unsafeBitCast(imp, to: Fn.self)(
+        client, sel, message, ObjCBool(true),
+        DispatchQueue.global(qos: .userInitiated), completion
+    )
+    if result.semaphore.wait(timeout: .now() + timeout) == .timedOut {
+        logErr("[hid] checked send timed out")
+        return false
+    }
+    if let error = result.error {
+        logErr("[hid] checked send failed: \(error)")
+        return false
+    }
+    return true
+}
+
+/// Verify a cached client still reaches the device's current boot.
+/// Re-sending a create-pointer-service message is harmless (it is already
+/// sent at client init) and round-trips through the device connection.
+func isHIDClientAlive(_ client: AnyObject) -> Bool {
+    guard let create = createPointerSvc, let probe = create() else {
+        return true // cannot probe — keep legacy behavior
+    }
+    return sendHIDMessageChecked(probe, to: client)
+}
+
+/// Prime the keyboard event path. backboardd creates the keyboard service
+/// lazily on the first KEY event; modifier-bit messages sent before that are
+/// silently discarded (observed as the first shifted character of a fresh
+/// client losing its shift). A bare shift keypress creates the service
+/// without producing any text. Called from the typing path only — keyboard
+/// events flip the simulator into hardware-keyboard mode (hiding the soft
+/// keyboard and surfacing the AutoFill bar), so taps must stay free of them.
+func primeKeyboardService(_ client: AnyObject) {
+    guard let keyFn = keyboardArbFn else { return }
+    if let down = keyFn(0xE1, 1) {
+        _ = sendHIDMessageChecked(down, to: client, timeout: 0.5)
+    }
+    if let up = keyFn(0xE1, 2) {
+        _ = sendHIDMessageChecked(up, to: client, timeout: 0.5)
+    }
+    usleep(20_000)
+}
+
 func ensureHIDClient(udid: String) -> AnyObject? {
-    if let existing = hidClients[udid] { return existing }
+    if let existing = hidClients[udid] {
+        if isHIDClientAlive(existing) {
+            return existing
+        }
+        logErr("[hid] cached client for \(udid) is stale (device rebooted?) — recreating")
+        hidClients.removeValue(forKey: udid)
+    }
     guard resolveHIDSymbols() else {
         logErr("[hid] symbol resolution failed")
         return nil
@@ -953,6 +1026,8 @@ func doTypeText(udid: String, text: String) -> Bool {
 
 func typeTextViaKeyboardMessages(text: String, client: AnyObject) -> Bool {
     guard let keyFn = keyboardArbFn, let modFn = modifierBitFn else { return false }
+
+    primeKeyboardService(client)
 
     for c in text {
         guard let (keyUsage, modifiers) = decomposeCharacter(c) else {


### PR DESCRIPTION
## Summary

Fixes the "shift-drop" bug where `type_text` on simulators silently dropped uppercase / shifted characters — e.g. mixed-case usernames typed as lowercase, exclamation marks typed as `1`. Reproduces on fresh-boot iOS 17.5 deterministically, intermittently on iOS 26.5 under parallel-fleet load.

**Root cause (9edc182):** `backboardd` only honors modifier state from synthetic keyboard events while CoreSimulator's `hardwareKeyboardEnabled` is `true`. On a freshly booted simulator that flag defaults to `false`, so every shifted character loses its modifier — regardless of HID message class, delays, or priming. A/B testing with the probe app confirmed it: same field, same server, seconds apart — keyboard detached → mangled, keyboard attached → clean. Simulator.app and the old `osascript Cmd+V` workaround were both attaching the hardware keyboard as a side effect of focus, which is why GUI-touched simulators typed correctly and untouched ones mangled. `doTypeText` now attaches the hardware keyboard before sending key events.

## Stack (6 commits)

| Commit | What |
|--------|------|
| `21b5c11` | Switch typing from generic `IndigoHIDMessageForHIDArbitrary` to the dedicated `IndigoHIDMessageForKeyboardArbitrary` / `IndigoHIDMessageForModifierKeyBit` constructors — same path Simulator.app uses. Generic-HID retained as fallback. |
| `03cd105` | Detect stale `SimDeviceLegacyHIDClient`s (cached across device reboots, silently dead) via a probe + `sendHIDMessageChecked`. Also prime the keyboard service once per type to dodge the "first-shifted-character-loses-shift" failure. |
| `ced96ad` | New `set_hardware_keyboard` tool/endpoint exposing `-[SimDevice setHardwareKeyboardEnabled:keyboardType:error:]`. Needed because typing now attaches the HW keyboard as a side effect; this lets callers restore the software keyboard. |
| `aefa562` | Doc the new endpoint in the `quern-api` skill. |
| `9edc182` | **The actual fix:** attach the hardware keyboard before typing. Earlier commits are supporting hardening. |
| `49ff426` | Bundled robustness fixes for `SimBridgeManager` surfaced during the investigation: oversized stdout lines killing the reader (120 KB UI trees), reader death leaking subprocesses (nine zombie sim-bridge processes observed), and stderr pipe filling and blocking the helper. |

## Side effect

Attaching the hardware keyboard hides the software keyboard. This is documented on the `type_text` MCP tool with a pointer to `set_hardware_keyboard enabled=false` to restore it if a subsequent step asserts software-keyboard visibility.

## Test plan

- [x] Fresh-boot repro on iOS 17.5: type a mixed-case + symbol string within seconds of boot — was mangled, now clean
- [x] iOS 18.6 and 26.5 fresh-boot — clean before and after (no regression)
- [x] Adversarial verification: explicitly detach hardware keyboard, then type — text lands with full shift fidelity
- [x] Long-running session with mid-session device reboot — stale-client detection recreates the HID client, typing recovers
- [x] First-shifted-character of a fresh client: was lowercased, now uppercase as typed
- [x] Dense UI tree (436 elements, ~120 KB): \`GET /device/ui\` returns 200, five consecutive describes succeed, single sim-bridge process, no reader errors
- [x] \`set_hardware_keyboard\` end-to-end: software keyboard hides on enable, returns on disable, focus preserved across both toggles

---

Diffstat vs main: 8 files, +305/−2 (\`tools/sim-bridge.swift\` +197 lines is the bulk).