### PR TITLE
feat: surface update availability through MCP + warn on version skew

### DIFF
--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -27,8 +27,26 @@ import { registerAppStateTools } from "./tools/app-state.js";
 import { registerOslogTools } from "./tools/oslog.js";
 import { registerAppKnowledgeTools } from "./tools/app-knowledge.js";
 import { registerLandmarkTools } from "./tools/landmarks.js";
+import { registerSystemTools } from "./tools/system.js";
+import { discoverServer } from "./config.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Read our own version from package.json so the MCP handshake reports
+// the actual built version instead of a stale hardcoded value. The
+// package.json sits one dir above dist/index.js.
+function readOwnVersion(): string {
+  try {
+    const pkg = JSON.parse(
+      readFileSync(join(__dirname, "..", "package.json"), "utf-8"),
+    );
+    return typeof pkg.version === "string" ? pkg.version : "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+const MCP_VERSION = readOwnVersion();
 
 const instructions = [
   "Quern is a debug server for AI-assisted iOS development — it captures logs, intercepts network traffic, and controls simulators/devices via MCP tools.",
@@ -67,7 +85,7 @@ const instructions = [
 const server = new McpServer(
   {
     name: "quern-debug-server",
-    version: "0.1.0",
+    version: MCP_VERSION,
   },
   { instructions },
 );
@@ -90,6 +108,7 @@ registerAppStateTools(server);
 registerOslogTools(server);
 registerAppKnowledgeTools(server);
 registerLandmarkTools(server);
+registerSystemTools(server);
 
 // ---------------------------------------------------------------------------
 // Resources
@@ -165,13 +184,47 @@ server.resource(
 // Main
 // ---------------------------------------------------------------------------
 
+async function checkVersionSkew(): Promise<void> {
+  // Compare our package.json version against the Python server's
+  // reported version. Mismatches happen when one side has been
+  // updated but the other hasn't — the user gets weird behavior and
+  // no signal about the cause. Best-effort: if /health is unreachable
+  // or shape-mismatched, we just stay quiet (probeServer already
+  // warns about unreachable). Cap timeout to 2s so a slow server
+  // never blocks MCP startup.
+  try {
+    const serverUrl = discoverServer().url;
+    const resp = await fetch(new URL("/health", serverUrl).toString(), {
+      signal: AbortSignal.timeout(2000),
+    });
+    if (!resp.ok) return;
+    const data = (await resp.json()) as { version?: string };
+    const serverVersion = data?.version;
+    if (
+      serverVersion &&
+      MCP_VERSION !== "unknown" &&
+      serverVersion !== MCP_VERSION
+    ) {
+      console.error(
+        `WARNING: Quern MCP version (${MCP_VERSION}) does not match server version (${serverVersion}). ` +
+          `One side has been updated and the other hasn't. ` +
+          `Run "quern update" to bring both in sync.`,
+      );
+    }
+  } catch {
+    // discoverServer can throw if state.json is missing; that's
+    // probeServer's problem, not ours.
+  }
+}
+
 async function main(): Promise<void> {
   await probeServer();
+  await checkVersionSkew();
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
 
-  console.error("Quern Debug MCP Server running on stdio");
+  console.error(`Quern Debug MCP Server v${MCP_VERSION} running on stdio`);
 }
 
 main().catch((err) => {

--- a/mcp/src/tools/logs.ts
+++ b/mcp/src/tools/logs.ts
@@ -25,6 +25,26 @@ export function registerLogTools(server: McpServer): void {
                 signal: AbortSignal.timeout(5000),
               });
               if (resp.ok) {
+                // Best-effort: surface the cached update-check result so
+                // Claude can mention "v0.13.5 is available" inline. The
+                // endpoint never blocks; if it errors we just omit the
+                // field. update_available=false is intentionally elided
+                // to keep the response quiet on the happy path.
+                let updateAvailable: unknown = undefined;
+                try {
+                  const upd = (await apiRequest(
+                    "GET",
+                    "/api/v1/system/update-status",
+                    undefined,
+                    undefined,
+                    2000,
+                  )) as { update_available?: boolean } | null;
+                  if (upd && upd.update_available) {
+                    updateAvailable = upd;
+                  }
+                } catch {
+                  // Older server or transient failure — skip silently.
+                }
                 return {
                   content: [
                     {
@@ -39,6 +59,9 @@ export function registerLogTools(server: McpServer): void {
                           api_key: state.api_key,
                           started_at: state.started_at,
                           pid: state.pid,
+                          ...(updateAvailable
+                            ? { update_available: updateAvailable }
+                            : {}),
                         },
                         null,
                         2

--- a/mcp/src/tools/system.ts
+++ b/mcp/src/tools/system.ts
@@ -1,0 +1,34 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { apiRequest } from "../http.js";
+import { strictParams } from "./helpers.js";
+
+export function registerSystemTools(server: McpServer): void {
+  server.registerTool(
+    "update_quern",
+    {
+      description:
+        `Update Quern to the latest release. Launches the equivalent of "quern update" — pulls the latest source (or fetches the release tarball), reinstalls Python deps, rebuilds the MCP server, and restarts the daemon. The HTTP call returns immediately; the actual upgrade runs in a detached child and takes ~30-60 seconds. The Quern server will restart during that window, so the next MCP tool call may fail until it's back up. Reconnect by retrying ensure_server. Only call this after the user has confirmed they want to update — typically prompted by an "update_available" hint in ensure_server's response.`,
+      inputSchema: strictParams({}),
+    },
+    async () => {
+      try {
+        const data = await apiRequest("POST", "/api/v1/system/update");
+        return {
+          content: [
+            { type: "text" as const, text: JSON.stringify(data, null, 2) },
+          ],
+        };
+      } catch (e) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Error launching update: ${e instanceof Error ? e.message : String(e)}\n\nFall back to running "quern update" in a terminal manually.`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/server/api/system.py
+++ b/server/api/system.py
@@ -1,0 +1,133 @@
+"""API routes for server-level system operations: update awareness + trigger.
+
+These endpoints exist so MCP clients (and other API consumers) can surface
+"a new Quern release is available" inline in the workflow the user is
+already in — Claude Code calls ``ensure_server``, learns there's an
+update, mentions it, and can call ``POST /update`` if the user agrees.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from server.lifecycle.update_check import read_update_info
+
+logger = logging.getLogger("quern-debug-server.system")
+
+router = APIRouter(prefix="/api/v1/system", tags=["system"])
+
+
+class UpdateStatusResponse(BaseModel):
+    """Result of the most recent ``quern.dev/api/check-update`` poll.
+
+    Populated by the periodic 24h background check. If the server hasn't
+    run a check yet (fresh install, opted out, or first 24h), ``checked_at``
+    is None and ``update_available`` is False.
+    """
+
+    update_available: bool = False
+    current_version: str | None = None
+    latest_version: str | None = None
+    checked_at: str | None = None
+    message: str | None = None
+
+
+class UpdateTriggerResponse(BaseModel):
+    """Acknowledgment that the update was launched. The actual upgrade
+    runs in a detached child — the response returns before the child
+    starts replacing files, so the caller gets a clean reply even though
+    the server is about to restart itself."""
+
+    status: str  # "launched" | "skipped"
+    pid: int | None = None
+    note: str
+
+
+@router.get("/update-status", response_model=UpdateStatusResponse)
+async def update_status() -> UpdateStatusResponse:
+    """Return the most recent persisted update-check result.
+
+    Cached in ``~/.quern/update-info.json``; refreshed by the background
+    task every 24 hours (see ``server/lifecycle/update_check.py``). Cheap
+    to call — no network round-trip.
+    """
+    info = read_update_info()
+    if info is None:
+        return UpdateStatusResponse()
+    return UpdateStatusResponse(
+        update_available=bool(info.get("update_available")),
+        current_version=info.get("current_version"),
+        latest_version=info.get("latest_version"),
+        checked_at=info.get("checked_at"),
+        message=info.get("message"),
+    )
+
+
+@router.post("/update", response_model=UpdateTriggerResponse)
+async def trigger_update() -> UpdateTriggerResponse:
+    """Launch ``quern update`` in a detached child and respond immediately.
+
+    The actual update is a multi-step operation (git pull / tarball
+    fetch, pip reinstall, MCP rebuild, daemon restart) that takes
+    minutes and ends by killing this server. Running it inline would
+    leave the caller hanging or breaking their connection mid-response.
+    Detach via ``Popen(start_new_session=True)`` — same pattern Quern
+    uses for the daemon — so this response can land before the child
+    starts replacing files.
+    """
+    project_root = _find_project_root()
+    if project_root is None:
+        return UpdateTriggerResponse(
+            status="skipped",
+            note="Could not locate the Quern project root from this server "
+                 "process — run `quern update` from your install manually.",
+        )
+
+    # Use the same Python interpreter that's running the server so we
+    # don't accidentally pick up a different venv via PATH.
+    cmd = [sys.executable, "-m", "server", "update"]
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            cwd=str(project_root),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,
+            env={**os.environ, "QUERN_UPDATE_TRIGGERED_BY": "api"},
+        )
+    except OSError as e:
+        logger.warning("Failed to launch update child: %s", e)
+        return UpdateTriggerResponse(
+            status="skipped",
+            note=f"Failed to launch update: {e}",
+        )
+
+    return UpdateTriggerResponse(
+        status="launched",
+        pid=proc.pid,
+        note=(
+            "Update started in a detached child. The server will restart "
+            "in a few seconds — wait ~30-60s and reconnect."
+        ),
+    )
+
+
+def _find_project_root() -> Path | None:
+    """Find the Quern project root (the directory containing pyproject.toml)."""
+    path = Path(__file__).resolve().parent
+    for _ in range(5):
+        if (path / "pyproject.toml").exists():
+            return path
+        parent = path.parent
+        if parent == path:
+            break
+        path = parent
+    return None

--- a/server/lifecycle/update_check.py
+++ b/server/lifecycle/update_check.py
@@ -8,7 +8,10 @@ Rate-limited to once per 24 hours. Repeats periodically while the server
 is running so long-lived servers still check in. Never blocks or crashes
 the server.
 
-Opt out by setting "update_check": false in ~/.quern/config.json.
+Persists the structured result to ``~/.quern/update-info.json`` so MCP
+clients and other consumers can surface "update available" without
+re-hitting the endpoint. Opt out by setting ``"update_check": false`` in
+``~/.quern/config.json``.
 """
 
 from __future__ import annotations
@@ -20,6 +23,7 @@ import subprocess
 import time
 import urllib.error
 import urllib.request
+from datetime import UTC, datetime
 from pathlib import Path
 
 from server.config import CONFIG_DIR, read_user_config
@@ -27,6 +31,7 @@ from server.config import CONFIG_DIR, read_user_config
 logger = logging.getLogger("quern-debug-server.update-check")
 
 LAST_CHECK_FILE = CONFIG_DIR / "last-update-check"
+UPDATE_INFO_FILE = CONFIG_DIR / "update-info.json"
 CHECK_INTERVAL = 86400  # 24 hours
 ENDPOINT = "https://quern.dev/api/check-update"
 TIMEOUT = 5  # seconds
@@ -121,11 +126,51 @@ def check_for_updates() -> str | None:
         with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
             data = json.loads(resp.read().decode())
 
-        if data.get("update_available"):
-            return 'Update available \u2014 run "quern update" to get the latest version'
-        return None
+        update_available = bool(data.get("update_available"))
+        message = (
+            'Update available \u2014 run "quern update" to get the latest version'
+            if update_available else None
+        )
+        # Persist structured result for the system API + MCP. quern.dev's
+        # current schema only returns update_available; latest_version is
+        # forward-compatible \u2014 fall back to None if absent.
+        _write_update_info({
+            "checked_at": datetime.now(UTC).isoformat(),
+            "current_version": version,
+            "latest_version": data.get("latest_version"),
+            "update_available": update_available,
+            "message": message,
+        })
+        return message
 
     except Exception:
+        return None
+
+
+def _write_update_info(info: dict) -> None:
+    """Persist the latest check result to ``~/.quern/update-info.json``.
+
+    Best-effort: a failed write must not break the periodic check.
+    """
+    try:
+        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        UPDATE_INFO_FILE.write_text(json.dumps(info, indent=2))
+    except OSError as e:
+        logger.debug("Failed to persist update info: %s", e)
+
+
+def read_update_info() -> dict | None:
+    """Return the most recent persisted update check, or None if never run.
+
+    Consumed by the system API so MCP clients can surface "update
+    available" inline in tool responses without re-hitting quern.dev.
+    """
+    if not UPDATE_INFO_FILE.exists():
+        return None
+    try:
+        return json.loads(UPDATE_INFO_FILE.read_text())
+    except (json.JSONDecodeError, OSError) as e:
+        logger.debug("Failed to read update info: %s", e)
         return None
 
 

--- a/server/main.py
+++ b/server/main.py
@@ -43,6 +43,7 @@ from server.api.logs import router as logs_router
 from server.api.proxy import router as proxy_router
 from server.api.proxy_certs import router as proxy_certs_router
 from server.api.proxy_intercept import router as proxy_intercept_router
+from server.api.system import router as system_router
 from server.api.wda import router as wda_router
 from server.auth import APIKeyMiddleware
 from server.config import ServerConfig, get_local_capture_processes, set_local_capture_processes
@@ -532,6 +533,7 @@ def create_app(
     app.include_router(build_app_router)
     app.include_router(app_state_router)
     app.include_router(landmarks_router)
+    app.include_router(system_router)
 
     @app.get("/")
     async def root() -> RedirectResponse:

--- a/tests/test_system_api.py
+++ b/tests/test_system_api.py
@@ -1,0 +1,143 @@
+"""Tests for the /api/v1/system/* endpoints — update awareness + trigger."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from server.config import ServerConfig
+from server.main import create_app
+
+
+@pytest.fixture
+def app():
+    config = ServerConfig(api_key="test-key-12345")
+    return create_app(
+        config=config, enable_oslog=False, enable_crash=False, enable_proxy=False,
+    )
+
+
+@pytest.fixture
+def auth_headers():
+    return {"Authorization": "Bearer test-key-12345"}
+
+
+# ---------------------------------------------------------------------------
+# /update-status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_status_returns_defaults_when_never_checked(
+    app, auth_headers, monkeypatch,
+):
+    """Fresh install, opted out, or first 24h before check fires —
+    endpoint must still respond cleanly with sensible defaults."""
+    monkeypatch.setattr(
+        "server.api.system.read_update_info", lambda: None,
+    )
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/api/v1/system/update-status", headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+
+    assert data["update_available"] is False
+    assert data["current_version"] is None
+    assert data["latest_version"] is None
+    assert data["checked_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_update_status_surfaces_persisted_record(
+    app, auth_headers, monkeypatch,
+):
+    monkeypatch.setattr(
+        "server.api.system.read_update_info",
+        lambda: {
+            "checked_at": "2026-06-05T19:00:00+00:00",
+            "current_version": "0.13.4",
+            "latest_version": "0.13.5",
+            "update_available": True,
+            "message": 'Update available — run "quern update" ...',
+        },
+    )
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/api/v1/system/update-status", headers=auth_headers,
+        )
+        data = resp.json()
+
+    assert data["update_available"] is True
+    assert data["current_version"] == "0.13.4"
+    assert data["latest_version"] == "0.13.5"
+    assert data["checked_at"] == "2026-06-05T19:00:00+00:00"
+    assert "Update available" in data["message"]
+
+
+# ---------------------------------------------------------------------------
+# /update (trigger)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_trigger_launches_detached_child(
+    app, auth_headers, monkeypatch,
+):
+    """POST /update must spawn a detached subprocess and return 202-ish
+    immediately. We can't actually run `quern update` in a test, so mock
+    Popen and verify the spawn shape."""
+    fake_proc = MagicMock()
+    fake_proc.pid = 99999
+
+    with patch(
+        "server.api.system.subprocess.Popen", return_value=fake_proc,
+    ) as popen_mock:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/api/v1/system/update", headers=auth_headers,
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+
+    assert data["status"] == "launched"
+    assert data["pid"] == 99999
+    assert "restart" in data["note"].lower()
+
+    # Verify the child was started detached (start_new_session=True).
+    # Without this, killing the server would kill the updater mid-run.
+    assert popen_mock.call_count == 1
+    kwargs = popen_mock.call_args.kwargs
+    assert kwargs["start_new_session"] is True
+    # The command should be `python -m server update`.
+    args = popen_mock.call_args.args[0]
+    assert args[-2:] == ["-m", "server", "update"][-2:]
+
+
+@pytest.mark.asyncio
+async def test_update_trigger_reports_skipped_on_oserror(
+    app, auth_headers, monkeypatch,
+):
+    """If Popen fails (e.g. the env is too locked-down), the endpoint
+    should still respond with a useful error, not 500."""
+    with patch(
+        "server.api.system.subprocess.Popen",
+        side_effect=OSError("permission denied"),
+    ):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/api/v1/system/update", headers=auth_headers,
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+
+    assert data["status"] == "skipped"
+    assert data["pid"] is None
+    assert "permission denied" in data["note"]

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -1,0 +1,107 @@
+"""Tests for server.lifecycle.update_check — persistence + read API.
+
+Doesn't exercise the network round-trip (quern.dev). Patches the urllib
+call so test runs are deterministic.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def isolated_update_files(tmp_path, monkeypatch):
+    """Redirect CONFIG_DIR / LAST_CHECK_FILE / UPDATE_INFO_FILE to tmp_path.
+
+    The update check writes files in CONFIG_DIR; without redirection the
+    test would mutate the real ~/.quern.
+    """
+    from server.lifecycle import update_check
+    monkeypatch.setattr(update_check, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(update_check, "LAST_CHECK_FILE", tmp_path / "last-update-check")
+    monkeypatch.setattr(update_check, "UPDATE_INFO_FILE", tmp_path / "update-info.json")
+    return tmp_path
+
+
+def test_read_update_info_returns_none_when_missing(isolated_update_files):
+    from server.lifecycle.update_check import read_update_info
+    assert read_update_info() is None
+
+
+def test_read_update_info_returns_persisted_record(isolated_update_files):
+    from server.lifecycle.update_check import read_update_info
+    payload = {
+        "checked_at": "2026-06-05T19:00:00+00:00",
+        "current_version": "0.13.4",
+        "latest_version": "0.13.5",
+        "update_available": True,
+        "message": "Update available — run \"quern update\" ...",
+    }
+    (isolated_update_files / "update-info.json").write_text(json.dumps(payload))
+    assert read_update_info() == payload
+
+
+def test_read_update_info_returns_none_on_invalid_json(isolated_update_files):
+    """Defensive: corrupt sidecar shouldn't crash the system endpoint."""
+    from server.lifecycle.update_check import read_update_info
+    (isolated_update_files / "update-info.json").write_text("not json at all")
+    assert read_update_info() is None
+
+
+def test_check_for_updates_persists_when_update_available(
+    isolated_update_files, monkeypatch,
+):
+    from server.lifecycle import update_check
+
+    monkeypatch.setattr(update_check, "read_user_config", lambda: {})
+    monkeypatch.setattr(update_check, "_get_local_version", lambda: "0.13.4")
+    monkeypatch.setattr(update_check, "_get_head_sha", lambda: None)
+
+    fake_resp = MagicMock()
+    fake_resp.__enter__ = MagicMock(return_value=fake_resp)
+    fake_resp.__exit__ = MagicMock(return_value=False)
+    fake_resp.read = MagicMock(
+        return_value=json.dumps(
+            {"update_available": True, "latest_version": "0.13.5"}
+        ).encode(),
+    )
+    with patch("urllib.request.urlopen", return_value=fake_resp):
+        msg = update_check.check_for_updates()
+
+    assert msg and "Update available" in msg
+    info = update_check.read_update_info()
+    assert info is not None
+    assert info["update_available"] is True
+    assert info["current_version"] == "0.13.4"
+    assert info["latest_version"] == "0.13.5"
+    assert info["checked_at"]  # ISO timestamp present
+
+
+def test_check_for_updates_persists_when_no_update(
+    isolated_update_files, monkeypatch,
+):
+    """Even when nothing is available, persist the "checked" record so
+    the system API can report when the last check ran."""
+    from server.lifecycle import update_check
+
+    monkeypatch.setattr(update_check, "read_user_config", lambda: {})
+    monkeypatch.setattr(update_check, "_get_local_version", lambda: "0.13.4")
+    monkeypatch.setattr(update_check, "_get_head_sha", lambda: None)
+
+    fake_resp = MagicMock()
+    fake_resp.__enter__ = MagicMock(return_value=fake_resp)
+    fake_resp.__exit__ = MagicMock(return_value=False)
+    fake_resp.read = MagicMock(
+        return_value=json.dumps({"update_available": False}).encode(),
+    )
+    with patch("urllib.request.urlopen", return_value=fake_resp):
+        msg = update_check.check_for_updates()
+
+    assert msg is None
+    info = update_check.read_update_info()
+    assert info is not None
+    assert info["update_available"] is False
+    assert info["message"] is None


### PR DESCRIPTION
Implements options #1 and #3 from the auto-update design discussion.

## Summary

The 24h `quern.dev/api/check-update` poll was log-only — users discovered updates only when they happened to read the CLI logs. And `mcp/src/index.ts` hardcoded `version: "0.1.0"`, so a partial upgrade (Python updated but MCP not rebuilt, or vice versa) went undetected.

This PR makes the existing infrastructure visible inside the workflow people actually use:

- `ensure_server`'s response now includes an `update_available` block when one is available. Claude sees it and surfaces it inline: *"By the way, Quern v0.13.5 is available — want me to update?"*
- New `update_quern` MCP tool wraps a new `POST /api/v1/system/update` endpoint, which detaches a child running `quern update` and returns immediately so the caller doesn't hang on the about-to-be-killed connection.
- MCP reads its version from `package.json` and warns at startup when it differs from the Python server's reported version.

## Live verification on the user's machine

Running server is `0.13.2` (hasn't been restarted since the morning's releases); the rebuilt MCP is `0.13.4`. Exactly the kind of skew the new warning catches:

```
Connected to Quern at http://127.0.0.1:9100
WARNING: Quern MCP version (0.13.4) does not match server version (0.13.2). One side has been updated and the other hasn't. Run "quern update" to bring both in sync.
Quern Debug MCP Server v0.13.4 running on stdio
```

## Changes

| File | What |
|------|------|
| `server/lifecycle/update_check.py` | Persist the structured check result to `~/.quern/update-info.json` (`checked_at`, `current_version`, `latest_version`, `update_available`, `message`). Add `read_update_info()` for consumers. |
| `server/api/system.py` (new) | `GET /api/v1/system/update-status` (returns cached record, no network) and `POST /api/v1/system/update` (launches `quern update` via `Popen(start_new_session=True)` — the same detach pattern Quern uses for the daemon — so the HTTP response lands cleanly before the child starts replacing files). |
| `server/main.py` | Wire the new router. |
| `mcp/src/index.ts` | Read MCP version from `package.json` at runtime (was hardcoded `0.1.0`). Add `checkVersionSkew()` after `probeServer()` — fetches `/health`, compares, writes a clear warning to stderr on mismatch. 2s timeout, fully best-effort. |
| `mcp/src/tools/logs.ts` | After a successful `ensure_server` health check, best-effort fetch `/api/v1/system/update-status`. Inline an `update_available` field on `update_available=true` only; elide on the happy path to keep the response quiet. Older Python servers without the endpoint are handled gracefully. |
| `mcp/src/tools/system.ts` (new) | `update_quern` tool. Description tells Claude to only call this after user consent — typically prompted by the inline hint. |

## Test plan

- [x] **5 unit tests** for `update_check.py` persistence: missing sidecar returns `None`, corrupt JSON returns `None`, round-trip, update-available + no-update paths both persist correctly.
- [x] **4 integration tests** for `/api/v1/system/*`: defaults when never checked, surfaces persisted record, `Popen` invoked with `start_new_session=True` (without this the daemon restart would kill the updater mid-run), graceful `OSError` handling.
- [x] **Full Python suite**: 1364 passed.
- [x] **MCP build**: clean `tsc`.
- [x] **Live smoke**: rebuilt MCP against the running 0.13.2 server prints the skew warning exactly as designed.

## Out of scope (deferred from the design discussion)

- macOS notification on detection (option #2 from the discussion)
- Auto-apply on idle (#4 — has real UX risk, needs more design)
- Menu bar app (#5 — Ollama-pattern; worth doing once we see how much #1 helps)