### PR TITLE
chore: sync mcp/package-lock.json to 0.13.2

### DIFF
--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quern-debug-mcp",
-  "version": "0.13.0",
+  "version": "0.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quern-debug-mcp",
-      "version": "0.13.0",
+      "version": "0.13.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
## Summary

The 0.13.2 version bump in bc1a1a6 updated `mcp/package.json` but missed `mcp/package-lock.json`, leaving the two drifted. This brings the lockfile's `version`/`packages.""` fields up to `0.13.2` — diff is exactly two lines.

## Test plan

- [x] Diff is 2 lines, both version-field bumps; no dependency hash changes