### PR TITLE
feat(android): scroll_to_element — native scrollIntoView, no dump

### DIFF
--- a/mcp/src/tools/device-ui.ts
+++ b/mcp/src/tools/device-ui.ts
@@ -503,6 +503,59 @@ Label matching modes (mutually exclusive — use only one):
     }
   });
 
+  server.registerTool("scroll_to_element", {
+    description: `Scroll a scrollable container until an element is in view, WITHOUT tapping it. Resolve by identifier or label. Android-only for now — uses native uiautomator2 scrollIntoView, so it does not trigger the dump-induced scroll that a full UI-tree read can cause. Returns the element's on-screen position once visible; 404 if it never appears after scrolling. On non-Android devices returns status "not_supported".`,
+    inputSchema: strictParams({
+      label: z
+        .string()
+        .optional()
+        .describe("Exact visible text or content-description of the target"),
+      identifier: z
+        .string()
+        .optional()
+        .describe("Resource-id (package-stripped, e.g. \"button_log\")"),
+      max_swipes: z
+        .coerce.number()
+        .int()
+        .default(10)
+        .describe("Max scroll attempts before giving up (default 10)"),
+      udid: z
+        .string()
+        .optional()
+        .describe("Target device UDID (defaults to active device)"),
+    }),
+  }, async ({ label, identifier, max_swipes, udid }) => {
+    try {
+      const body: Record<string, unknown> = { max_swipes };
+      if (label) body.label = label;
+      if (identifier) body.identifier = identifier;
+      if (udid) body.udid = udid;
+
+      const data = await apiRequest(
+        "POST",
+        "/api/v1/device/ui/scroll-to-element",
+        undefined,
+        body
+      );
+
+      return {
+        content: [
+          { type: "text" as const, text: JSON.stringify(data, null, 2) },
+        ],
+      };
+    } catch (e) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error: ${e instanceof Error ? e.message : String(e)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  });
+
   server.registerTool("type_text", {
     description: `Type text into the currently focused input field. On iOS simulators this attaches the simulated hardware keyboard before typing (required for shifted characters to retain their modifier), which hides the software keyboard — use set_hardware_keyboard with enabled=false afterward if a later step expects the software keyboard to be visible.`,
     inputSchema: strictParams({

--- a/server/api/device_ui.py
+++ b/server/api/device_ui.py
@@ -18,6 +18,7 @@ from server.models import (
     ClearTextRequest,
     DeviceError,
     PressButtonRequest,
+    ScrollToElementRequest,
     SwipeRequest,
     TapElementRequest,
     TapRequest,
@@ -398,6 +399,29 @@ async def swipe(request: Request, body: SwipeRequest):
             udid=body.udid,
         )
         return {"status": "ok", "udid": udid}
+    except DeviceError as e:
+        raise _handle_device_error(e)
+
+
+@router.post("/ui/scroll-to-element")
+async def scroll_to_element(request: Request, body: ScrollToElementRequest):
+    """Scroll a scrollable container until the target element is in view.
+
+    Android-only for now (native uiautomator2 scrollIntoView). Returns 404 when
+    the element never appears after scrolling; 200 with status "not_supported"
+    on non-Android devices.
+    """
+    controller = _get_controller(request)
+    try:
+        result = await controller.scroll_to_element(
+            label=body.label,
+            identifier=body.identifier,
+            udid=body.udid,
+            max_swipes=body.max_swipes,
+        )
+        if result.get("status") == "not_found":
+            raise HTTPException(status_code=404, detail=result)
+        return result
     except DeviceError as e:
         raise _handle_device_error(e)
 

--- a/server/device/controller_ui.py
+++ b/server/device/controller_ui.py
@@ -1217,6 +1217,50 @@ class DeviceControllerUI:
         self._invalidate_ui_cache(resolved)  # UI changed
         return resolved
 
+    async def scroll_to_element(
+        self,
+        label: str | None = None,
+        identifier: str | None = None,
+        udid: str | None = None,
+        max_swipes: int = 10,
+    ) -> dict:
+        """Scroll until an element is in view, without interacting with it.
+
+        Android: native uiautomator2 scrollIntoView (no dump_hierarchy, so no
+        dump-induced scroll — see #49). iOS is not yet wired here (tracked in
+        #50); tap_element already nudges home-indicator-obscured elements into
+        view via _scroll_element_into_view.
+
+        Returns {"status": "ok", "element": {...}} once visible,
+        {"status": "not_found", ...} if it never appeared, or
+        {"status": "not_supported", ...} on non-Android devices.
+        """
+        if not label and not identifier:
+            raise DeviceError(
+                "Either label or identifier is required for scroll-to-element",
+                tool="u2",
+            )
+
+        resolved = await self.resolve_udid(udid)
+        if not self._is_android(resolved):
+            return {
+                "status": "not_supported",
+                "detail": "scroll_to_element is currently Android-only (see #50)",
+            }
+
+        found = await self._ui_backend(resolved).scroll_into_view(
+            resolved, identifier=identifier, label=label, max_swipes=max_swipes,
+        )
+        self._invalidate_ui_cache(resolved)  # scrolling changes the viewport
+
+        if found is None:
+            target = f"identifier='{identifier}'" if identifier else f"label='{label}'"
+            return {
+                "status": "not_found",
+                "detail": f"Element not found after scrolling ({target})",
+            }
+        return {"status": "ok", "element": found}
+
     async def type_text(self, text: str, udid: str | None = None) -> str:
         """Type text into focused field. Returns the resolved udid."""
         resolved = await self.resolve_udid(udid)

--- a/server/device/u2_client.py
+++ b/server/device/u2_client.py
@@ -392,6 +392,94 @@ class U2Backend:
             logger.debug("tap_by_selector fell back (%s)", e)
             return None
 
+    async def scroll_into_view(
+        self,
+        udid: str,
+        identifier: str | None = None,
+        label: str | None = None,
+        max_swipes: int = 10,
+    ) -> dict | None:
+        """Scroll a scrollable container until the target element is on-screen —
+        WITHOUT dumping the full hierarchy.
+
+        Prefers uiautomator2's native scrollIntoView (UiScrollable) via
+        ``d(scrollable=True).scroll.to(**selector)``, which searches both
+        directions and stops at the element. Falls back to a bounded, targeted
+        swipe loop (checking ``obj.exists`` per selector, not dump_hierarchy) if
+        the native scroll helper is unavailable. Neither path triggers the
+        dump-induced scroll that motivated the selector-based tap (see #49/#50).
+
+        Returns a normalized ``{label, identifier, type, x, y}`` dict once the
+        element is present, or ``None`` if it never appeared.
+        """
+
+        def _result(obj, fallback_label: str | None) -> dict:
+            info = obj.info or {}
+            bounds = info.get("bounds") or {}
+            cx = (bounds.get("left", 0) + bounds.get("right", 0)) / 2
+            cy = (bounds.get("top", 0) + bounds.get("bottom", 0)) / 2
+            cls = info.get("className", "")
+            return {
+                "label": info.get("text")
+                or info.get("contentDescription")
+                or fallback_label
+                or "",
+                "identifier": identifier,
+                "type": _map_class(cls) if cls else None,
+                "x": cx,
+                "y": cy,
+            }
+
+        def _do():
+            device = self._connect(udid)
+            selectors: list[dict] = []
+            if identifier:
+                selectors.append({"resourceIdMatches": rf".*/{re.escape(identifier)}$"})
+            if label:
+                selectors.append({"text": label})
+                selectors.append({"description": label})
+
+            for sel in selectors:
+                target = device(**sel)
+                # Already in the hierarchy — no scrolling needed.
+                if target.exists:
+                    return _result(target, label)
+
+                scrollable = device(scrollable=True)
+                if not scrollable.exists:
+                    continue
+
+                # Native scrollIntoView (both directions, stops at element).
+                found = False
+                try:
+                    found = bool(scrollable.scroll.to(**sel))
+                except AttributeError:
+                    # Older/newer u2 without .scroll.to — bounded manual fallback.
+                    try:
+                        w, h = device.window_size()
+                    except Exception:
+                        w, h = 1080, 1920
+                    mid_x = w // 2
+                    start_y, end_y = int(h * 0.7), int(h * 0.3)
+                    for _ in range(max_swipes):
+                        if target.exists:
+                            found = True
+                            break
+                        device.swipe(mid_x, start_y, mid_x, end_y, duration=0.3)
+                except Exception as e:
+                    logger.debug("scroll_into_view native scroll failed (%s)", e)
+
+                if found and target.exists:
+                    return _result(target, label)
+
+            return None
+
+        try:
+            return await asyncio.to_thread(_do)
+        except Exception as e:
+            logger.debug("scroll_into_view fell back (%s)", e)
+            return None
+
     async def swipe(
         self,
         udid: str,

--- a/server/models.py
+++ b/server/models.py
@@ -1005,6 +1005,21 @@ class SwipeRequest(BaseModel):
     udid: str | None = None
 
 
+class ScrollToElementRequest(BaseModel):
+    """Request body for POST /device/ui/scroll-to-element."""
+
+    label: str | None = None
+    identifier: str | None = None
+    udid: str | None = None
+    max_swipes: int = Field(default=10, ge=1, le=50)
+
+    @model_validator(mode="after")
+    def check_target(self):
+        if not self.label and not self.identifier:
+            raise ValueError("Either label or identifier is required")
+        return self
+
+
 class TypeTextRequest(BaseModel):
     """Request body for POST /device/ui/type."""
 

--- a/tests/test_device_api.py
+++ b/tests/test_device_api.py
@@ -995,3 +995,81 @@ class TestAnnotatedScreenshot:
                 headers=auth_headers,
             )
         assert resp.status_code == 400
+
+
+class TestScrollToElement:
+    async def test_scroll_to_element_ok(self, app, auth_headers, mock_controller):
+        mock_controller.scroll_to_element = AsyncMock(
+            return_value={
+                "status": "ok",
+                "element": {"label": "Log", "identifier": "button_log",
+                            "type": "Button", "x": 100, "y": 200},
+            }
+        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/api/v1/device/ui/scroll-to-element",
+                json={"identifier": "button_log"},
+                headers=auth_headers,
+            )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+        mock_controller.scroll_to_element.assert_called_once_with(
+            label=None, identifier="button_log", udid=None, max_swipes=10,
+        )
+
+    async def test_scroll_to_element_by_label_and_max_swipes(
+        self, app, auth_headers, mock_controller
+    ):
+        mock_controller.scroll_to_element = AsyncMock(
+            return_value={"status": "ok", "element": {}}
+        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/api/v1/device/ui/scroll-to-element",
+                json={"label": "Log cache", "max_swipes": 5},
+                headers=auth_headers,
+            )
+        assert resp.status_code == 200
+        mock_controller.scroll_to_element.assert_called_once_with(
+            label="Log cache", identifier=None, udid=None, max_swipes=5,
+        )
+
+    async def test_scroll_to_element_not_found(self, app, auth_headers, mock_controller):
+        mock_controller.scroll_to_element = AsyncMock(
+            return_value={"status": "not_found", "detail": "gone"}
+        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/api/v1/device/ui/scroll-to-element",
+                json={"identifier": "missing"},
+                headers=auth_headers,
+            )
+        assert resp.status_code == 404
+
+    async def test_scroll_to_element_not_supported(self, app, auth_headers, mock_controller):
+        mock_controller.scroll_to_element = AsyncMock(
+            return_value={"status": "not_supported", "detail": "iOS"}
+        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/api/v1/device/ui/scroll-to-element",
+                json={"identifier": "button_log"},
+                headers=auth_headers,
+            )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "not_supported"
+
+    async def test_scroll_to_element_requires_target(self, app, auth_headers, mock_controller):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/api/v1/device/ui/scroll-to-element",
+                json={},
+                headers=auth_headers,
+            )
+        assert resp.status_code == 422

--- a/tests/test_device_controller.py
+++ b/tests/test_device_controller.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -1123,3 +1123,49 @@ class TestAndroidUIBackendSelection:
         from server.device.u2_client import U2Backend
 
         assert isinstance(ctrl._ui_backend("ZY224H6L"), U2Backend)
+
+
+class TestScrollToElement:
+    async def test_requires_label_or_identifier(self):
+        ctrl = DeviceController()
+        with pytest.raises(DeviceError, match="label or identifier"):
+            await ctrl.scroll_to_element()
+
+    async def test_not_supported_on_ios(self):
+        ctrl = DeviceController()
+        ctrl._device_type_cache["AAAA-1111"] = DeviceType.SIMULATOR
+        ctrl.resolve_udid = AsyncMock(return_value="AAAA-1111")
+
+        result = await ctrl.scroll_to_element(identifier="button_log")
+        assert result["status"] == "not_supported"
+
+    async def test_android_ok_delegates_to_backend(self):
+        ctrl = DeviceController()
+        ctrl._device_type_cache["emulator-5554"] = DeviceType.ANDROID_EMULATOR
+        ctrl.resolve_udid = AsyncMock(return_value="emulator-5554")
+        ctrl._invalidate_ui_cache = MagicMock()
+
+        element = {"label": "Log", "identifier": "button_log",
+                   "type": "Button", "x": 100, "y": 200}
+        backend = MagicMock()
+        backend.scroll_into_view = AsyncMock(return_value=element)
+        ctrl._ui_backend = MagicMock(return_value=backend)
+
+        result = await ctrl.scroll_to_element(identifier="button_log", max_swipes=5)
+        assert result == {"status": "ok", "element": element}
+        backend.scroll_into_view.assert_called_once_with(
+            "emulator-5554", identifier="button_log", label=None, max_swipes=5,
+        )
+
+    async def test_android_not_found(self):
+        ctrl = DeviceController()
+        ctrl._device_type_cache["emulator-5554"] = DeviceType.ANDROID_EMULATOR
+        ctrl.resolve_udid = AsyncMock(return_value="emulator-5554")
+        ctrl._invalidate_ui_cache = MagicMock()
+
+        backend = MagicMock()
+        backend.scroll_into_view = AsyncMock(return_value=None)
+        ctrl._ui_backend = MagicMock(return_value=backend)
+
+        result = await ctrl.scroll_to_element(label="Nope")
+        assert result["status"] == "not_found"


### PR DESCRIPTION
Implements the standalone scroll-to-element primitive from #50 (Android side).

## What

A new `scroll_to_element` that scrolls a scrollable container until a target is in view **without tapping it** — resolved by identifier or label. Android-only for now; iOS returns `not_supported` (deferred, see #50).

The Android backend uses uiautomator2's native scrollIntoView (`d(scrollable=True).scroll.to(**selector)`) with a bounded, targeted-swipe fallback. Like the tap-by-selector fix (#49), it **never calls `dump_hierarchy`**, so it doesn't trigger the dump-induced scroll that pushes top controls out of reach.

Full vertical slice:
- `U2Backend.scroll_into_view()` — native scrollIntoView + fallback
- `controller_ui.scroll_to_element()` — Android dispatch; `not_supported` on iOS
- `ScrollToElementRequest` model + `POST /api/v1/device/ui/scroll-to-element`
- `scroll_to_element` MCP tool
- Controller + API unit tests (9)

## Live validation

Tested on the **cache-details screen** (native `CoordinatorLayout`/`RecyclerView`) at normal font — the exact #49 repro:

- `scroll_to_element(identifier="button_log")` → `status: ok`, returned **"Log cache"** at (802, 922), and scrolled the collapsed header (map + cache name + Navigate/Log buttons) back into view.
- That's the control the tree dump scrolls away — now reachable, no dump, header stable.
- Already-present branch (visible element → immediate coords) and not-found branch (clean 404, no hang) also confirmed.

## Known limitation (follow-up, tracked in #50)

Pure **Jetpack Compose** scrollers aren't matched by the classic `scrollable=true` selector, so native `scroll.to` no-ops there (observed on the Compose Settings list). Needs a Compose fallback (accessibility scroll action, or the coordinate-swipe loop). **#50 stays open until the follow-ups land.**

Refs #50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)