### PR TITLE
fix(updater): check against origin/main, not the current branch's upstream

### DIFF
--- a/server/lifecycle/updater.py
+++ b/server/lifecycle/updater.py
@@ -90,10 +90,29 @@ def _check_via_quern_dev(head_sha: str) -> bool | None:
         return None
 
 
+# The git branch that ships releases. Compared against directly when
+# answering "is there a Quern update available", regardless of which
+# branch the user happens to have checked out. Hardcoded for now; the
+# channels work (#41) will make this configurable so users can opt into
+# a `release/beta` track without leaving the install path they have.
+RELEASE_BRANCH = "main"
+
+
 def _check_via_git(project_root: Path) -> tuple[bool, str, int] | None:
     """Fall back to git fetch to check for updates.
 
-    Returns (has_updates, branch, behind_count) or None on failure.
+    Always compares HEAD against ``origin/<RELEASE_BRANCH>``, not against
+    the current branch's tracking ref — closes #40. A user on a non-
+    release branch (e.g. a developer hacking on a feature) was previously
+    told "already up to date" when the only thing that was up-to-date was
+    their feature branch vs its own remote; new releases on main were
+    silently ignored.
+
+    Returns ``(has_updates, current_branch, behind_count)`` or None on
+    failure. ``has_updates`` and ``behind_count`` are always measured
+    against ``origin/<RELEASE_BRANCH>``; ``current_branch`` is reported
+    so the caller can decide whether to actually pull (only safe on the
+    release branch) or just warn (any other branch).
     """
     result = subprocess.run(
         ["git", "fetch", "origin"],
@@ -117,31 +136,26 @@ def _check_via_git(project_root: Path) -> tuple[bool, str, int] | None:
     if result.returncode != 0:
         print("Error: could not determine current branch")
         return None
-    branch = result.stdout.strip()
+    current_branch = result.stdout.strip()
 
-    # Count commits behind
+    # Count commits behind origin/<RELEASE_BRANCH> — always, regardless
+    # of which branch is currently checked out.
     result = subprocess.run(
-        ["git", "rev-list", f"HEAD..origin/{branch}", "--count"],
+        ["git", "rev-list", f"HEAD..origin/{RELEASE_BRANCH}", "--count"],
         cwd=str(project_root),
         capture_output=True,
         text=True,
         timeout=10,
     )
     if result.returncode != 0:
-        result = subprocess.run(
-            ["git", "rev-list", "HEAD..origin/main", "--count"],
-            cwd=str(project_root),
-            capture_output=True,
-            text=True,
-            timeout=10,
+        print(
+            f"Error: could not compare HEAD against origin/{RELEASE_BRANCH} "
+            f"({result.stderr.strip()})"
         )
-        if result.returncode != 0:
-            print("Error: could not compare with remote (no tracking branch)")
-            return None
-        branch = "main"
+        return None
 
     behind_count = int(result.stdout.strip())
-    return (behind_count > 0, branch, behind_count)
+    return (behind_count > 0, current_branch, behind_count)
 
 
 def _update_via_git(project_root: Path) -> int:
@@ -170,6 +184,31 @@ def _update_via_git(project_root: Path) -> int:
         return 1
 
     has_updates, branch, behind_count = git_check
+
+    # Approach (A) from #40: when the user is on a non-release branch
+    # (typical for dev clones), the commit count is now truthful about
+    # `origin/<RELEASE_BRANCH>`, but pulling here would be wrong — `git
+    # pull --ff-only` tracks the current branch's upstream, not the
+    # release branch. So we report what's available and let the user
+    # decide whether to switch.
+    if branch != RELEASE_BRANCH:
+        if has_updates:
+            plural = "s" if behind_count != 1 else ""
+            print(
+                f"You're on branch `{branch}`. "
+                f"`origin/{RELEASE_BRANCH}` is {behind_count} commit{plural} ahead. "
+                f"Switch with `git checkout {RELEASE_BRANCH}` and rerun "
+                f"`quern update` to apply — or stay on `{branch}` "
+                f"if you're working on Quern itself."
+            )
+        else:
+            print(
+                f"You're on branch `{branch}` "
+                f"(not the release branch `{RELEASE_BRANCH}`). "
+                f"No new commits on `origin/{RELEASE_BRANCH}`."
+            )
+        return 2  # Skip rebuild — current workspace isn't pull-able
+
     if not has_updates:
         print("Already up to date.")
         return 2  # No update needed

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,0 +1,237 @@
+"""Tests for server.lifecycle.updater — `quern update` flow.
+
+Focuses on the branch-vs-release semantics fixed in #40: the check
+should always compare against ``origin/<RELEASE_BRANCH>``, and the pull
+step must be skipped when the user isn't actually on that branch.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_run(returncode: int = 0, stdout: str = "", stderr: str = ""):
+    """Build a MagicMock subprocess CompletedProcess-ish object."""
+    result = MagicMock()
+    result.returncode = returncode
+    result.stdout = stdout
+    result.stderr = stderr
+    return result
+
+
+def _make_subprocess_dispatcher(responses: dict):
+    """Build a side_effect that dispatches on the command tuple.
+
+    ``responses`` is keyed by the tuple of command tokens. Defaults are
+    provided for the common quern.dev / git ops; tests override only the
+    interesting ones.
+    """
+    def fake_run(cmd, *args, **kwargs):
+        key = tuple(cmd)
+        for prefix, response in responses.items():
+            if key[: len(prefix)] == prefix:
+                return response
+        # Default to a successful no-op so unmocked git invocations
+        # don't crash the test — they'd surface as the wrong answer
+        # rather than an exception, which is what we want when
+        # diagnosing a missed mock.
+        return _make_run(returncode=0, stdout="")
+    return fake_run
+
+
+# ---------------------------------------------------------------------------
+# _check_via_git — compares against origin/<RELEASE_BRANCH>, not the
+# current branch's upstream
+# ---------------------------------------------------------------------------
+
+
+def test_check_via_git_compares_to_release_branch_not_current_branch():
+    """Bug #40: on a non-main branch the check used to look at
+    `origin/<current-branch>` and miss new commits on main."""
+    from server.lifecycle import updater
+
+    responses = {
+        ("git", "fetch", "origin"): _make_run(0),
+        ("git", "rev-parse", "--abbrev-ref", "HEAD"): _make_run(
+            0, stdout="feat/something\n",
+        ),
+        ("git", "rev-list", "HEAD..origin/main", "--count"): _make_run(
+            0, stdout="3\n",
+        ),
+    }
+    with patch(
+        "server.lifecycle.updater.subprocess.run",
+        side_effect=_make_subprocess_dispatcher(responses),
+    ) as run_mock:
+        result = updater._check_via_git(Path("/fake"))
+
+    assert result == (True, "feat/something", 3)
+    # Crucial assertion: the rev-list command must reference origin/main,
+    # not origin/feat/something.
+    rev_list_calls = [
+        c for c in run_mock.call_args_list
+        if c.args[0][:2] == ["git", "rev-list"]
+    ]
+    assert len(rev_list_calls) == 1
+    assert rev_list_calls[0].args[0] == [
+        "git", "rev-list", "HEAD..origin/main", "--count",
+    ]
+
+
+def test_check_via_git_returns_zero_when_no_new_commits_on_release_branch():
+    from server.lifecycle import updater
+
+    responses = {
+        ("git", "fetch", "origin"): _make_run(0),
+        ("git", "rev-parse", "--abbrev-ref", "HEAD"): _make_run(
+            0, stdout="main\n",
+        ),
+        ("git", "rev-list", "HEAD..origin/main", "--count"): _make_run(
+            0, stdout="0\n",
+        ),
+    }
+    with patch(
+        "server.lifecycle.updater.subprocess.run",
+        side_effect=_make_subprocess_dispatcher(responses),
+    ):
+        result = updater._check_via_git(Path("/fake"))
+
+    assert result == (False, "main", 0)
+
+
+def test_check_via_git_returns_none_on_fetch_failure():
+    from server.lifecycle import updater
+
+    responses = {
+        ("git", "fetch", "origin"): _make_run(
+            1, stderr="fatal: unable to access ...\n",
+        ),
+    }
+    with patch(
+        "server.lifecycle.updater.subprocess.run",
+        side_effect=_make_subprocess_dispatcher(responses),
+    ):
+        assert updater._check_via_git(Path("/fake")) is None
+
+
+# ---------------------------------------------------------------------------
+# _update_via_git — non-release-branch handling per approach (A) of #40
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def stub_quern_dev_no_signal(monkeypatch):
+    """Make _check_via_quern_dev return None ("don't know") so the test
+    falls through to the git-side logic we actually want to exercise."""
+    monkeypatch.setattr(
+        "server.lifecycle.updater._check_via_quern_dev", lambda sha: None,
+    )
+
+
+def test_update_via_git_on_feature_branch_with_updates_warns_and_skips_pull(
+    capsys, stub_quern_dev_no_signal,
+):
+    """The key #40 scenario: user is on a feature branch, main has new
+    commits. We must tell the user what's available without pulling
+    (because `git pull --ff-only` would operate on the wrong upstream),
+    and skip the rebuild (rc=2)."""
+    from server.lifecycle import updater
+
+    responses = {
+        ("git", "rev-parse", "HEAD"): _make_run(0, stdout="deadbeef\n"),
+        ("git", "fetch", "origin"): _make_run(0),
+        ("git", "rev-parse", "--abbrev-ref", "HEAD"): _make_run(
+            0, stdout="feat/foo\n",
+        ),
+        ("git", "rev-list", "HEAD..origin/main", "--count"): _make_run(
+            0, stdout="3\n",
+        ),
+    }
+    with patch(
+        "server.lifecycle.updater.subprocess.run",
+        side_effect=_make_subprocess_dispatcher(responses),
+    ) as run_mock:
+        rc = updater._update_via_git(Path("/fake"))
+
+    assert rc == 2  # Skip rebuild
+    captured = capsys.readouterr()
+    assert "feat/foo" in captured.out
+    assert "`origin/main` is 3 commits ahead" in captured.out
+    assert "git checkout main" in captured.out
+
+    # Critically: `git pull` must NOT have been invoked.
+    pull_calls = [
+        c for c in run_mock.call_args_list
+        if c.args[0][:2] == ["git", "pull"]
+    ]
+    assert pull_calls == []
+
+
+def test_update_via_git_on_feature_branch_with_no_updates_notes_and_skips(
+    capsys, stub_quern_dev_no_signal,
+):
+    """When the feature branch is in sync with main, we should still
+    point out that the user is on a non-release branch — silent success
+    is misleading because the check semantics aren't obvious."""
+    from server.lifecycle import updater
+
+    responses = {
+        ("git", "rev-parse", "HEAD"): _make_run(0, stdout="deadbeef\n"),
+        ("git", "fetch", "origin"): _make_run(0),
+        ("git", "rev-parse", "--abbrev-ref", "HEAD"): _make_run(
+            0, stdout="feat/foo\n",
+        ),
+        ("git", "rev-list", "HEAD..origin/main", "--count"): _make_run(
+            0, stdout="0\n",
+        ),
+    }
+    with patch(
+        "server.lifecycle.updater.subprocess.run",
+        side_effect=_make_subprocess_dispatcher(responses),
+    ):
+        rc = updater._update_via_git(Path("/fake"))
+
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "feat/foo" in captured.out
+    assert "release branch `main`" in captured.out
+    assert "No new commits" in captured.out
+
+
+def test_update_via_git_on_main_with_updates_still_pulls(
+    capsys, stub_quern_dev_no_signal, monkeypatch,
+):
+    """Regression guard: the happy path (on main, behind, pull-and-rebuild)
+    must still work after the #40 rewrite."""
+    from server.lifecycle import updater
+
+    monkeypatch.setattr(updater, "_read_local_version", lambda root: "0.13.5")
+
+    responses = {
+        ("git", "rev-parse", "HEAD"): _make_run(0, stdout="deadbeef\n"),
+        ("git", "fetch", "origin"): _make_run(0),
+        ("git", "rev-parse", "--abbrev-ref", "HEAD"): _make_run(
+            0, stdout="main\n",
+        ),
+        ("git", "rev-list", "HEAD..origin/main", "--count"): _make_run(
+            0, stdout="2\n",
+        ),
+        ("git", "pull", "--ff-only"): _make_run(0, stdout="Updating ...\n"),
+    }
+    with patch(
+        "server.lifecycle.updater.subprocess.run",
+        side_effect=_make_subprocess_dispatcher(responses),
+    ) as run_mock:
+        rc = updater._update_via_git(Path("/fake"))
+
+    assert rc == 0  # Will trigger rebuild
+    pull_calls = [
+        c for c in run_mock.call_args_list
+        if c.args[0][:2] == ["git", "pull"]
+    ]
+    assert len(pull_calls) == 1
+    captured = capsys.readouterr()
+    assert "0.13.5" in captured.out


### PR DESCRIPTION
Closes #40.

## Summary

For git-cloned installs, `_check_via_git` was counting commits behind `origin/<current-branch>` (the local branch's tracking ref). On any non-`main` branch the updater silently reported "Already up to date" no matter how many real releases shipped on main. The new `update_quern` MCP tool (#39) made this very visible — Claude could ask Quern to update itself, and the answer would be confidently wrong whenever the user was off main.

This PR adopts **approach (A)** from the issue: always check against `origin/main`, and when the user isn't on `main`, **warn but don't auto-switch branches and don't pull** — that's the dev-clone-safe choice.

## Behavior

On a feature branch with updates available on main:
```
You're on branch `feat/foo`. `origin/main` is 3 commits ahead.
Switch with `git checkout main` and rerun `quern update` to
apply — or stay on `feat/foo` if you're working on Quern itself.
```

On a feature branch with no updates pending:
```
You're on branch `feat/foo` (not the release branch `main`).
No new commits on `origin/main`.
```

On main: existing happy path unchanged — pulls and rebuilds.

The check is always truthful about what's available on main. The pull/rebuild step only runs when the user is actually on a branch where pulling would apply those commits — which today means `main`. The channels work in #41 generalizes this to "any of the recognized release branches per the user's configured channel."

## Why this shape

- `git pull --ff-only` operates on the **current branch's** upstream, not on `origin/main`. So a pull on `feat/foo` couldn't apply the updates we just counted — silently doing it would be wrong.
- Auto-switching branches (`git checkout main && git pull`) would clobber in-progress work on a dev clone. Dev clones are the dominant case for non-main branches.
- A confused-but-truthful state ("I see updates on main; I can't pull them because you're on feat/foo") is strictly better than a confidently-wrong state ("you're up to date").

## Out of scope

- Making the release branch configurable per channel — that's #41.
- Managed-install detection so `quern update` can auto-switch on installs Quern owns — also #41.
- The MCP-vs-Python version skew warning — already in #39.

## Changes

- `server/lifecycle/updater.py`:
  - New `RELEASE_BRANCH = "main"` constant (will become a config field in #41).
  - `_check_via_git` always invokes `git rev-list HEAD..origin/main --count`, regardless of current branch. Removed the dead fallback to `origin/main` (it only ever fired when origin didn't have a tracking branch, which doesn't apply now that we always go to main).
  - `_update_via_git` branches on `current_branch == RELEASE_BRANCH` and prints the appropriate warning + returns `rc=2` (skip rebuild) when off-branch.

## Test plan

- [x] **3 unit tests for `_check_via_git`**: rev-list invokes `origin/main` regardless of current branch (the key assertion), zero-behind on main, fetch failure returns None.
- [x] **3 unit tests for `_update_via_git`**: feature branch with updates warns and skips pull (asserting `git pull` is never invoked), feature branch without updates emits the non-release-branch note, on-main happy path still pulls and rebuilds.
- [x] **Full suite**: 1370 passed locally.
- [x] **ruff** clean (pre-commit hook).