### PR TITLE
fix(mcp): CJS launcher with Node version gate

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -5,7 +5,7 @@ MCP (Model Context Protocol) server that wraps the Quern HTTP API, letting AI ag
 ## Prerequisites
 
 - The Python Quern must be running (`quern start`)
-- Node.js 18+
+- Node.js 22+
 
 ## Usage
 
@@ -43,8 +43,10 @@ Add to your MCP settings:
 cd mcp
 npm install
 npm run build
-node dist/index.js
+node dist/launcher.cjs
 ```
+
+The launcher is a tiny CommonJS file that checks the Node version and prints a clear error if it's too old, then dynamically imports the ESM entry. Both `dist/launcher.cjs` and `dist/index.js` are executable; the launcher is the recommended entry because it survives being invoked by an old Node binary (e.g. Claude Desktop sometimes picks the lowest-versioned `node` from `~/.nvm`).
 
 ## Configuration
 

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -3,12 +3,12 @@
   "version": "0.13.3",
   "description": "MCP server for Quern — thin wrapper over HTTP API",
   "type": "module",
-  "main": "dist/index.js",
+  "main": "dist/launcher.cjs",
   "bin": {
-    "quern-debug-mcp": "dist/index.js"
+    "quern-debug-mcp": "dist/launcher.cjs"
   },
   "scripts": {
-    "build": "tsc && chmod 755 dist/index.js",
+    "build": "tsc && cp src/launcher.cjs dist/launcher.cjs && chmod 755 dist/launcher.cjs dist/index.js",
     "dev": "tsc --watch"
   },
   "files": [

--- a/mcp/src/launcher.cjs
+++ b/mcp/src/launcher.cjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+"use strict";
+
+// CommonJS launcher: this file must parse on ancient Node so we can
+// surface a clear "Node too old" message when the MCP client launches
+// us with the wrong binary (e.g. Claude Desktop picking nvm's lowest
+// node off PATH). The ESM entry (dist/index.js) is loaded only after
+// the version gate passes.
+
+var REQUIRED_MAJOR = 22;
+var major = parseInt(process.versions.node.split(".")[0], 10);
+
+if (isNaN(major) || major < REQUIRED_MAJOR) {
+  process.stderr.write(
+    "quern-debug-mcp: requires Node >= " + REQUIRED_MAJOR +
+    ", but is running on Node " + process.versions.node + "\n" +
+    "  Binary: " + process.execPath + "\n" +
+    "  Fix: in your MCP client config, set 'command' to an absolute path\n" +
+    "       to a Node " + REQUIRED_MAJOR + "+ binary, e.g.\n" +
+    "       /Users/you/.nvm/versions/node/v" + REQUIRED_MAJOR + ".x.x/bin/node\n"
+  );
+  process.exit(1);
+}
+
+var path = require("path");
+var url = require("url");
+var entryUrl = url.pathToFileURL(path.resolve(__dirname, "index.js")).href;
+
+// Dynamic import() is a syntax error on Node < 12.17, so we hide it
+// behind new Function — the body is parsed at Function() invocation
+// time, after our version gate has already exited on those Nodes.
+new Function("u", "return import(u)")(entryUrl).catch(function (err) {
+  process.stderr.write(
+    "quern-debug-mcp: failed to load server: " +
+    ((err && err.stack) || err) + "\n"
+  );
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #34.

## Summary

When the MCP server is launched by an old Node (e.g. Claude Desktop picking the lowest-versioned `node` off the nvm-enumerated PATH), parsing fails at the first ESM `import` with a cryptic `SyntaxError: Unexpected token {` — no Node-version context, no fix path. Adds a tiny CommonJS launcher that gates on Node version *before* the ESM entry is loaded and prints a clear, actionable error if the version is too old.

## Demo

Before:
```
/Users/.../mcp/dist/index.js:8
import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
       ^
SyntaxError: Unexpected token {
```

After:
```
quern-debug-mcp: requires Node >= 22, but is running on Node 10.15.3
  Binary: /Users/jerimiah/.nvm/versions/node/v10.15.3/bin/node
  Fix: in your MCP client config, set 'command' to an absolute path
       to a Node 22+ binary, e.g.
       /Users/you/.nvm/versions/node/v22.x.x/bin/node
```

## Two implementation subtleties

1. **The launcher must parse on ancient Node.** Written in CommonJS (`var` / `require` / string concat — no `const`/`let`/templates). `const`/`let` would be safe on Node 6+, but `var` is bulletproof.

2. **`import()` syntax is itself a parse error on Node < 12.17.** So the dynamic import is wrapped in `new Function("u", "return import(u)")(entryUrl)` — the body of a `new Function` is parsed when `Function()` is *invoked*, not at module load. By the time we reach it on an ancient Node, the version gate has already `process.exit(1)`'d us.

Without trick #2, the launcher would have the same problem as the original: an unparseable file is unparseable, regardless of how cleverly the code "would have" gated.

## Changes

- `mcp/src/launcher.cjs` — new. ~30 lines of bulletproof CJS.
- `mcp/package.json` — `main` and `bin` now point at `dist/launcher.cjs`. `build` script gets a `cp src/launcher.cjs dist/launcher.cjs` step (tsc won't process `.cjs`). Both `dist/launcher.cjs` and `dist/index.js` stay executable; the launcher is the documented entry.
- `mcp/README.md` — stale `Node.js 18+` prereq bumped to match `engines: ">=22"`. From Source example uses `node dist/launcher.cjs`.

## Test plan

Verified locally with three Node versions on the user's nvm:

- [x] **Node 10.15.3** (pre-ESM, pre-dynamic-import) — launcher parses, gate prints clear error, `exit 1`
- [x] **Node 20.19.5** (modern Node, still below `>=22` threshold) — gate prints clear error, `exit 1`
- [x] **Node 22.22.2** — gate passes, `new Function`-wrapped dynamic import succeeds, MCP server starts on stdio (verified by clean stderr and the process hanging on stdin waiting for JSON-RPC)