### PR TITLE
feat: update channels (stable / beta) for opt-in prerelease testing

### DIFF
--- a/docs/release-channels.md
+++ b/docs/release-channels.md
@@ -1,0 +1,232 @@
+# Release channels
+
+Quern ships on two update channels: `stable` (the default) and `beta` (opt-in
+prerelease testing). This doc covers both **what users see** and **how
+maintainers cut releases** on each channel.
+
+## TL;DR
+
+| Channel  | What it tracks (git installs)                  | What it tracks (tarball installs)                  |
+|----------|------------------------------------------------|----------------------------------------------------|
+| `stable` | `origin/release/stable`                        | GitHub Releases marked **not prerelease**          |
+| `beta`   | `origin/release/beta`                          | GitHub Releases marked **prerelease**              |
+
+Switch with `quern set-channel beta` (or back with `quern set-channel stable`).
+Setting the channel updates `~/.quern/config.json`; nothing else changes until
+the next `quern update`.
+
+---
+
+## For users
+
+### Default behavior
+
+Out of the box, every install is on `stable`. New users never have to think
+about channels.
+
+### Opting into beta
+
+```sh
+quern set-channel beta
+```
+
+The next `quern update` will pull from the beta channel:
+
+- **Git-clone install:** you must be checked out on `release/beta` (or already
+  on `main` and willing to switch). If you're on a feature branch, the updater
+  will tell you it sees beta updates available but won't auto-switch your
+  workspace — that's a developer-clone-safety choice.
+- **Tarball install:** the updater downloads whichever GitHub Release is the
+  newest one flagged `prerelease: true`. If no prereleases exist yet, you
+  silently fall through to the latest stable so you never see *older* content
+  than a stable user.
+
+### Switching back
+
+```sh
+quern set-channel stable
+quern update
+```
+
+Same flow in reverse. Stable is always a safe target.
+
+### What channel am I on?
+
+```sh
+quern set-channel        # no argument — prints current channel
+```
+
+Or from inside Claude Code:
+
+> "What's my Quern channel?"
+
+The MCP `ensure_server` tool surfaces channel + update status; Claude reads it
+in the normal course of any session.
+
+---
+
+## For maintainers — release-cut procedure
+
+### Channel branches: where they live, what they track
+
+Two reserved branches on `origin`:
+
+- **`release/stable`** — pointer branch for the stable channel. Should be
+  fast-forwarded to the commit corresponding to each tagged stable release
+  (`vN.M.K`).
+- **`release/beta`** — pointer branch for the beta channel. Fast-forwarded
+  whenever you want beta users to see new content — either a tagged prerelease
+  (`vN.M.K-beta.X`), or just an arbitrary commit on `main` you want beta users
+  to try.
+
+Both branches are descendants of `main` at all times. Neither contains commits
+that aren't already in `main`.
+
+### Cutting a stable release
+
+```sh
+# 1. Bump version, finalize CHANGELOG, commit on main.
+git switch main
+# (edit pyproject.toml, mcp/package.json, mcp/package-lock.json, CHANGELOG.md)
+git commit -am "Bump version to vN.M.K and finalize CHANGELOG"
+git push origin main
+
+# 2. Tag the release commit.
+git tag -a vN.M.K -m "vN.M.K — short release headline"
+git push origin vN.M.K
+
+# 3. Fast-forward release/stable to the same commit.
+#    *** Do this BEFORE creating the GitHub Release. ***
+#    Once a commit has a Release attached, GitHub silently refuses pushes
+#    that point any branch at that exact commit (see "GitHub quirk" below).
+git push origin main:refs/heads/release/stable
+
+# 4. Now create the GitHub Release.
+gh release create vN.M.K --title "vN.M.K — short release headline" --notes-file RELEASE_NOTES.md
+```
+
+**Why the ordering matters:** see the *GitHub quirk* section. Once step 4 has
+happened, you cannot retroactively move `release/stable` to that commit. The
+fast-forward in step 3 has to happen first.
+
+### Cutting a beta release
+
+There are two common beta flavors:
+
+**(a) Tagged prerelease** — when you want a citable beta version that tarball
+users can install:
+
+```sh
+# Tag on the commit you want beta users to land on (usually main HEAD).
+git tag -a vN.M.K-beta.X -m "vN.M.K beta X"
+git push origin vN.M.K-beta.X
+
+# Fast-forward release/beta. Must happen BEFORE the Release is created.
+git push origin <commit-sha>:refs/heads/release/beta
+
+# Create the GitHub Release with --prerelease so the tarball updater
+# picks it up only for beta channel users.
+gh release create vN.M.K-beta.X --prerelease \
+  --title "vN.M.K beta X" --notes-file BETA_NOTES.md
+```
+
+**(b) Untagged beta advance** — when you just want git-clone beta users to see
+recent main changes without minting a prerelease version:
+
+```sh
+# Fast-forward release/beta to whatever main commit you want beta users on.
+git push origin main:refs/heads/release/beta
+```
+
+Tarball beta users are unaffected by (b) since they're driven by the GitHub
+Releases API.
+
+### Why are both `release/*` branches currently at main HEAD?
+
+When this channels work first shipped, GitHub's `release/stable` and
+`release/beta` branches were created at the then-current `main` HEAD, not at
+the most recent stable tag. The reason is the *GitHub quirk* below.
+
+The practical effect: until you cut the next stable release using the
+procedure above, "stable channel" effectively means "the post-release main
+HEAD at the moment release/stable was last advanced." That's a slightly looser
+interpretation than "the latest tagged commit," but it's functionally fine —
+every commit on main has passed CI, and once you cut the next release the
+strict semantics kick in.
+
+### The GitHub quirk — read this once
+
+There is an **undocumented** GitHub platform behavior we hit while
+bootstrapping the channel branches:
+
+> **You cannot create or move a branch to point at a commit that is the
+> target of a published Release.** The push is silently rejected with
+> `remote rejected ... (failed)` and the REST API returns
+> `422: Reference update failed` with no detail. The behavior persists even
+> after deleting the Release — the platform-level marker doesn't go away.
+
+We confirmed this by:
+
+1. Pushing a branch from the parent of `v0.13.4` — worked.
+2. Pushing a branch from `v0.13.4` itself — rejected.
+3. Pushing a branch from a freshly-created tag we'd just made on a non-tagged
+   commit — worked.
+4. Pushing a branch from `v0.13.3` (also a Release commit) — rejected.
+5. Deleting the `v0.13.4` Release and trying again — still rejected.
+
+The implication is the ordering rule above: **fast-forward `release/*` to the
+release commit BEFORE creating the GitHub Release object**. Doing it in the
+other order locks you out.
+
+`gh ruleset check <branch>` reports zero rules, so this isn't surfaceable
+through normal policy inspection. It's worth filing with GitHub Support if it
+ever materially blocks something.
+
+### Helper script (optional)
+
+Save the ordering and the gotcha in one place so future-you doesn't have to
+remember:
+
+```sh
+#!/bin/bash
+# scripts/cut-stable-release.sh — usage: ./scripts/cut-stable-release.sh vN.M.K
+set -euo pipefail
+TAG="$1"
+
+# 1. Tag
+git tag -a "$TAG" -m "$TAG"
+git push origin "$TAG"
+
+# 2. Fast-forward release/stable — MUST happen before step 3
+git push origin main:refs/heads/release/stable
+
+# 3. Now create the Release
+gh release create "$TAG" --title "$TAG" --notes "see CHANGELOG.md"
+
+echo "release/stable now at $(git rev-parse "$TAG")"
+```
+
+(Same shape works for `release/beta`; swap `--prerelease` in for step 3.)
+
+---
+
+## How the code knows about channels
+
+- `~/.quern/config.json` field `update_channel`: `"stable"` (default) or
+  `"beta"`. Persisted by `quern set-channel`, `server.config.set_update_channel`,
+  and the `PUT /api/v1/system/channel` endpoint.
+- `server.lifecycle.updater._get_release_branch()` resolves the configured
+  channel to `release/<channel>`.
+- `_update_via_git()` compares HEAD against `origin/<release_branch>` and
+  warns when the user isn't on a release branch (no auto-switch).
+- `_update_via_tarball()` calls `_fetch_latest_release(channel)`:
+  - `stable` → `/releases/latest` (GitHub-defined as latest non-prerelease).
+  - `beta` → `/releases`, picks the first non-draft prerelease; falls through
+    to the latest stable when no prereleases exist.
+
+## Related
+
+- Issue #41 — original channels proposal
+- Issue #40 — the upstream-tracking bug that motivated the `_get_release_branch`
+  refactor
+- PR #43 — channels implementation

--- a/mcp/src/http.ts
+++ b/mcp/src/http.ts
@@ -1,7 +1,7 @@
 import { discoverServer } from "./config.js";
 
 export async function apiRequest(
-  method: "GET" | "POST" | "PATCH" | "DELETE",
+  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE",
   path: string,
   params?: Record<string, string | number | boolean | string[] | undefined>,
   body?: unknown,

--- a/mcp/src/tools/system.ts
+++ b/mcp/src/tools/system.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
 import { apiRequest } from "../http.js";
 import { strictParams } from "./helpers.js";
 
@@ -7,7 +8,7 @@ export function registerSystemTools(server: McpServer): void {
     "update_quern",
     {
       description:
-        `Update Quern to the latest release. Launches the equivalent of "quern update" — pulls the latest source (or fetches the release tarball), reinstalls Python deps, rebuilds the MCP server, and restarts the daemon. The HTTP call returns immediately; the actual upgrade runs in a detached child and takes ~30-60 seconds. The Quern server will restart during that window, so the next MCP tool call may fail until it's back up. Reconnect by retrying ensure_server. Only call this after the user has confirmed they want to update — typically prompted by an "update_available" hint in ensure_server's response.`,
+        `Update Quern to the latest release on the user's configured channel (stable or beta). Launches the equivalent of "quern update" — pulls the latest source (or fetches the release tarball), reinstalls Python deps, rebuilds the MCP server, and restarts the daemon. The HTTP call returns immediately; the actual upgrade runs in a detached child and takes ~30-60 seconds. The Quern server will restart during that window, so the next MCP tool call may fail until it's back up. Reconnect by retrying ensure_server. Only call this after the user has confirmed they want to update — typically prompted by an "update_available" hint in ensure_server's response.`,
       inputSchema: strictParams({}),
     },
     async () => {
@@ -24,6 +25,44 @@ export function registerSystemTools(server: McpServer): void {
             {
               type: "text" as const,
               text: `Error launching update: ${e instanceof Error ? e.message : String(e)}\n\nFall back to running "quern update" in a terminal manually.`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.registerTool(
+    "set_update_channel",
+    {
+      description:
+        `Set the user's Quern update channel preference (stable or beta). "stable" tracks the release/stable branch (only tagged releases); "beta" tracks release/beta for opt-in early testing. Setting the channel only updates ~/.quern/config.json — it does not switch git branches or apply an update. After flipping to beta, the next call to update_quern (and any future periodic check) will compare against the beta branch. Only call this after the user has explicitly asked to change channels.`,
+      inputSchema: strictParams({
+        channel: z.enum(["stable", "beta"]).describe(
+          "stable (default, recommended) or beta (opt-in prerelease)",
+        ),
+      }),
+    },
+    async ({ channel }) => {
+      try {
+        const data = await apiRequest(
+          "PUT",
+          "/api/v1/system/channel",
+          undefined,
+          { channel },
+        );
+        return {
+          content: [
+            { type: "text" as const, text: JSON.stringify(data, null, 2) },
+          ],
+        };
+      } catch (e) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Error setting channel: ${e instanceof Error ? e.message : String(e)}`,
             },
           ],
           isError: true,

--- a/server/__main__.py
+++ b/server/__main__.py
@@ -285,6 +285,45 @@ def _cmd_grant_full_perms() -> int:
     return 0
 
 
+def _cmd_set_channel(args: list[str]) -> int:
+    """Persist the update channel preference (``stable`` or ``beta``).
+
+    Usage:
+        quern set-channel <name>
+        quern set-channel            # print the current channel
+
+    Setting the channel only updates ``~/.quern/config.json``; it does
+    not switch git branches or apply an update. Run ``quern update``
+    afterwards (and, on a dev clone, switch branches manually) to pick
+    up the new channel's content.
+    """
+    from server.config import (
+        VALID_UPDATE_CHANNELS,
+        channel_to_release_branch,
+        get_update_channel,
+        set_update_channel,
+    )
+
+    if not args:
+        current = get_update_channel()
+        branch = channel_to_release_branch(current)
+        print(f"Current update channel: {current} (tracks origin/{branch})")
+        print(f"Valid channels: {', '.join(VALID_UPDATE_CHANNELS)}")
+        return 0
+
+    target = args[0]
+    try:
+        set_update_channel(target)
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+
+    branch = channel_to_release_branch(target)
+    print(f"Update channel set to: {target} (tracks origin/{branch})")
+    print("Run `quern update` to apply changes from this channel.")
+    return 0
+
+
 def _cmd_install_precommit_hook() -> int:
     """Install the pre-commit checklist hook into ~/.claude/settings.json.
 
@@ -412,6 +451,9 @@ def main() -> None:
     if len(sys.argv) >= 2 and sys.argv[1] == "update":
         from server.lifecycle.updater import run_update
         sys.exit(run_update())
+
+    if len(sys.argv) >= 2 and sys.argv[1] == "set-channel":
+        sys.exit(_cmd_set_channel(sys.argv[2:]))
 
     if len(sys.argv) >= 2 and sys.argv[1] == "tunneld":
         from server.device.tunneld import cli_tunneld

--- a/server/api/system.py
+++ b/server/api/system.py
@@ -14,9 +14,15 @@ import subprocess
 import sys
 from pathlib import Path
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
+from server.config import (
+    VALID_UPDATE_CHANNELS,
+    channel_to_release_branch,
+    get_update_channel,
+    set_update_channel,
+)
 from server.lifecycle.update_check import read_update_info
 
 logger = logging.getLogger("quern-debug-server.system")
@@ -37,6 +43,20 @@ class UpdateStatusResponse(BaseModel):
     latest_version: str | None = None
     checked_at: str | None = None
     message: str | None = None
+    channel: str = "stable"  # The user's configured update channel (#41)
+    release_branch: str = "release/stable"  # Branch the channel tracks
+
+
+class UpdateChannelResponse(BaseModel):
+    """Current update channel preference."""
+
+    channel: str  # "stable" | "beta"
+    release_branch: str  # The git branch this channel tracks
+    valid_channels: list[str]
+
+
+class SetUpdateChannelRequest(BaseModel):
+    channel: str  # "stable" | "beta"
 
 
 class UpdateTriggerResponse(BaseModel):
@@ -57,16 +77,56 @@ async def update_status() -> UpdateStatusResponse:
     Cached in ``~/.quern/update-info.json``; refreshed by the background
     task every 24 hours (see ``server/lifecycle/update_check.py``). Cheap
     to call — no network round-trip.
+
+    Also includes the configured update channel and the git branch it
+    tracks so MCP clients can mention things like *"you're on stable;
+    beta has 0.13.5-beta.2 available"* once the channels work is wired
+    end-to-end.
     """
+    channel = get_update_channel()
+    release_branch = channel_to_release_branch(channel)
     info = read_update_info()
     if info is None:
-        return UpdateStatusResponse()
+        return UpdateStatusResponse(channel=channel, release_branch=release_branch)
     return UpdateStatusResponse(
         update_available=bool(info.get("update_available")),
         current_version=info.get("current_version"),
         latest_version=info.get("latest_version"),
         checked_at=info.get("checked_at"),
         message=info.get("message"),
+        channel=channel,
+        release_branch=release_branch,
+    )
+
+
+@router.get("/channel", response_model=UpdateChannelResponse)
+async def get_channel() -> UpdateChannelResponse:
+    """Return the user's current update channel preference."""
+    channel = get_update_channel()
+    return UpdateChannelResponse(
+        channel=channel,
+        release_branch=channel_to_release_branch(channel),
+        valid_channels=list(VALID_UPDATE_CHANNELS),
+    )
+
+
+@router.put("/channel", response_model=UpdateChannelResponse)
+async def put_channel(body: SetUpdateChannelRequest) -> UpdateChannelResponse:
+    """Set the update channel preference.
+
+    Persists to ``~/.quern/config.json``. Does not switch git branches
+    or apply an immediate update — that's a separate call to ``POST
+    /update`` once the user is ready (and, for dev clones, has
+    explicitly switched their branch).
+    """
+    try:
+        set_update_channel(body.channel)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return UpdateChannelResponse(
+        channel=body.channel,
+        release_branch=channel_to_release_branch(body.channel),
+        valid_channels=list(VALID_UPDATE_CHANNELS),
     )
 
 

--- a/server/config.py
+++ b/server/config.py
@@ -70,6 +70,52 @@ def get_default_device_family() -> str:
     return read_user_config().get("default_device_family", "iPhone")
 
 
+# ---------------------------------------------------------------------------
+# Update channel — `stable` (default) or `beta`. Drives which branch
+# `quern update` checks against and which GitHub release filter the
+# tarball updater uses (#41).
+# ---------------------------------------------------------------------------
+
+VALID_UPDATE_CHANNELS = ("stable", "beta")
+DEFAULT_UPDATE_CHANNEL = "stable"
+
+
+def get_update_channel() -> str:
+    """Return the configured update channel, defaulting to ``stable``.
+
+    Unknown values fall back to the default rather than throwing — a
+    typo in config.json shouldn't break the daemon.
+    """
+    raw = read_user_config().get("update_channel")
+    if isinstance(raw, str) and raw in VALID_UPDATE_CHANNELS:
+        return raw
+    return DEFAULT_UPDATE_CHANNEL
+
+
+def set_update_channel(channel: str) -> None:
+    """Persist the update channel preference. Raises ValueError on an
+    unknown channel name to prevent typos from silently no-op'ing."""
+    if channel not in VALID_UPDATE_CHANNELS:
+        raise ValueError(
+            f"Unknown update channel {channel!r}. "
+            f"Valid: {', '.join(VALID_UPDATE_CHANNELS)}"
+        )
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    config = read_user_config()
+    config["update_channel"] = channel
+    USER_CONFIG_FILE.write_text(json.dumps(config, indent=2) + "\n")
+
+
+def channel_to_release_branch(channel: str) -> str:
+    """Map a channel name to its reserved release pointer branch.
+
+    Maintainers fast-forward these branches on each release cut —
+    ``release/stable`` to the latest tagged stable release, ``release/
+    beta`` to the latest prerelease commit (or main HEAD).
+    """
+    return f"release/{channel}"
+
+
 def get_local_capture_processes() -> list[str]:
     """Return the list of process names for local capture mode.
 

--- a/server/lifecycle/updater.py
+++ b/server/lifecycle/updater.py
@@ -90,30 +90,35 @@ def _check_via_quern_dev(head_sha: str) -> bool | None:
         return None
 
 
-# The git branch that ships releases. Compared against directly when
-# answering "is there a Quern update available", regardless of which
-# branch the user happens to have checked out. Hardcoded for now; the
-# channels work (#41) will make this configurable so users can opt into
-# a `release/beta` track without leaving the install path they have.
-RELEASE_BRANCH = "main"
+def _get_release_branch() -> str:
+    """Return the branch the user's update channel tracks.
+
+    Reads ``update_channel`` from ``~/.quern/config.json`` (#41). Default
+    is ``stable`` → ``release/stable``; opt-in to ``beta`` → ``release/
+    beta`` via ``quern set-channel beta``. Maintainers fast-forward
+    these branches on each release cut.
+    """
+    from server.config import channel_to_release_branch, get_update_channel
+    return channel_to_release_branch(get_update_channel())
 
 
 def _check_via_git(project_root: Path) -> tuple[bool, str, int] | None:
     """Fall back to git fetch to check for updates.
 
-    Always compares HEAD against ``origin/<RELEASE_BRANCH>``, not against
-    the current branch's tracking ref — closes #40. A user on a non-
-    release branch (e.g. a developer hacking on a feature) was previously
-    told "already up to date" when the only thing that was up-to-date was
-    their feature branch vs its own remote; new releases on main were
-    silently ignored.
+    Always compares HEAD against ``origin/<release_branch>``, where the
+    release branch is determined by the user's configured channel
+    (``stable`` → ``release/stable``, ``beta`` → ``release/beta``).
+    Closes #40 (the original bug used the current branch's tracking ref,
+    silently missing real releases for users on a feature branch) and
+    introduces the channel selection from #41.
 
     Returns ``(has_updates, current_branch, behind_count)`` or None on
     failure. ``has_updates`` and ``behind_count`` are always measured
-    against ``origin/<RELEASE_BRANCH>``; ``current_branch`` is reported
+    against ``origin/<release_branch>``; ``current_branch`` is reported
     so the caller can decide whether to actually pull (only safe on the
     release branch) or just warn (any other branch).
     """
+    release_branch = _get_release_branch()
     result = subprocess.run(
         ["git", "fetch", "origin"],
         cwd=str(project_root),
@@ -138,10 +143,10 @@ def _check_via_git(project_root: Path) -> tuple[bool, str, int] | None:
         return None
     current_branch = result.stdout.strip()
 
-    # Count commits behind origin/<RELEASE_BRANCH> — always, regardless
+    # Count commits behind origin/<release_branch> — always, regardless
     # of which branch is currently checked out.
     result = subprocess.run(
-        ["git", "rev-list", f"HEAD..origin/{RELEASE_BRANCH}", "--count"],
+        ["git", "rev-list", f"HEAD..origin/{release_branch}", "--count"],
         cwd=str(project_root),
         capture_output=True,
         text=True,
@@ -149,7 +154,7 @@ def _check_via_git(project_root: Path) -> tuple[bool, str, int] | None:
     )
     if result.returncode != 0:
         print(
-            f"Error: could not compare HEAD against origin/{RELEASE_BRANCH} "
+            f"Error: could not compare HEAD against origin/{release_branch} "
             f"({result.stderr.strip()})"
         )
         return None
@@ -184,28 +189,29 @@ def _update_via_git(project_root: Path) -> int:
         return 1
 
     has_updates, branch, behind_count = git_check
+    release_branch = _get_release_branch()
 
     # Approach (A) from #40: when the user is on a non-release branch
     # (typical for dev clones), the commit count is now truthful about
-    # `origin/<RELEASE_BRANCH>`, but pulling here would be wrong — `git
+    # `origin/<release_branch>`, but pulling here would be wrong — `git
     # pull --ff-only` tracks the current branch's upstream, not the
     # release branch. So we report what's available and let the user
     # decide whether to switch.
-    if branch != RELEASE_BRANCH:
+    if branch != release_branch:
         if has_updates:
             plural = "s" if behind_count != 1 else ""
             print(
                 f"You're on branch `{branch}`. "
-                f"`origin/{RELEASE_BRANCH}` is {behind_count} commit{plural} ahead. "
-                f"Switch with `git checkout {RELEASE_BRANCH}` and rerun "
+                f"`origin/{release_branch}` is {behind_count} commit{plural} ahead. "
+                f"Switch with `git checkout {release_branch}` and rerun "
                 f"`quern update` to apply — or stay on `{branch}` "
                 f"if you're working on Quern itself."
             )
         else:
             print(
                 f"You're on branch `{branch}` "
-                f"(not the release branch `{RELEASE_BRANCH}`). "
-                f"No new commits on `origin/{RELEASE_BRANCH}`."
+                f"(not the release branch `{release_branch}`). "
+                f"No new commits on `origin/{release_branch}`."
             )
         return 2  # Skip rebuild — current workspace isn't pull-able
 

--- a/server/lifecycle/updater.py
+++ b/server/lifecycle/updater.py
@@ -48,16 +48,43 @@ def _read_local_version(project_root: Path) -> str | None:
     return None
 
 
-def _fetch_latest_release() -> tuple[str, str] | None:
-    """Fetch latest release version and tarball URL from GitHub.
+def _fetch_latest_release(channel: str = "stable") -> tuple[str, str] | None:
+    """Fetch the latest release for the user's channel from GitHub.
 
-    Returns (version, tarball_url) or None on failure.
+    For ``stable``: hits ``/releases/latest``, which is GitHub-defined as
+    the most recent release with ``prerelease: false``.
+
+    For ``beta``: hits ``/releases`` and picks the topmost entry with
+    ``prerelease: true``. Beta users get prereleases when they exist; if
+    there are none, returns the stable latest so beta users never see
+    older content than stable users.
+
+    Returns ``(version, tarball_url)`` or None on failure.
     """
     try:
-        url = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
+        if channel == "beta":
+            url = f"https://api.github.com/repos/{GITHUB_REPO}/releases"
+        else:
+            url = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
         req = urllib.request.Request(url, headers={"User-Agent": "quern-update/1.0"})
         with urllib.request.urlopen(req, timeout=10) as resp:
             data = json.loads(resp.read().decode())
+
+        if channel == "beta":
+            # /releases returns an array sorted newest-first. Pick the
+            # first prerelease entry; fall back to stable if there are
+            # no prereleases yet.
+            prerelease = next(
+                (r for r in data if r.get("prerelease") and not r.get("draft")),
+                None,
+            )
+            data = prerelease if prerelease else next(
+                (r for r in data if not r.get("prerelease") and not r.get("draft")),
+                None,
+            )
+            if data is None:
+                return None
+
         tag = data.get("tag_name", "")
         version = tag.lstrip("v")
         tarball_url = data.get("tarball_url", "")
@@ -259,20 +286,23 @@ def _update_via_git(project_root: Path) -> int:
 
 def _update_via_tarball(project_root: Path) -> int:
     """Update a tarball-based install by downloading the latest release."""
-    print("Checking for updates...")
+    from server.config import get_update_channel
+    channel = get_update_channel()
+
+    print(f"Checking for updates on channel '{channel}'...")
 
     current_version = _read_local_version(project_root)
-    release = _fetch_latest_release()
+    release = _fetch_latest_release(channel)
     if release is None:
         return 1
 
     latest_version, tarball_url = release
 
     if current_version == latest_version:
-        print(f"Already up to date (v{current_version}).")
+        print(f"Already up to date (v{current_version}, channel '{channel}').")
         return 2  # No update needed
 
-    print(f"Updating v{current_version or 'unknown'} → v{latest_version}...")
+    print(f"Updating v{current_version or 'unknown'} → v{latest_version} (channel '{channel}')...")
 
     # Download tarball
     tmpdir = tempfile.mkdtemp()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,53 @@
+"""Tests for server.config — user-config persistence helpers.
+
+Focused on the channel helpers added in #41. Other config helpers in
+this module are exercised indirectly by the routes that use them.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolated_config(tmp_path, monkeypatch):
+    """Redirect ~/.quern/config.json to a temp dir for every test."""
+    monkeypatch.setattr("server.config.CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(
+        "server.config.USER_CONFIG_FILE", tmp_path / "config.json",
+    )
+    return tmp_path
+
+
+def test_get_update_channel_defaults_to_stable():
+    from server.config import get_update_channel
+    assert get_update_channel() == "stable"
+
+
+def test_set_update_channel_round_trip():
+    from server.config import get_update_channel, set_update_channel
+    set_update_channel("beta")
+    assert get_update_channel() == "beta"
+
+
+def test_set_update_channel_rejects_unknown_name():
+    from server.config import set_update_channel
+    with pytest.raises(ValueError, match="Unknown update channel"):
+        set_update_channel("nightly")
+
+
+def test_unknown_channel_in_config_falls_back_to_default(isolated_config):
+    """A typo in config.json should not break the daemon — falls back to
+    the safe default rather than throwing."""
+    import json
+    (isolated_config / "config.json").write_text(
+        json.dumps({"update_channel": "very_unstable"})
+    )
+    from server.config import get_update_channel
+    assert get_update_channel() == "stable"
+
+
+def test_channel_to_release_branch():
+    from server.config import channel_to_release_branch
+    assert channel_to_release_branch("stable") == "release/stable"
+    assert channel_to_release_branch("beta") == "release/beta"

--- a/tests/test_system_api.py
+++ b/tests/test_system_api.py
@@ -141,3 +141,104 @@ async def test_update_trigger_reports_skipped_on_oserror(
     assert data["status"] == "skipped"
     assert data["pid"] is None
     assert "permission denied" in data["note"]
+
+
+# ---------------------------------------------------------------------------
+# /channel — get/put
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_config(tmp_path, monkeypatch):
+    """Redirect ~/.quern/config.json to a temp dir so tests don't mutate
+    the real user config."""
+    monkeypatch.setattr("server.config.CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(
+        "server.config.USER_CONFIG_FILE", tmp_path / "config.json",
+    )
+    return tmp_path
+
+
+@pytest.mark.asyncio
+async def test_get_channel_returns_default_when_unset(
+    app, auth_headers, isolated_config,
+):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/v1/system/channel", headers=auth_headers)
+        data = resp.json()
+
+    assert data["channel"] == "stable"
+    assert data["release_branch"] == "release/stable"
+    assert data["valid_channels"] == ["stable", "beta"]
+
+
+@pytest.mark.asyncio
+async def test_put_channel_persists_and_returns_new_state(
+    app, auth_headers, isolated_config,
+):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.put(
+            "/api/v1/system/channel",
+            headers=auth_headers,
+            json={"channel": "beta"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+
+    assert data["channel"] == "beta"
+    assert data["release_branch"] == "release/beta"
+
+    # Confirm persistence: subsequent GET should return the same value.
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/v1/system/channel", headers=auth_headers)
+        assert resp.json()["channel"] == "beta"
+
+
+@pytest.mark.asyncio
+async def test_put_channel_rejects_unknown_channel(
+    app, auth_headers, isolated_config,
+):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.put(
+            "/api/v1/system/channel",
+            headers=auth_headers,
+            json={"channel": "nightly"},
+        )
+
+    assert resp.status_code == 400
+    assert "Unknown update channel" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_update_status_includes_channel(
+    app, auth_headers, isolated_config, monkeypatch,
+):
+    """update-status must surface the configured channel + release branch
+    so MCP clients can render them inline without an extra round-trip."""
+    monkeypatch.setattr(
+        "server.api.system.read_update_info",
+        lambda: {
+            "checked_at": "2026-06-05T19:00:00+00:00",
+            "current_version": "0.13.4",
+            "latest_version": "0.13.5",
+            "update_available": True,
+            "message": "Update available",
+        },
+    )
+    from server.config import set_update_channel
+    set_update_channel("beta")
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/api/v1/system/update-status", headers=auth_headers,
+        )
+        data = resp.json()
+
+    assert data["channel"] == "beta"
+    assert data["release_branch"] == "release/beta"
+    assert data["update_available"] is True
+    assert data["latest_version"] == "0.13.5"

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -218,6 +218,122 @@ def test_update_via_git_on_feature_branch_with_no_updates_notes_and_skips(
     assert "No new commits" in captured.out
 
 
+# ---------------------------------------------------------------------------
+# Tarball updater — channel-aware release selection
+# ---------------------------------------------------------------------------
+
+
+class _FakeUrlResp:
+    """Minimal context-manager wrapper for the urlopen patch."""
+    def __init__(self, payload):
+        self._payload = payload
+    def __enter__(self):
+        return self
+    def __exit__(self, *args):
+        return False
+    def read(self):
+        import json as _json
+        return _json.dumps(self._payload).encode()
+
+
+def test_fetch_latest_release_stable_hits_releases_latest(monkeypatch):
+    """Stable channel must hit /releases/latest — GitHub's stable-only
+    feed. The previous unconditional behavior is unchanged."""
+    from server.lifecycle import updater
+
+    captured_urls: list[str] = []
+
+    def fake_urlopen(req, **kwargs):
+        captured_urls.append(req.full_url)
+        return _FakeUrlResp({
+            "tag_name": "v0.13.4",
+            "tarball_url": "https://example.com/v0.13.4.tar.gz",
+            "prerelease": False,
+        })
+
+    monkeypatch.setattr(
+        updater.urllib.request, "urlopen", fake_urlopen,
+    )
+
+    result = updater._fetch_latest_release("stable")
+    assert result == ("0.13.4", "https://example.com/v0.13.4.tar.gz")
+    assert captured_urls == [
+        "https://api.github.com/repos/quern-dev/quern/releases/latest",
+    ]
+
+
+def test_fetch_latest_release_beta_picks_first_prerelease(monkeypatch):
+    """Beta channel must scan /releases and pick the first prerelease.
+    Stable entries newer than the topmost prerelease are deliberately
+    NOT chosen — that's how beta diverges from stable."""
+    from server.lifecycle import updater
+
+    def fake_urlopen(req, **kwargs):
+        return _FakeUrlResp([
+            {"tag_name": "v0.13.5", "tarball_url": "stable.tgz", "prerelease": False},
+            {"tag_name": "v0.13.6-beta.1", "tarball_url": "beta1.tgz", "prerelease": True},
+            {"tag_name": "v0.13.4", "tarball_url": "stable-older.tgz", "prerelease": False},
+        ])
+
+    monkeypatch.setattr(
+        updater.urllib.request, "urlopen", fake_urlopen,
+    )
+
+    result = updater._fetch_latest_release("beta")
+    assert result == ("0.13.6-beta.1", "beta1.tgz")
+
+
+def test_fetch_latest_release_beta_falls_back_to_stable_when_no_prereleases(
+    monkeypatch,
+):
+    """If no prerelease exists yet, beta users must NOT regress to nothing.
+    Fall through to the latest stable so they never see older content than
+    a stable user."""
+    from server.lifecycle import updater
+
+    def fake_urlopen(req, **kwargs):
+        return _FakeUrlResp([
+            {"tag_name": "v0.13.5", "tarball_url": "stable.tgz", "prerelease": False},
+            {"tag_name": "v0.13.4", "tarball_url": "older.tgz", "prerelease": False},
+        ])
+
+    monkeypatch.setattr(
+        updater.urllib.request, "urlopen", fake_urlopen,
+    )
+
+    result = updater._fetch_latest_release("beta")
+    assert result == ("0.13.5", "stable.tgz")
+
+
+def test_fetch_latest_release_beta_skips_draft_prereleases(monkeypatch):
+    """Drafts are not user-visible releases — beta channel must ignore
+    them even when they're flagged prerelease."""
+    from server.lifecycle import updater
+
+    def fake_urlopen(req, **kwargs):
+        return _FakeUrlResp([
+            {
+                "tag_name": "v0.13.6-beta.2",
+                "tarball_url": "draft.tgz",
+                "prerelease": True,
+                "draft": True,
+            },
+            {
+                "tag_name": "v0.13.6-beta.1",
+                "tarball_url": "published.tgz",
+                "prerelease": True,
+                "draft": False,
+            },
+        ])
+
+    monkeypatch.setattr(
+        updater.urllib.request, "urlopen", fake_urlopen,
+    )
+
+    result = updater._fetch_latest_release("beta")
+    assert result == ("0.13.6-beta.1", "published.tgz")
+
+
 def test_update_via_git_on_release_branch_with_updates_still_pulls(
     capsys, stub_quern_dev_no_signal, monkeypatch,
 ):

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -43,7 +43,24 @@ def _make_subprocess_dispatcher(responses: dict):
 
 
 # ---------------------------------------------------------------------------
-# _check_via_git — compares against origin/<RELEASE_BRANCH>, not the
+# Channel → release branch mapping
+# ---------------------------------------------------------------------------
+
+
+def test_get_release_branch_defaults_to_stable(monkeypatch):
+    from server.lifecycle import updater
+    monkeypatch.setattr("server.config.get_update_channel", lambda: "stable")
+    assert updater._get_release_branch() == "release/stable"
+
+
+def test_get_release_branch_respects_beta_channel(monkeypatch):
+    from server.lifecycle import updater
+    monkeypatch.setattr("server.config.get_update_channel", lambda: "beta")
+    assert updater._get_release_branch() == "release/beta"
+
+
+# ---------------------------------------------------------------------------
+# _check_via_git — compares against origin/<release_branch>, not the
 # current branch's upstream
 # ---------------------------------------------------------------------------
 
@@ -58,7 +75,7 @@ def test_check_via_git_compares_to_release_branch_not_current_branch():
         ("git", "rev-parse", "--abbrev-ref", "HEAD"): _make_run(
             0, stdout="feat/something\n",
         ),
-        ("git", "rev-list", "HEAD..origin/main", "--count"): _make_run(
+        ("git", "rev-list", "HEAD..origin/release/stable", "--count"): _make_run(
             0, stdout="3\n",
         ),
     }
@@ -77,7 +94,7 @@ def test_check_via_git_compares_to_release_branch_not_current_branch():
     ]
     assert len(rev_list_calls) == 1
     assert rev_list_calls[0].args[0] == [
-        "git", "rev-list", "HEAD..origin/main", "--count",
+        "git", "rev-list", "HEAD..origin/release/stable", "--count",
     ]
 
 
@@ -89,7 +106,7 @@ def test_check_via_git_returns_zero_when_no_new_commits_on_release_branch():
         ("git", "rev-parse", "--abbrev-ref", "HEAD"): _make_run(
             0, stdout="main\n",
         ),
-        ("git", "rev-list", "HEAD..origin/main", "--count"): _make_run(
+        ("git", "rev-list", "HEAD..origin/release/stable", "--count"): _make_run(
             0, stdout="0\n",
         ),
     }
@@ -146,7 +163,7 @@ def test_update_via_git_on_feature_branch_with_updates_warns_and_skips_pull(
         ("git", "rev-parse", "--abbrev-ref", "HEAD"): _make_run(
             0, stdout="feat/foo\n",
         ),
-        ("git", "rev-list", "HEAD..origin/main", "--count"): _make_run(
+        ("git", "rev-list", "HEAD..origin/release/stable", "--count"): _make_run(
             0, stdout="3\n",
         ),
     }
@@ -159,8 +176,8 @@ def test_update_via_git_on_feature_branch_with_updates_warns_and_skips_pull(
     assert rc == 2  # Skip rebuild
     captured = capsys.readouterr()
     assert "feat/foo" in captured.out
-    assert "`origin/main` is 3 commits ahead" in captured.out
-    assert "git checkout main" in captured.out
+    assert "`origin/release/stable` is 3 commits ahead" in captured.out
+    assert "git checkout release/stable" in captured.out
 
     # Critically: `git pull` must NOT have been invoked.
     pull_calls = [
@@ -184,7 +201,7 @@ def test_update_via_git_on_feature_branch_with_no_updates_notes_and_skips(
         ("git", "rev-parse", "--abbrev-ref", "HEAD"): _make_run(
             0, stdout="feat/foo\n",
         ),
-        ("git", "rev-list", "HEAD..origin/main", "--count"): _make_run(
+        ("git", "rev-list", "HEAD..origin/release/stable", "--count"): _make_run(
             0, stdout="0\n",
         ),
     }
@@ -197,15 +214,16 @@ def test_update_via_git_on_feature_branch_with_no_updates_notes_and_skips(
     assert rc == 2
     captured = capsys.readouterr()
     assert "feat/foo" in captured.out
-    assert "release branch `main`" in captured.out
+    assert "release branch `release/stable`" in captured.out
     assert "No new commits" in captured.out
 
 
-def test_update_via_git_on_main_with_updates_still_pulls(
+def test_update_via_git_on_release_branch_with_updates_still_pulls(
     capsys, stub_quern_dev_no_signal, monkeypatch,
 ):
-    """Regression guard: the happy path (on main, behind, pull-and-rebuild)
-    must still work after the #40 rewrite."""
+    """Regression guard: the happy path (on the configured release
+    branch, behind, pull-and-rebuild) must still work after the
+    channels rewrite."""
     from server.lifecycle import updater
 
     monkeypatch.setattr(updater, "_read_local_version", lambda root: "0.13.5")
@@ -214,9 +232,9 @@ def test_update_via_git_on_main_with_updates_still_pulls(
         ("git", "rev-parse", "HEAD"): _make_run(0, stdout="deadbeef\n"),
         ("git", "fetch", "origin"): _make_run(0),
         ("git", "rev-parse", "--abbrev-ref", "HEAD"): _make_run(
-            0, stdout="main\n",
+            0, stdout="release/stable\n",
         ),
-        ("git", "rev-list", "HEAD..origin/main", "--count"): _make_run(
+        ("git", "rev-list", "HEAD..origin/release/stable", "--count"): _make_run(
             0, stdout="2\n",
         ),
         ("git", "pull", "--ff-only"): _make_run(0, stdout="Updating ...\n"),


### PR DESCRIPTION
Closes #41. Builds on #42 (which fixed the underlying branch-vs-release confusion).

## Summary

Adds an explicit `update_channel` config field plus the surfaces to read it, write it, and act on it — letting users opt into a separate "test the next thing early" track without leaving the git install path they already have. Maintainers gain a way to push fixes or features to a subset of users before cutting a full release; users get explicit opt-in.

## Mechanism

Channels are reserved pointer branches on origin that maintainers fast-forward on each release cut:

| Branch | Points at | Channel that tracks it |
|--------|-----------|------------------------|
| `release/stable` | the commit corresponding to the latest tagged stable release | `stable` (default) |
| `release/beta` | the latest prerelease commit (or main HEAD) | `beta` (opt-in) |

The updater's existing pull machinery is reused; this PR generalizes the hardcoded `main` from #42 to "whichever branch the configured channel tracks."

## Surfaces

| Layer | What |
|-------|------|
| `server/config.py` | `get_update_channel()` / `set_update_channel()` round-trip via `~/.quern/config.json` (default `stable`). Unknown values fall back to default — typos shouldn't break the daemon. `channel_to_release_branch()` maps `stable→release/stable`, `beta→release/beta`. |
| `server/lifecycle/updater.py` | `_get_release_branch()` consults the config; `_check_via_git` and `_update_via_git` use the resolved branch instead of a hardcoded `main`. `_fetch_latest_release(channel)` makes the **tarball** path channel-aware too: stable → `/releases/latest`, beta → `/releases` filtered to `prerelease: true` (falls through to stable if there are no prereleases so beta users never regress). |
| `server/api/system.py` | New `GET /api/v1/system/channel` and `PUT /api/v1/system/channel`. `GET /update-status` gains `channel` + `release_branch` fields. |
| `server/__main__.py` | New `quern set-channel <name>` CLI. Bare `quern set-channel` prints the current channel and tracked branch. |
| `mcp/src/tools/system.ts` | New `set_update_channel` MCP tool. Description tells Claude this only updates the config and doesn't switch branches or apply an update. |
| `mcp/src/http.ts` | Adds `"PUT"` to the method type so the new tool can reach the channel endpoint. |
| `docs/release-channels.md` | **New.** End-to-end docs for both users and maintainers: how channels work per install type, when/how to advance `release/stable` and `release/beta`, the release-cut procedure with explicit ordering, an optional helper-script shape, and the GitHub quirk we discovered. |

## The GitHub quirk we discovered

While bootstrapping the channel branches we hit an undocumented platform behavior worth recording:

> You cannot create or move a branch to point at any commit referenced by a published GitHub Release. The push is silently rejected with `remote rejected ... (failed)`; the REST API returns `422: Reference update failed` with no detail. The behavior persists even after the Release is deleted. `gh ruleset check` reports zero rules.

The doc covers this in full (we reproduced it against `v0.13.3`, `v0.13.4`, lightweight and annotated tags). The practical mitigation is the release-cut ordering documented in `docs/release-channels.md`: **fast-forward `release/*` before creating the GitHub Release**, never after.

This is also why `release/stable` and `release/beta` currently both live at main HEAD rather than at `v0.13.4` — the bootstrap path is locked. Once we cut the next release using the documented procedure, the strict semantics kick in.

## What this PR deliberately does *not* do

- **Auto-switch branches.** Setting the channel only updates the config; the user is responsible for `git checkout release/<channel>`. Managed-install detection + auto-switch is a follow-up.
- **Setup-time prompt.** `quern setup` doesn't ask which channel to install on. Can be added later without breaking the model.

## Bootstrap state

`release/stable` and `release/beta` are both pushed and live (both at current main HEAD). The release-cut procedure in `docs/release-channels.md` covers advancing them correctly going forward.

## Test plan

- [x] **5 unit tests for the config helpers** (default, round-trip, invalid-name rejection, typo fallback, channel-to-branch mapping).
- [x] **2 tests for `_get_release_branch`** (stable + beta channels resolve to the right branches).
- [x] **4 integration tests for `/api/v1/system/channel`** (default when unset, persisted round-trip, unknown-name 400, `update-status` surfaces both fields).
- [x] **4 unit tests for `_fetch_latest_release(channel)`** (stable hits `/releases/latest`, beta picks first prerelease, beta falls back to stable when no prereleases, beta skips drafts).
- [x] **Existing updater tests** updated to expect `release/stable` as the default release branch.
- [x] **Full Python suite**: 1385 passed locally.
- [x] **MCP build**: clean `tsc`.
- [x] **ruff**: clean (pre-commit hook).