### PR TITLE
feat(android): open_url can target an app package (deep links bypass App Links)

### DIFF
--- a/mcp/src/tools/device.ts
+++ b/mcp/src/tools/device.ts
@@ -678,7 +678,9 @@ Examples:
 - Web: "https://example.com"
 - Maps: "geo:48.8584,2.2945?z=15" (Android) or "maps://?ll=48.8584,2.2945&z=15" (iOS)
 - Settings: "App-prefs:WIFI" (iOS) — Android uses action-based intents via adb
-- Deep link: "myapp://path/to/screen"`,
+- Deep link: "myapp://path/to/screen"
+
+Android deep links: pass bundle_id (the app package) to deliver the URL straight to that app. Needed for https deep links on debug/staging builds, which usually aren't verified App Links — without a package target Android opens the browser instead of the app.`,
     inputSchema: strictParams({
       url: z.string().describe(
         "URL or URI to open (e.g. https://example.com, geo:48.8,2.3?z=15, maps://?ll=48.8,2.3)"
@@ -687,6 +689,10 @@ Examples:
         .string()
         .optional()
         .describe("Target device UDID (defaults to active device)"),
+      bundle_id: z
+        .string()
+        .optional()
+        .describe("Android only: app package to receive the intent directly (bypasses App Links verification). Use for deep links on debug/staging builds; ignored on iOS."),
       include_screen_context: z
         .boolean()
         .default(false)
@@ -702,10 +708,11 @@ Examples:
         .optional()
         .describe("Seconds to wait before capturing after screenshot/screen context (default 1.0)."),
     }),
-  }, async ({ url, udid, include_screen_context, capture_screenshots, settle_delay }) => {
+  }, async ({ url, udid, bundle_id, include_screen_context, capture_screenshots, settle_delay }) => {
     try {
       const body: Record<string, unknown> = { url };
       if (udid) body.udid = udid;
+      if (bundle_id) body.bundle_id = bundle_id;
       if (include_screen_context) body.include_screen_context = true;
       if (capture_screenshots) body.capture_screenshots = true;
       if (settle_delay !== undefined) body.settle_delay = settle_delay;

--- a/server/api/device.py
+++ b/server/api/device.py
@@ -467,7 +467,7 @@ async def open_url(request: Request, body: OpenUrlRequest):
         resolved = await controller.resolve_udid(body.udid)
         if body.capture_screenshots:
             before = await _capture_action_screenshot(controller, resolved, "open_url_before")
-        udid = await controller.open_url(url=body.url, udid=body.udid)
+        udid = await controller.open_url(url=body.url, udid=body.udid, bundle_id=body.bundle_id)
         result: dict = {"status": "ok", "udid": udid, "url": body.url}
         if body.capture_screenshots:
             await asyncio.sleep(body.settle_delay)

--- a/server/device/adb.py
+++ b/server/device/adb.py
@@ -714,18 +714,28 @@ rm -rf /data/local/tmp/tmp-ca-copy
             str(longitude), str(latitude), "0", str(satellites),
         )
 
-    async def open_url(self, serial: str, url: str) -> None:
+    async def open_url(self, serial: str, url: str, package: str | None = None) -> None:
         """Open a URL via Android's VIEW intent.
 
-        Runs: adb -s <serial> shell am start -a android.intent.action.VIEW -d <url>
+        Runs: adb -s <serial> shell am start -a android.intent.action.VIEW -d <url> [<package>]
         Supports any URI scheme the device has a handler for: https://, geo:,
         tel:, mailto:, custom app schemes, etc.
+
+        When `package` is given, the intent is delivered directly to that app,
+        bypassing Android App Links verification. This is required to drive deep
+        links into a debug/staging build: such https links are usually NOT
+        verified App Links (autoVerify=false and/or the debug signing cert isn't
+        in the domain's assetlinks.json), so a package-less VIEW intent falls
+        through to the browser instead of opening the app.
         """
-        await self._run_adb_for_device(
+        args = [
             serial, "shell", "am", "start",
             "-a", "android.intent.action.VIEW",
             "-d", url,
-        )
+        ]
+        if package:
+            args.append(package)
+        await self._run_adb_for_device(*args)
 
     async def grant_permission(self, serial: str, package: str, permission: str) -> None:
         """Grant a runtime permission to an app.

--- a/server/device/controller.py
+++ b/server/device/controller.py
@@ -489,11 +489,19 @@ class DeviceController(DeviceControllerUI):
             await self.simctl.set_location(resolved, latitude, longitude)
         return resolved
 
-    async def open_url(self, url: str, udid: str | None = None) -> str:
-        """Open a URL on the device. Returns the resolved udid."""
+    async def open_url(
+        self, url: str, udid: str | None = None, bundle_id: str | None = None,
+    ) -> str:
+        """Open a URL on the device. Returns the resolved udid.
+
+        On Android, pass `bundle_id` (the app package) to deliver the URL
+        straight to that app — needed for deep links on debug/staging builds
+        that aren't verified App Links (otherwise Android opens the browser).
+        Ignored on iOS (universal links route to the associated app by the OS).
+        """
         resolved = await self.resolve_udid(udid)
         if self._is_android(resolved):
-            await self.adb.open_url(resolved, url)
+            await self.adb.open_url(resolved, url, package=bundle_id)
         else:
             self._require_simulator(resolved, "Open URL")
             await self.simctl.open_url(resolved, url)

--- a/server/models.py
+++ b/server/models.py
@@ -1041,6 +1041,7 @@ class OpenUrlRequest(BaseModel):
 
     url: str
     udid: str | None = None
+    bundle_id: str | None = None
     include_screen_context: bool = False
     capture_screenshots: bool = False
     settle_delay: float = Field(default=1.0, ge=0, le=10)


### PR DESCRIPTION
## Problem

`open_url` fired a package-less `VIEW` intent (`am start -a android.intent.action.VIEW -d <url>`).
On Android, an `https://` deep link only opens the app when the domain is a **verified App Link**
(`autoVerify=true` + the app's signing cert in the domain's `assetlinks.json`). On debug/staging
builds that's false, so the intent falls through to the **browser** — making it impossible to drive
deep links into the app for automation/testing.

## Fix

Add an optional **`bundle_id`** (app package) to `open_url`, plumbed end-to-end
(MCP tool → REST `OpenUrlRequest` → `DeviceController.open_url` → `AdbBackend.open_url`). When
provided on Android, the intent is delivered directly to that package
(`am start -a VIEW -d <url> <package>`), bypassing App-Links verification and opening the app.
Ignored on iOS (the OS routes universal links to the associated app).

- `server/device/adb.py` — `open_url(serial, url, package=None)`
- `server/device/controller.py` — `open_url(url, udid, bundle_id=None)`
- `server/models.py` — `OpenUrlRequest.bundle_id`
- `server/api/device.py` — pass `bundle_id` through
- `mcp/src/tools/device.ts` — new `bundle_id` param + doc note

No new required args; the `/ui`/`open-url` contract is otherwise unchanged.

## Validation

Verified against the Android Geocaching staging build: with `bundle_id` set, `/dl/*` deep links open
**in the app** (confirmed by `identify_screen` on the landing screen) instead of Chrome. This
unblocked a full deep-link smoke-test pass across ~34 links. Python syntax + ruff clean; `tsc`
builds; targeted device api/controller tests pass. (Full suite not run — the pre-commit hook is slow;
please run it in CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
