### PR TITLE
fix(proxy): enumerate all interfaces in proxy_status / setup_guide

### DIFF
--- a/server/api/proxy.py
+++ b/server/api/proxy.py
@@ -11,7 +11,12 @@ from datetime import UTC, datetime, timedelta
 from fastapi import APIRouter, HTTPException, Query, Request
 from sse_starlette.sse import EventSourceResponse
 
-from server.lifecycle.state import detect_current_ssid, detect_host_ip_for_subnet, update_state
+from server.lifecycle.state import (
+    detect_current_ssid,
+    detect_host_ip_for_subnet,
+    enumerate_local_interfaces,
+    update_state,
+)
 from server.models import (
     CaptureStartRequest,
     CaptureStartResponse,
@@ -23,6 +28,7 @@ from server.models import (
     FlowQueryResponse,
     FlowRecord,
     FlowSummaryResponse,
+    InterfaceInfo,
     ProxyStatusResponse,
     SystemProxyInfo,
     SystemProxyRestoreInfo,
@@ -87,6 +93,14 @@ async def _get_proxy_status(
     cert_setup = None
     system_proxy_info: SystemProxyInfo | None = None
     local_ip = _detect_local_ip()
+    local_ips = [InterfaceInfo(**entry) for entry in enumerate_local_interfaces()]
+    warnings: list[str] = []
+    # Flag multi-interface ambiguity: more than one distinct /24 means
+    # `local_ip` alone can't tell a caller which IP to point a physical
+    # device at. The full list in `local_ips` is the right answer.
+    distinct_subnets = {iface.subnet for iface in local_ips if iface.subnet}
+    if len(distinct_subnets) >= 2:
+        warnings.append("multi_interface_active")
     try:
         from server.proxy.cert_state import read_cert_state, strip_noncanonical_fields
         device_certs = read_cert_state()
@@ -177,6 +191,8 @@ async def _get_proxy_status(
             status="stopped",
             local_capture=local_capture,
             local_ip=local_ip,
+            local_ips=local_ips,
+            warnings=warnings,
             cert_setup=cert_setup,
             system_proxy=system_proxy_info,
             network_state=network_state_dict,
@@ -195,6 +211,8 @@ async def _get_proxy_status(
             bypass_patterns=adapter.get_bypass_patterns(),
             local_capture=local_capture,
             local_ip=local_ip,
+            local_ips=local_ips,
+            warnings=warnings,
             cert_setup=cert_setup,
             system_proxy=system_proxy_info,
             network_state=network_state_dict,
@@ -213,6 +231,8 @@ async def _get_proxy_status(
             bypass_patterns=adapter.get_bypass_patterns(),
             local_capture=local_capture,
             local_ip=local_ip,
+            local_ips=local_ips,
+            warnings=warnings,
             cert_setup=cert_setup,
             system_proxy=system_proxy_info,
             network_state=network_state_dict,
@@ -225,6 +245,8 @@ async def _get_proxy_status(
         flows_captured=flow_store.size if flow_store else 0,
         local_capture=local_capture,
         local_ip=local_ip,
+        local_ips=local_ips,
+        warnings=warnings,
         cert_setup=cert_setup,
         system_proxy=system_proxy_info,
         network_state=network_state_dict,

--- a/server/api/proxy_certs.py
+++ b/server/api/proxy_certs.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import socket
 import subprocess
 from datetime import UTC, datetime
 from pathlib import Path
@@ -525,23 +524,32 @@ async def record_device_proxy_config_endpoint(
 @router.get("/setup-guide")
 async def setup_guide(request: Request) -> dict:
     """Get device proxy setup instructions with auto-detected local IP and network interface."""
+    from server.lifecycle.state import enumerate_local_interfaces
+
     adapter = request.app.state.proxy_adapter
     port = adapter.listen_port if adapter else 9101
 
-    # Auto-detect local IP
-    try:
-        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        s.connect(("8.8.8.8", 80))
-        local_ip = s.getsockname()[0]
-        s.close()
-    except Exception:
-        local_ip = "127.0.0.1"
+    # Enumerate all active interfaces so we can advertise every Mac IP a
+    # device might need to reach (Wi-Fi + Ethernet on different subnets is
+    # common). The default-route entry is what `local_ip` reflects.
+    interfaces = enumerate_local_interfaces()
+    default_iface = next((i for i in interfaces if i["is_default_route"]), None)
+    local_ip = default_iface["ip"] if default_iface else (
+        interfaces[0]["ip"] if interfaces else "127.0.0.1"
+    )
 
     # Auto-detect active network interface name (macOS networksetup name)
     active_interface = _detect_active_interface()
 
     # Detect VPN and other potential issues
     warnings = _detect_proxy_warnings()
+
+    # Flag multi-interface ambiguity so callers know not to trust a single
+    # IP. Mirrors the warning in proxy_status.
+    distinct_subnets = {i["subnet"] for i in interfaces if i["subnet"]}
+    multi_interface = len(distinct_subnets) >= 2
+    if multi_interface:
+        warnings.append("multi_interface_active")
 
     # Get cert status for booted devices from persistent state
     cert_status_by_device = {}
@@ -585,9 +593,27 @@ async def setup_guide(request: Request) -> dict:
             "route -n get default | grep interface, then "
             "networksetup -listallhardwareports | grep -B1 <device>"
         )
+    if multi_interface:
+        iface_summary = ", ".join(
+            f"{i['interface']}={i['ip']}"
+            + (f" (Wi-Fi: {i['ssid']})" if i.get('ssid') else "")
+            + (" [default route]" if i['is_default_route'] else "")
+            for i in interfaces
+        )
+        multi_iface_note = (
+            "1. Multiple network interfaces are active on different subnets — "
+            f"{iface_summary}. The proxy server listens on 0.0.0.0:" + str(port)
+            + " so it's reachable on any of them, but a physical device must "
+            "use the Mac IP on its OWN subnet. See the physical-device steps "
+            "for guidance; for system-proxy mode on the Mac itself, pick the "
+            "interface you actually want to capture from."
+        )
+    else:
+        multi_iface_note = (
+            "1. (Only one interface is active — no ambiguity here.)"
+        )
     simulator_steps.extend([
-        "1. If you have multiple network interfaces active (e.g. Wi-Fi + Ethernet), "
-        "disable the one you're NOT using to avoid routing ambiguity.",
+        multi_iface_note,
         f"2. Set proxy on the Mac's active network interface (NOT in simulator settings): "
         f"{set_proxy_cmd}",
         "3. Install the CA certificate into the simulator keychain: "
@@ -611,10 +637,32 @@ async def setup_guide(request: Request) -> dict:
     api_port = request.app.state.config.port
     cert_url = f"http://{local_ip}:{api_port}/api/v1/proxy/cert"
 
+    # Physical-device step 5: when multiple interfaces are active, the
+    # user has to pick the Mac IP on the same subnet as the device. Spell
+    # the options out instead of advertising a single (possibly wrong) IP.
+    if multi_interface:
+        iface_lines = []
+        for i in interfaces:
+            label = i["interface"]
+            if i.get("ssid"):
+                label += f" (Wi-Fi: {i['ssid']})"
+            if i["is_default_route"]:
+                label += " [default route]"
+            iface_lines.append(f"     - {i['ip']} on {label}")
+        step_5 = (
+            f"5. Set Server to the Mac IP on the same subnet as this device "
+            f"(check Settings > Wi-Fi > (network) > IP Address on the device). "
+            f"Port: {port}.\n   Active Mac interfaces:\n"
+            + "\n".join(iface_lines)
+        )
+    else:
+        step_5 = f"5. Set Server: {local_ip}, Port: {port}"
+
     return {
         "proxy_host": local_ip,
         "proxy_port": port,
         "active_interface": active_interface,
+        "interfaces": interfaces,
         "warnings": warnings,
         "cert_install_url": cert_url,
         "cert_status": cert_status_by_device,
@@ -635,7 +683,7 @@ async def setup_guide(request: Request) -> dict:
                     "3. Trust the certificate — Settings > General > About > "
                     "Certificate Trust Settings",
                     "4. Go to Settings > Wi-Fi > (your network) > Configure Proxy > Manual",
-                    f"5. Set Server: {local_ip}, Port: {port}",
+                    step_5,
                 ],
             },
         ],

--- a/server/lifecycle/state.py
+++ b/server/lifecycle/state.py
@@ -220,6 +220,101 @@ def detect_host_ip_for_subnet(device_ip: str) -> str | None:
     return None
 
 
+def enumerate_local_interfaces() -> list[dict]:
+    """Enumerate active Mac network interfaces with IPv4 addresses, the
+    default-route flag, and the Wi-Fi SSID when applicable.
+
+    Each entry: ``{"interface", "ip", "subnet", "is_default_route", "ssid"}``.
+    Loopback (127.0.0.0/8) is excluded. ``subnet`` is a /24 string; ``ssid``
+    is set only for Wi-Fi interfaces that are currently associated.
+
+    Used by ``proxy_status`` and ``proxy_setup_guide`` to disambiguate which
+    Mac IP to advertise when multiple interfaces are active on different
+    subnets — the single ``local_ip`` field (default-route only) is wrong
+    in that scenario for any device not on the default-route subnet.
+    """
+    import ipaddress
+    import subprocess
+
+    entries: list[dict] = []
+    try:
+        result = subprocess.run(["ifconfig"], capture_output=True, text=True, timeout=5)
+    except Exception:
+        return []
+
+    current_iface: str | None = None
+    for raw in result.stdout.splitlines():
+        # Interface header lines start at column 0 ("en0: flags=...");
+        # `inet` lines are indented. Track the most-recent header so we can
+        # attach each address to the right BSD device.
+        if raw and not raw[0].isspace():
+            if ":" in raw:
+                current_iface = raw.split(":", 1)[0]
+            continue
+        stripped = raw.strip()
+        if not current_iface or not stripped.startswith("inet ") or stripped.startswith("inet6"):
+            continue
+        parts = stripped.split()
+        if len(parts) < 2:
+            continue
+        ip = parts[1]
+        # Skip loopback (127.0.0.0/8) and link-local autoconfig
+        # (APIPA, 169.254.0.0/16). Link-local addresses appear on
+        # interfaces that never got a DHCP lease — they're not reachable
+        # from devices on any real subnet, so they'd only add noise to
+        # the multi-interface ambiguity check.
+        if ip.startswith("127.") or ip.startswith("169.254."):
+            continue
+        try:
+            subnet = str(ipaddress.ip_network(f"{ip}/24", strict=False))
+        except ValueError:
+            subnet = None
+        entries.append({
+            "interface": current_iface,
+            "ip": ip,
+            "subnet": subnet,
+            "is_default_route": False,
+            "ssid": None,
+        })
+
+    if not entries:
+        return entries
+
+    # Annotate default-route interface. Import locally to avoid a module
+    # cycle with server.proxy.system_proxy (which already imports state).
+    try:
+        from server.proxy.system_proxy import get_default_route_device
+        default_iface = get_default_route_device()
+    except Exception:
+        default_iface = None
+    if default_iface:
+        for entry in entries:
+            if entry["interface"] == default_iface:
+                entry["is_default_route"] = True
+
+    # Best-effort per-interface SSID lookup. networksetup -getairportnetwork
+    # errors out on non-Wi-Fi interfaces; we treat any non-match as None.
+    for entry in entries:
+        entry["ssid"] = _get_interface_ssid(entry["interface"])
+
+    return entries
+
+
+def _get_interface_ssid(interface: str) -> str | None:
+    """Return the SSID for a Wi-Fi interface, or None if not Wi-Fi or not connected."""
+    import subprocess
+    try:
+        result = subprocess.run(
+            ["networksetup", "-getairportnetwork", interface],
+            capture_output=True, text=True, timeout=3,
+        )
+    except Exception:
+        return None
+    if "Current Wi-Fi Network:" in result.stdout:
+        return result.stdout.split("Current Wi-Fi Network:", 1)[1].strip()
+    return None
+
+
 def detect_current_ssid() -> str | None:
     """Return the current Wi-Fi SSID, or None if not connected / not detectable."""
     import subprocess

--- a/server/models.py
+++ b/server/models.py
@@ -450,6 +450,24 @@ class WaitForFlowResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+class InterfaceInfo(BaseModel):
+    """One active Mac network interface with its IPv4 address.
+
+    Returned in ``ProxyStatusResponse.local_ips`` to disambiguate which Mac
+    IP to advertise when the host has multiple interfaces on different
+    subnets (Wi-Fi + Ethernet to different networks). The default-route
+    interface — what ``local_ip`` reflects — is correct for outbound
+    traffic but not necessarily reachable from a physical device on the
+    *other* interface's subnet.
+    """
+
+    interface: str  # BSD device name (e.g. "en0", "en10")
+    ip: str  # IPv4 address
+    subnet: str | None = None  # /24 containing `ip`, e.g. "192.168.31.0/24"
+    is_default_route: bool = False  # OS default-route interface (matches `local_ip`)
+    ssid: str | None = None  # Wi-Fi SSID when the interface is associated, else None
+
+
 class ProxyStatusResponse(BaseModel):
     """Response from GET /api/v1/proxy/status."""
 
@@ -466,6 +484,19 @@ class ProxyStatusResponse(BaseModel):
     error: str | None = None
     local_capture: list[str] = Field(default_factory=list)
     local_ip: str | None = None
+    """OS default-route IP — one entry from ``local_ips``. Convenient when
+    there's only one interface; misleading in dual-interface setups. Prefer
+    ``local_ips`` and per-device subnet matching when configuring a
+    physical device's manual proxy."""
+    local_ips: list[InterfaceInfo] = Field(default_factory=list)
+    """Every active non-loopback IPv4 interface on the Mac. Pick the entry
+    whose ``subnet`` matches the device's LAN IP when configuring a
+    physical device's Wi-Fi proxy — the device must be on the same subnet
+    as the Mac IP it talks to."""
+    warnings: list[str] = Field(default_factory=list)
+    """Network-state warnings the agent should surface. Currently:
+    ``"multi_interface_active"`` — more than one interface is on a distinct
+    /24, so ``local_ip`` is not the right answer for every device."""
     system_proxy: SystemProxyInfo | None = None
     cert_setup: dict[str, DeviceCertState] | None = None  # Per-device cert status
     network_state: dict | None = None

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -702,6 +702,118 @@ async def test_proxy_setup_guide(app, auth_headers):
         assert "note" in phys
 
 
+@pytest.mark.asyncio
+async def test_proxy_status_surfaces_multi_interface(app, auth_headers, monkeypatch):
+    """proxy_status should enumerate all interfaces and flag ambiguity."""
+    monkeypatch.setattr(
+        "server.api.proxy.enumerate_local_interfaces",
+        lambda: [
+            {
+                "interface": "en0",
+                "ip": "192.168.31.243",
+                "subnet": "192.168.31.0/24",
+                "is_default_route": False,
+                "ssid": "Lilypad",
+            },
+            {
+                "interface": "en10",
+                "ip": "192.168.200.98",
+                "subnet": "192.168.200.0/24",
+                "is_default_route": True,
+                "ssid": None,
+            },
+        ],
+    )
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/v1/proxy/status", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+
+    ips = {entry["ip"] for entry in data["local_ips"]}
+    assert ips == {"192.168.31.243", "192.168.200.98"}
+    default = [e for e in data["local_ips"] if e["is_default_route"]]
+    assert len(default) == 1 and default[0]["interface"] == "en10"
+    assert "multi_interface_active" in data["warnings"]
+
+
+@pytest.mark.asyncio
+async def test_proxy_status_no_warning_for_single_interface(
+    app, auth_headers, monkeypatch,
+):
+    """Single-interface setups should not see the multi-interface warning."""
+    monkeypatch.setattr(
+        "server.api.proxy.enumerate_local_interfaces",
+        lambda: [
+            {
+                "interface": "en0",
+                "ip": "192.168.1.10",
+                "subnet": "192.168.1.0/24",
+                "is_default_route": True,
+                "ssid": "home",
+            },
+        ],
+    )
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/v1/proxy/status", headers=auth_headers)
+        data = resp.json()
+
+    assert len(data["local_ips"]) == 1
+    assert "multi_interface_active" not in data["warnings"]
+
+
+@pytest.mark.asyncio
+async def test_proxy_setup_guide_lists_all_interfaces_when_ambiguous(
+    app, auth_headers, monkeypatch,
+):
+    """setup_guide's physical-device step 5 should enumerate every interface
+    when more than one is active, rather than picking a single (possibly
+    wrong) IP."""
+    from server.sources.proxy import ProxyAdapter
+
+    adapter = ProxyAdapter(flow_store=FlowStore())
+    app.state.proxy_adapter = adapter
+
+    monkeypatch.setattr(
+        "server.lifecycle.state.enumerate_local_interfaces",
+        lambda: [
+            {
+                "interface": "en0",
+                "ip": "192.168.31.243",
+                "subnet": "192.168.31.0/24",
+                "is_default_route": False,
+                "ssid": "Lilypad",
+            },
+            {
+                "interface": "en10",
+                "ip": "192.168.200.98",
+                "subnet": "192.168.200.0/24",
+                "is_default_route": True,
+                "ssid": None,
+            },
+        ],
+    )
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/v1/proxy/setup-guide", headers=auth_headers)
+        data = resp.json()
+
+    assert "multi_interface_active" in data["warnings"]
+    assert {iface["ip"] for iface in data["interfaces"]} == {
+        "192.168.31.243",
+        "192.168.200.98",
+    }
+
+    phys_step_5 = data["steps"][1]["instructions"][4]
+    # Both Mac IPs should appear in the physical-device guidance.
+    assert "192.168.31.243" in phys_step_5
+    assert "192.168.200.98" in phys_step_5
+
+
 # ---------------------------------------------------------------------------
 # Dual ring buffer (server_buffer) routing
 # ---------------------------------------------------------------------------

--- a/tests/test_lifecycle_state.py
+++ b/tests/test_lifecycle_state.py
@@ -198,3 +198,139 @@ def test_write_creates_config_dir(tmp_path):
 
     assert nested.exists()
     assert state_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# Multi-interface enumeration (proxy_status / setup_guide disambiguation)
+# ---------------------------------------------------------------------------
+
+
+_IFCONFIG_DUAL_INTERFACE = """\
+lo0: flags=8049<UP,LOOPBACK> mtu 16384
+\tinet 127.0.0.1 netmask 0xff000000
+en0: flags=8863<UP,BROADCAST,SMART,RUNNING> mtu 1500
+\tinet 192.168.31.243 netmask 0xffffff00 broadcast 192.168.31.255
+en10: flags=8863<UP,BROADCAST,SMART,RUNNING> mtu 1500
+\tinet 192.168.200.98 netmask 0xfffffe00 broadcast 192.168.201.255
+en14: flags=8863<UP,BROADCAST,SMART,RUNNING> mtu 1500
+\tinet 169.254.128.252 netmask 0xffff0000 broadcast 169.254.255.255
+utun0: flags=8051<UP,POINTOPOINT,RUNNING> mtu 1500
+"""
+
+
+def _mock_subprocess_run(ifconfig_stdout, ssid_responses=None):
+    """Return a subprocess.run double that maps ifconfig and networksetup."""
+    ssid_responses = ssid_responses or {}
+
+    def fake_run(cmd, *args, **kwargs):
+        result = MagicMock()
+        result.returncode = 0
+        if cmd[0] == "ifconfig":
+            result.stdout = ifconfig_stdout
+        elif cmd[0] == "networksetup" and cmd[1] == "-getairportnetwork":
+            iface = cmd[2]
+            ssid = ssid_responses.get(iface)
+            result.stdout = (
+                f"Current Wi-Fi Network: {ssid}\n" if ssid
+                else "You are not associated with an AirPort network.\n"
+            )
+        else:
+            result.stdout = ""
+        return result
+    return fake_run
+
+
+def test_enumerate_local_interfaces_parses_ifconfig_and_excludes_loopback():
+    from server.lifecycle import state as state_mod
+
+    with (
+        patch.object(
+            state_mod.subprocess if hasattr(state_mod, "subprocess") else __import__("subprocess"),
+            "run",
+            side_effect=_mock_subprocess_run(_IFCONFIG_DUAL_INTERFACE),
+        ),
+        patch(
+            "server.proxy.system_proxy.get_default_route_device",
+            return_value="en10",
+        ),
+    ):
+        entries = state_mod.enumerate_local_interfaces()
+
+    # Loopback (127.x) and link-local (169.254.x) are excluded; en0 and en10 remain.
+    ips = {e["ip"] for e in entries}
+    assert ips == {"192.168.31.243", "192.168.200.98"}
+
+
+def test_enumerate_local_interfaces_marks_default_route():
+    from server.lifecycle import state as state_mod
+
+    with (
+        patch(
+            "subprocess.run",
+            side_effect=_mock_subprocess_run(_IFCONFIG_DUAL_INTERFACE),
+        ),
+        patch(
+            "server.proxy.system_proxy.get_default_route_device",
+            return_value="en10",
+        ),
+    ):
+        entries = state_mod.enumerate_local_interfaces()
+
+    default = [e for e in entries if e["is_default_route"]]
+    assert len(default) == 1
+    assert default[0]["interface"] == "en10"
+    assert default[0]["ip"] == "192.168.200.98"
+
+
+def test_enumerate_local_interfaces_attaches_ssid_for_wifi():
+    from server.lifecycle import state as state_mod
+
+    with (
+        patch(
+            "subprocess.run",
+            side_effect=_mock_subprocess_run(
+                _IFCONFIG_DUAL_INTERFACE,
+                ssid_responses={"en0": "Lilypad"},
+            ),
+        ),
+        patch(
+            "server.proxy.system_proxy.get_default_route_device",
+            return_value="en10",
+        ),
+    ):
+        entries = state_mod.enumerate_local_interfaces()
+
+    by_iface = {e["interface"]: e for e in entries}
+    assert by_iface["en0"]["ssid"] == "Lilypad"
+    # en10 is Ethernet — no SSID
+    assert by_iface["en10"]["ssid"] is None
+
+
+def test_enumerate_local_interfaces_computes_subnet():
+    from server.lifecycle import state as state_mod
+
+    with (
+        patch(
+            "subprocess.run",
+            side_effect=_mock_subprocess_run(_IFCONFIG_DUAL_INTERFACE),
+        ),
+        patch(
+            "server.proxy.system_proxy.get_default_route_device",
+            return_value=None,
+        ),
+    ):
+        entries = state_mod.enumerate_local_interfaces()
+
+    by_ip = {e["ip"]: e for e in entries}
+    assert by_ip["192.168.31.243"]["subnet"] == "192.168.31.0/24"
+    assert by_ip["192.168.200.98"]["subnet"] == "192.168.200.0/24"
+
+
+def test_enumerate_local_interfaces_handles_ifconfig_failure():
+    """If ifconfig itself blows up, return an empty list rather than raising."""
+    from server.lifecycle import state as state_mod
+
+    with patch("subprocess.run", side_effect=OSError("no ifconfig")):
+        entries = state_mod.enumerate_local_interfaces()
+
+    assert entries == []


### PR DESCRIPTION
Closes #26.

## Summary

When the Mac has multiple active network interfaces on different subnets (Wi-Fi + Ethernet to different networks — the standard office dock setup), `proxy_status.local_ip` and `proxy_setup_guide` both quote a single IP from the OS default-route heuristic. That IP is often the *wrong* one to advertise to a physical device on the other interface's subnet — the proxy host is unreachable, the manual Wi-Fi proxy silently doesn't work, and the user spends time debugging routing.

This PR enumerates every active non-loopback IPv4 interface, exposes them as `proxy_status.local_ips`, and adds a `multi_interface_active` warning when there's actual ambiguity. `setup_guide` lists every Mac IP in the physical-device steps so the user can pick the one on the same subnet as the device.

The underlying `_get_all_interface_ips()` helper already existed — it's used by `detect_host_ip_for_subnet()`, which `record_device_proxy_config` already calls correctly. The fix just brings the *advisory* endpoints in line with what the *actioning* endpoint has been doing all along.

## Live example from the user's machine

`enumerate_local_interfaces()` on a dual-interface dock returns:

```json
[
  {"interface": "en0",  "ip": "192.168.31.35",   "subnet": "192.168.31.0/24",  "is_default_route": false, "ssid": null},
  {"interface": "en10", "ip": "192.168.200.143", "subnet": "192.168.200.0/24", "is_default_route": true,  "ssid": null}
]
```

`proxy_status` returns `warnings: ["multi_interface_active"]` for this setup. `setup_guide`'s physical-device step 5 now reads:

> 5. Set Server to the Mac IP on the same subnet as this device (check Settings > Wi-Fi > (network) > IP Address on the device). Port: 9101.
>    Active Mac interfaces:
>      - 192.168.31.35 on en0
>      - 192.168.200.143 on en10 [default route]

…instead of `5. Set Server: 192.168.200.143, Port: 9101` (which would be wrong for a device on Wi-Fi).

## Two small but worth-mentioning details

1. **Link-local autoconfig (`169.254.0.0/16`, APIPA) is filtered** alongside loopback. Without this, an Ethernet interface that never got a DHCP lease shows up as a third "active" subnet and trips the multi-interface warning spuriously.

2. **SSID lookup is best-effort.** macOS Sonoma+ tightened `networksetup -getairportnetwork` so it often returns *"You are not associated with an AirPort network"* even when Wi-Fi is on. The helper returns `None` gracefully. Subnet matching (which doesn't need an SSID) is the reliable disambiguation path either way.

## Out of scope (intentionally)

From the issue's solution list — these are deferred to follow-up PRs:

- **(3) Network monitor tracking all interfaces.** Would require refactoring `network_state`'s shape, which is a separate concern.
- **(5) `record_device_proxy_config` defaulting to subnet match.** Already works when `client_ip` is supplied; making it the *only* path is a flow change rather than a fix.

## Changes

| File | What |
|------|------|
| `server/lifecycle/state.py` | New `enumerate_local_interfaces()`. Parses `ifconfig`, attaches BSD device name + /24 + default-route flag + best-effort SSID. Filters loopback + APIPA. |
| `server/models.py` | New `InterfaceInfo` model. `ProxyStatusResponse` gains `local_ips` and `warnings`. |
| `server/api/proxy.py` | `_get_proxy_status` populates the new fields and computes the multi-interface warning. |
| `server/api/proxy_certs.py` | `setup_guide` uses the enumeration, exposes `interfaces` in the response, and adapts the simulator step 1 + physical-device step 5 wording when ambiguity is present. Drops the unused inline socket trick. |
| `tests/test_lifecycle_state.py` | 5 unit tests against canned `ifconfig` output (parsing, filtering, default-route, SSID, failure fallback). |
| `tests/test_integration.py` | 3 integration tests: multi-interface warning fires + interface list returned, single-interface case skips the warning, `setup_guide` step 5 lists every Mac IP when ambiguous. |

## Test plan

- [x] Local: `pytest tests/` → **1341 passed**
- [x] Live sanity-check on the user's dock setup: `enumerate_local_interfaces()` returns both interfaces with correct subnets and default-route flag
- [x] `ruff` clean (pre-commit hook)