### PR TITLE
fix: skip xcrun probes on Macs without Xcode

### DIFF
--- a/server/device/_xcode.py
+++ b/server/device/_xcode.py
@@ -1,0 +1,44 @@
+"""Xcode-availability preflight for iOS toolchain probes.
+
+Direct invocation of ``xcrun simctl`` / ``xcrun devicectl`` on a Mac with
+no Xcode and no Command Line Tools triggers the macOS *"install developer
+tools"* system dialog. The dialog is rendered by Apple's ``xcselect``
+library before ``xcrun`` exits, so wrapping the call in ``try/except``
+catches the eventual error but the user has already seen (and may be
+forced to dismiss) the dialog.
+
+This module provides a sync preflight using ``xcode-select -p``, which
+returns the active developer dir if anything is installed and exits
+non-zero otherwise — without ever triggering the install dialog. Backends
+and setup checks gate their ``xcrun`` calls on ``xcode_available()`` so
+Android-only machines never see the dialog.
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+import subprocess
+
+
+@functools.lru_cache(maxsize=1)
+def xcode_available() -> bool:
+    """Return True iff Xcode / CLT is installed and ``xcrun`` will work
+    without triggering the macOS install dialog.
+
+    Checks ``xcode-select -p`` (safe — never triggers the dialog) and the
+    ``DEVELOPER_DIR`` environment variable (which Quern's setup script
+    sets as a runtime fix-up when Xcode lives somewhere ``xcode-select``
+    isn't pointed at). Cached; call ``xcode_available.cache_clear()``
+    after mutating ``DEVELOPER_DIR`` or installing Xcode mid-session.
+    """
+    if os.environ.get("DEVELOPER_DIR"):
+        return True
+    try:
+        result = subprocess.run(
+            ["xcode-select", "-p"],
+            capture_output=True, text=True, timeout=2,
+        )
+    except Exception:
+        return False
+    return result.returncode == 0 and bool(result.stdout.strip())

--- a/server/device/devicectl.py
+++ b/server/device/devicectl.py
@@ -8,6 +8,7 @@ import logging
 import tempfile
 from pathlib import Path
 
+from server.device._xcode import xcode_available
 from server.models import AppInfo, DeviceError, DeviceInfo, DeviceState, DeviceType
 
 logger = logging.getLogger("quern-debug-server.devicectl")
@@ -65,7 +66,14 @@ class DevicectlBackend:
         return stdout_bytes.decode(), stderr_bytes.decode()
 
     async def is_available(self) -> bool:
-        """Check if xcrun devicectl is available."""
+        """Check if xcrun devicectl is available.
+
+        Preflights via xcode-select so a no-Xcode machine never triggers
+        the macOS "install developer tools" dialog (which fires before
+        xcrun returns, so try/except on the subprocess can't suppress it).
+        """
+        if not xcode_available():
+            return False
         try:
             proc = await asyncio.create_subprocess_exec(
                 "xcrun", "devicectl", "list", "devices", "--help",
@@ -78,7 +86,13 @@ class DevicectlBackend:
             return False
 
     async def list_devices(self) -> list[DeviceInfo]:
-        """List connected physical devices by parsing devicectl list devices output."""
+        """List connected physical devices by parsing devicectl list devices output.
+
+        Short-circuits when Xcode isn't installed so the macOS "install
+        developer tools" dialog doesn't fire. See server/device/_xcode.py.
+        """
+        if not xcode_available():
+            return []
         try:
             stdout, _ = await self._run_devicectl(
                 "list", "devices", json_output=True,

--- a/server/device/simctl.py
+++ b/server/device/simctl.py
@@ -11,6 +11,7 @@ import shutil
 import tempfile
 from pathlib import Path
 
+from server.device._xcode import xcode_available
 from server.models import AppInfo, DeviceError, DeviceInfo, DeviceState, DeviceType
 
 logger = logging.getLogger("quern-debug-server.simctl")
@@ -57,7 +58,14 @@ class SimctlBackend:
         return stdout.decode(), stderr.decode()
 
     async def is_available(self) -> bool:
-        """Check if xcrun simctl is available and working."""
+        """Check if xcrun simctl is available and working.
+
+        Preflights via xcode-select so a no-Xcode machine never triggers
+        the macOS "install developer tools" dialog (which fires before
+        xcrun returns, so try/except on the subprocess can't suppress it).
+        """
+        if not xcode_available():
+            return False
         try:
             proc = await asyncio.create_subprocess_exec(
                 "xcrun", "simctl", "help",
@@ -81,7 +89,13 @@ class SimctlBackend:
             return False
 
     async def list_devices(self) -> list[DeviceInfo]:
-        """List all simulators by parsing simctl list devices --json."""
+        """List all simulators by parsing simctl list devices --json.
+
+        Short-circuits when Xcode isn't installed so the macOS "install
+        developer tools" dialog doesn't fire. See server/device/_xcode.py.
+        """
+        if not xcode_available():
+            return []
         stdout, _ = await self._run_simctl("list", "devices", "--json")
         data = json.loads(stdout)
         devices: list[DeviceInfo] = []

--- a/server/lifecycle/setup.py
+++ b/server/lifecycle/setup.py
@@ -20,6 +20,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 
+from server.device._xcode import xcode_available
+
 # ── Result types ──────────────────────────────────────────────────────────
 
 class CheckStatus(Enum):
@@ -154,16 +156,26 @@ def _fix_developer_dir_for_setup() -> str | None:
 
     Sets the DEVELOPER_DIR env var for this process so subsequent xcrun
     calls work. Returns a message describing the fix, or None if not needed.
+
+    Skips the initial ``xcrun simctl help`` probe when no developer dir is
+    configured — that probe triggers the macOS install dialog on a clean
+    machine. We can still find an Xcode in ``/Applications`` and set
+    DEVELOPER_DIR ourselves; the dialog is only avoided in the no-dev-dir
+    case.
     """
     if os.environ.get("DEVELOPER_DIR"):
         return None
 
-    # Check if simctl already works
-    rc, _, _ = _run(["xcrun", "simctl", "help"])
-    if rc == 0:
-        return None
+    # Only probe simctl if a developer dir is configured. Without one,
+    # xcrun would trigger the macOS install dialog before returning.
+    if xcode_available():
+        rc, _, _ = _run(["xcrun", "simctl", "help"])
+        if rc == 0:
+            return None
 
-    # simctl broken — find a working Xcode
+    # No working simctl — find a usable Xcode in /Applications and point
+    # DEVELOPER_DIR at it. Once DEVELOPER_DIR is set, xcrun uses it
+    # directly and won't trigger the dialog even on a clean machine.
     rc, current_dir, _ = _run(["xcode-select", "-p"])
     current_dir = current_dir.strip() if rc == 0 else "(unknown)"
 
@@ -171,6 +183,7 @@ def _fix_developer_dir_for_setup() -> str | None:
         candidate = xcode_app / "Contents" / "Developer"
         if candidate.exists():
             os.environ["DEVELOPER_DIR"] = str(candidate)
+            xcode_available.cache_clear()
             rc, _, _ = _run(["xcrun", "simctl", "help"])
             if rc == 0:
                 return (
@@ -179,6 +192,7 @@ def _fix_developer_dir_for_setup() -> str | None:
                     f"To make this permanent: sudo xcode-select -s '{candidate}'"
                 )
             del os.environ["DEVELOPER_DIR"]
+            xcode_available.cache_clear()
 
     return None
 
@@ -959,6 +973,22 @@ def check_xcode_cli_tools() -> CheckResult:
             message="Not installed",
             detail="Install with: xcode-select --install",
         )
+    # /usr/bin/xcrun ships on every modern macOS as an install-prompt stub
+    # even when no CLT is present, so `which xcrun` returning a path isn't
+    # proof anything works. Gate on xcode-select reporting an actual
+    # developer dir before invoking xcrun — otherwise we'd trigger the
+    # macOS install dialog here on Android-only machines.
+    if not xcode_available():
+        return CheckResult(
+            name="Xcode CLI Tools",
+            status=CheckStatus.MISSING,
+            message="Not installed (no developer directory configured)",
+            detail=(
+                "Install Xcode or the Command Line Tools to enable iOS support. "
+                "If you only need Android, this is safe to ignore — Quern will "
+                "skip the iOS toolchain. Install with: xcode-select --install"
+            ),
+        )
     # Verify simctl works
     rc, stdout, _ = _run(["xcrun", "simctl", "help"])
     if rc == 0:
@@ -1342,6 +1372,10 @@ def configure_crash_reporter_dialog() -> CheckResult:
 
 def check_booted_simulators() -> list[dict[str, str]]:
     """Return a list of booted simulators [{name, udid}]."""
+    # Skip the simctl probe when there's no developer dir — would trigger
+    # the macOS install dialog otherwise.
+    if not xcode_available():
+        return []
     rc, stdout, _ = _run(["xcrun", "simctl", "list", "devices", "--json"])
     if rc != 0:
         return []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Global test fixtures — runs before any test module is imported."""
 
+import functools
 import os
 import tempfile
 from pathlib import Path
@@ -26,3 +27,25 @@ def _reset_active_device_sidecar():
     yield
     if sidecar.exists():
         sidecar.unlink()
+
+
+@pytest.fixture(autouse=True)
+def _default_xcode_available(monkeypatch):
+    """Default xcode_available() to True so existing iOS-backend tests work
+    regardless of whether the CI runner has Xcode installed. Each consumer
+    holds its own local reference (`from server.device._xcode import
+    xcode_available`), so we patch every import site. Tests verifying the
+    no-Xcode gate can monkeypatch the same names to ``lambda: False``.
+
+    The replacement is lru_cached so callers that invoke ``.cache_clear()``
+    (e.g. ``_fix_developer_dir_for_setup`` after it mutates DEVELOPER_DIR)
+    don't blow up on a bare ``lambda``.
+    """
+    def _make_stub():
+        return functools.lru_cache(maxsize=1)(lambda: True)
+    for path in (
+        "server.device.simctl.xcode_available",
+        "server.device.devicectl.xcode_available",
+        "server.lifecycle.setup.xcode_available",
+    ):
+        monkeypatch.setattr(path, _make_stub())

--- a/tests/test_devicectl_backend.py
+++ b/tests/test_devicectl_backend.py
@@ -318,3 +318,27 @@ class TestRunDevicectl:
 
             stdout, _ = await backend._run_devicectl("list", "devices", json_output=True)
             assert stdout == expected_json
+
+
+# ---------------------------------------------------------------------------
+# Xcode-availability gate
+# ---------------------------------------------------------------------------
+
+
+class TestXcodeGate:
+    """On a no-Xcode Mac, devicectl methods short-circuit without invoking
+    xcrun. See server/device/_xcode.py."""
+
+    async def test_is_available_returns_false_without_invoking_xcrun(self, monkeypatch):
+        monkeypatch.setattr("server.device.devicectl.xcode_available", lambda: False)
+        backend = DevicectlBackend()
+        with patch("asyncio.create_subprocess_exec") as exec_mock:
+            assert await backend.is_available() is False
+        assert exec_mock.call_count == 0
+
+    async def test_list_devices_returns_empty_without_invoking_xcrun(self, monkeypatch):
+        monkeypatch.setattr("server.device.devicectl.xcode_available", lambda: False)
+        backend = DevicectlBackend()
+        with patch("asyncio.create_subprocess_exec") as exec_mock:
+            assert await backend.list_devices() == []
+        assert exec_mock.call_count == 0

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1055,3 +1055,63 @@ class TestRunUninstall:
             run_uninstall()
             output = capsys.readouterr().out
             assert "none were installed by setup" in output
+
+
+# ---------------------------------------------------------------------------
+# Xcode-availability gate
+# ---------------------------------------------------------------------------
+
+
+class TestXcodeGate:
+    """On a no-Xcode Mac, the setup checks short-circuit without invoking
+    xcrun — otherwise the macOS install dialog fires during ./quern setup."""
+
+    def test_check_xcode_cli_tools_reports_missing_without_invoking_xcrun(
+        self, monkeypatch,
+    ):
+        import server.lifecycle.setup as setup_mod
+        monkeypatch.setattr("server.lifecycle.setup.xcode_available", lambda: False)
+        # /usr/bin/xcrun ships on every modern macOS as an install-prompt
+        # stub, so `which xcrun` returns a path even on no-CLT machines —
+        # let the test see that path, then verify we don't actually run it.
+        monkeypatch.setattr(
+            "server.lifecycle.setup._which",
+            lambda name: "/usr/bin/xcrun" if name == "xcrun" else None,
+        )
+        with patch.object(setup_mod, "_run") as run_mock:
+            result = setup_mod.check_xcode_cli_tools()
+        assert result.status.name == "MISSING"
+        assert run_mock.call_count == 0
+
+    def test_check_booted_simulators_returns_empty_without_invoking_xcrun(
+        self, monkeypatch,
+    ):
+        import server.lifecycle.setup as setup_mod
+        monkeypatch.setattr("server.lifecycle.setup.xcode_available", lambda: False)
+        with patch.object(setup_mod, "_run") as run_mock:
+            assert setup_mod.check_booted_simulators() == []
+        assert run_mock.call_count == 0
+
+    def test_fix_developer_dir_skips_simctl_probe_when_no_xcode(
+        self, monkeypatch,
+    ):
+        """Without a developer dir, the initial `xcrun simctl help` probe
+        would trigger the install dialog. We should jump straight to
+        scanning /Applications instead."""
+        import server.lifecycle.setup as setup_mod
+        monkeypatch.delenv("DEVELOPER_DIR", raising=False)
+        monkeypatch.setattr("server.lifecycle.setup.xcode_available", lambda: False)
+
+        # /Applications has no Xcode → function returns None without ever
+        # running xcrun.
+        monkeypatch.setattr("pathlib.Path.glob", lambda self, pattern: [])
+
+        # _run returns (rc, stdout, stderr); xcode-select -p is called
+        # for the diagnostic message — stub it with a non-xcrun result.
+        with patch.object(setup_mod, "_run", return_value=(1, "", "")) as run_mock:
+            result = setup_mod._fix_developer_dir_for_setup()
+        assert result is None
+        # No xcrun invocation — the initial probe was gated.
+        for call in run_mock.call_args_list:
+            args = call.args[0]
+            assert args[0] != "xcrun", f"unexpected xcrun call: {args}"

--- a/tests/test_simctl_backend.py
+++ b/tests/test_simctl_backend.py
@@ -439,3 +439,28 @@ class TestScreenshot:
             result = await backend.screenshot("AAAA-1111")
 
         assert result == fake_png
+
+
+# ---------------------------------------------------------------------------
+# Xcode-availability gate
+# ---------------------------------------------------------------------------
+
+
+class TestXcodeGate:
+    """On a no-Xcode Mac, simctl methods short-circuit without invoking
+    xcrun. The macOS install dialog fires before xcrun returns, so the
+    backend can't recover after the fact — see server/device/_xcode.py."""
+
+    async def test_is_available_returns_false_without_invoking_xcrun(self, monkeypatch):
+        monkeypatch.setattr("server.device.simctl.xcode_available", lambda: False)
+        backend = SimctlBackend()
+        with patch("asyncio.create_subprocess_exec") as exec_mock:
+            assert await backend.is_available() is False
+        assert exec_mock.call_count == 0
+
+    async def test_list_devices_returns_empty_without_invoking_xcrun(self, monkeypatch):
+        monkeypatch.setattr("server.device.simctl.xcode_available", lambda: False)
+        backend = SimctlBackend()
+        with patch("asyncio.create_subprocess_exec") as exec_mock:
+            assert await backend.list_devices() == []
+        assert exec_mock.call_count == 0

--- a/tests/test_xcode_availability.py
+++ b/tests/test_xcode_availability.py
@@ -1,0 +1,99 @@
+"""Tests for server.device._xcode.xcode_available preflight."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_xcode_cache(monkeypatch):
+    """Clear the lru_cache between tests and bypass the autouse conftest
+    fixture so we exercise the real implementation."""
+    from server.device import _xcode
+    _xcode.xcode_available.cache_clear()
+    # Clear DEVELOPER_DIR so its presence doesn't shortcut the check.
+    monkeypatch.delenv("DEVELOPER_DIR", raising=False)
+    yield
+    _xcode.xcode_available.cache_clear()
+
+
+def _xcode_select_result(returncode: int, stdout: str = ""):
+    result = MagicMock()
+    result.returncode = returncode
+    result.stdout = stdout
+    return result
+
+
+def test_returns_true_when_xcode_select_reports_a_developer_dir():
+    from server.device._xcode import xcode_available
+    with patch(
+        "subprocess.run",
+        return_value=_xcode_select_result(0, "/Applications/Xcode.app/Contents/Developer\n"),
+    ) as run_mock:
+        assert xcode_available() is True
+    assert run_mock.call_count == 1
+    args, _ = run_mock.call_args
+    assert args[0] == ["xcode-select", "-p"]
+
+
+def test_returns_false_when_xcode_select_exits_nonzero():
+    """No developer dir configured — Mac will trigger the install dialog
+    if anything invokes xcrun, so we must report unavailable."""
+    from server.device._xcode import xcode_available
+    with patch("subprocess.run", return_value=_xcode_select_result(2, "")):
+        assert xcode_available() is False
+
+
+def test_returns_false_when_xcode_select_returns_empty_stdout():
+    """Defensive: rc==0 but no dev dir means xcrun would still fail."""
+    from server.device._xcode import xcode_available
+    with patch("subprocess.run", return_value=_xcode_select_result(0, "   \n")):
+        assert xcode_available() is False
+
+
+def test_returns_true_when_developer_dir_env_var_is_set(monkeypatch):
+    """Quern's setup script sets DEVELOPER_DIR as a runtime fix-up — that
+    counts even if xcode-select isn't pointed at anything useful."""
+    from server.device._xcode import xcode_available
+    monkeypatch.setenv("DEVELOPER_DIR", "/Applications/Xcode.app/Contents/Developer")
+    # xcode-select isn't called when DEVELOPER_DIR is set.
+    with patch("subprocess.run") as run_mock:
+        assert xcode_available() is True
+    assert run_mock.call_count == 0
+
+
+def test_returns_false_on_subprocess_exception():
+    """Defensive: subprocess failure shouldn't propagate; we report
+    unavailable so callers gate their xcrun calls."""
+    from server.device._xcode import xcode_available
+    with patch("subprocess.run", side_effect=OSError("xcode-select not found")):
+        assert xcode_available() is False
+
+
+def test_result_is_cached_across_calls():
+    """The lru_cache means we don't shell out on every backend probe."""
+    from server.device._xcode import xcode_available
+    with patch(
+        "subprocess.run",
+        return_value=_xcode_select_result(0, "/Applications/Xcode.app/Contents/Developer\n"),
+    ) as run_mock:
+        xcode_available()
+        xcode_available()
+        xcode_available()
+    assert run_mock.call_count == 1
+
+
+def test_cache_clear_forces_reprobe():
+    """cache_clear() should make the next call shell out again. Used by
+    setup.py after it mutates DEVELOPER_DIR mid-process."""
+    from server.device._xcode import xcode_available
+    with patch(
+        "subprocess.run",
+        return_value=_xcode_select_result(0, "/dir\n"),
+    ) as run_mock:
+        xcode_available()
+        xcode_available.cache_clear()
+        xcode_available()
+    assert run_mock.call_count == 2


### PR DESCRIPTION
Closes #37.

## Summary

Android-only devs installing Quern on a clean Mac saw the macOS *"install developer tools"* system dialog pop up during `./quern setup`, again on `quern start`, and again on their first `list_devices` call — because Quern was invoking `xcrun simctl` / `xcrun devicectl` unconditionally in five places. The Python `try/except` blocks caught the resulting `DeviceError`, but the dialog is rendered by Apple's `xcselect` library *before* `xcrun` returns. By the time the catch runs, the user has already had to dismiss a system dialog telling them to install something they don't need.

Fix: add a sync `xcode_available()` preflight that probes via `xcode-select -p` (which never triggers the dialog, unlike `xcrun`), then gate all five sites on it.

## Demo

Before, on a no-Xcode Mac:
- `./quern setup` → install dialog × 2
- `quern start` → install dialog (from the background warmup task)
- `list_devices` (even with `type=android_emulator`) → install dialog

After:
- `./quern setup` → reports "Xcode CLI Tools: Not installed (no developer directory configured). … If you only need Android, this is safe to ignore"
- `quern start` → silent; iOS backends report `is_available=False`
- `list_devices` → returns Android devices only, zero `xcrun` invocations

## The xcrun-vs-xcode-select trap

`/usr/bin/xcrun` ships on every modern macOS as a tiny stub that triggers `xcode-select --install` via the `xcselect` library when it can't find a developer dir. So `shutil.which("xcrun")` returning a path is **not** proof that the toolchain works — every clean Mac has that stub. The check we actually want is `xcode-select -p`, which exits 2 if no dev dir is set and never triggers the dialog. `check_xcode_cli_tools()` had this bug (passed `which("xcrun")`, then immediately invoked the stub) and was producing the dialog itself.

## Changes

| File | What |
|------|------|
| `server/device/_xcode.py` | New. `xcode_available()` — sync, `lru_cache`d, probes `xcode-select -p` plus `DEVELOPER_DIR` env shortcut. ~30 lines. |
| `server/device/simctl.py` | `is_available()` and `list_devices()` short-circuit on `not xcode_available()`. |
| `server/device/devicectl.py` | Same shape. |
| `server/lifecycle/setup.py` | Three functions gated: `check_xcode_cli_tools` (now reports MISSING with an Android-friendly hint), `check_booted_simulators` (returns `[]`), `_fix_developer_dir_for_setup` (skips the initial `xcrun simctl help` probe, jumps straight to scanning `/Applications` — once `DEVELOPER_DIR` is set, xcrun is safe). Cache-clears after env mutation. |
| `tests/conftest.py` | Autouse fixture defaults `xcode_available` to a lru-cached `True` in every consumer so existing tests aren't sensitive to CI runner state. |
| `tests/test_xcode_availability.py` | 7 unit tests for `xcode_available()` (success / nonzero exit / empty stdout / DEVELOPER_DIR shortcut / subprocess exception / cache / cache_clear). |
| `tests/test_simctl_backend.py` + `tests/test_devicectl_backend.py` | 4 gate tests proving `is_available` and `list_devices` return False / `[]` without invoking `asyncio.create_subprocess_exec` (asserting `call_count == 0`). |
| `tests/test_setup.py` | 3 gate tests for the three setup-script sites (each asserts `_run` is never invoked with an `xcrun` command on a no-Xcode machine). |

## Architecture note

The gate lives in each backend's `list_devices()` (and `is_available()`), not in `DeviceController.list_devices()`. That way tests that mock the backend's `list_devices` wholesale (the existing pattern) bypass the gate transparently, and the controller stays simple. The `xcode_available()` check itself is sync and `lru_cache`d, so the cost of calling it on every backend invocation is one cached function call, not a subprocess.

## Test plan

- [x] `pytest tests/` → **1355 passed locally** (1341 before + 14 new)
- [x] `ruff` clean (pre-commit hook)
- [x] No-Xcode behavior verified: with `xcode_available` mocked to `False`, `asyncio.create_subprocess_exec` is asserted to be called 0 times across all five gated sites.

I'll watch CI and merge once it goes green.