### PR TITLE
fix(android): correct screen-on detection so screenshots don't scroll the app

### DIFF
--- a/server/device/adb.py
+++ b/server/device/adb.py
@@ -669,14 +669,25 @@ rm -rf /data/local/tmp/tmp-ca-copy
         logger.info("Set HTTP proxy on %s to %s:%d", serial, host, port)
 
     async def is_screen_on(self, serial: str) -> bool:
-        """Check if the device screen is on."""
+        """Check if the device screen is on (interactive)."""
         try:
             stdout, _ = await self._run_adb_for_device(serial, "shell", "dumpsys", "power")
-            # Different Android versions use different keys
+            # Different Android versions expose this differently. Prefer
+            # mWakefulness (authoritative on modern Android: Awake / Dreaming /
+            # Dozing / Asleep).
+            #
+            # IMPORTANT: do NOT match a bare "Display Power:" line — on recent
+            # Android that line is a listener object reference, e.g.
+            #   "Display Power: com.android.server.power.PowerManagerService$1@..."
+            # which contains no state and always read as OFF, making the screen
+            # look off even when awake. Require "state=" so we only match the
+            # actual display-state line ("Display Power: state=ON").
             for line in stdout.splitlines():
                 stripped = line.strip()
-                if stripped.startswith("Display Power:"):
-                    return "ON" in stripped
+                if stripped.startswith("mWakefulness="):
+                    return "Awake" in stripped
+                if stripped.startswith("Display Power: state="):
+                    return "state=ON" in stripped
                 if stripped.startswith("mScreenOn="):
                     return "true" in stripped
         except DeviceError:
@@ -684,15 +695,19 @@ rm -rf /data/local/tmp/tmp-ca-copy
         return True  # Assume on if we can't tell
 
     async def wake_screen(self, serial: str) -> None:
-        """Wake the device screen and dismiss the lock screen (no passcode)."""
+        """Wake the device screen and dismiss a non-secure lock screen."""
         if await self.is_screen_on(serial):
             return
         # KEYCODE_WAKEUP (224) turns screen on without toggling
         await self._run_adb_for_device(serial, "shell", "input", "keyevent", "224")
-        # Swipe up to dismiss lock screen (no passcode assumed)
-        await self._run_adb_for_device(
-            serial, "shell", "input", "swipe", "540", "1800", "540", "800", "300",
-        )
+        # Dismiss a non-secure keyguard WITHOUT a content-scrolling gesture.
+        # The previous `input swipe 540 1800 540 800` was a full-screen upward
+        # swipe that scrolled whatever app was showing (e.g. scrolling a
+        # cache-detail RecyclerView out of place), corrupting scroll state on
+        # every screenshot / UI read that happened to wake the screen.
+        # `wm dismiss-keyguard` is a no-op when there's no keyguard and never
+        # touches app content (secure keyguards still require the passcode).
+        await self._run_adb_for_device(serial, "shell", "wm", "dismiss-keyguard")
 
     async def set_location(
         self, serial: str, latitude: float, longitude: float,

--- a/tests/test_adb_backend.py
+++ b/tests/test_adb_backend.py
@@ -230,3 +230,58 @@ class TestScreenshot:
 
             with pytest.raises(DeviceError, match="adb screencap failed"):
                 await backend.screenshot("emulator-5554")
+
+
+class TestScreenState:
+    async def test_is_screen_on_awake_wins_over_object_ref_display_power(self):
+        # Regression: on modern Android the bare "Display Power:" line is a
+        # listener object reference (no state) — it must NOT be read as OFF.
+        # mWakefulness=Awake is authoritative.
+        backend = AdbBackend()
+        dump = (
+            "  mWakefulness=Awake\n"
+            "  mHoldingDisplaySuspendBlocker=true\n"
+            "Display Power: com.android.server.power.PowerManagerService$1@7306ed6\n"
+        )
+        backend._run_adb_for_device = AsyncMock(return_value=(dump, ""))
+        assert await backend.is_screen_on("dev") is True
+
+    async def test_is_screen_on_asleep(self):
+        backend = AdbBackend()
+        backend._run_adb_for_device = AsyncMock(return_value=("  mWakefulness=Asleep\n", ""))
+        assert await backend.is_screen_on("dev") is False
+
+    async def test_is_screen_on_legacy_display_power_state(self):
+        backend = AdbBackend()
+        backend._run_adb_for_device = AsyncMock(return_value=("Display Power: state=ON\n", ""))
+        assert await backend.is_screen_on("dev") is True
+
+    async def test_is_screen_on_display_power_state_off(self):
+        backend = AdbBackend()
+        backend._run_adb_for_device = AsyncMock(return_value=("Display Power: state=OFF\n", ""))
+        assert await backend.is_screen_on("dev") is False
+
+    async def test_is_screen_on_object_ref_only_assumes_on(self):
+        # Only the object-ref line, no wakefulness/state → don't match it; assume on.
+        backend = AdbBackend()
+        backend._run_adb_for_device = AsyncMock(
+            return_value=("Display Power: com.android.server.power.PowerManagerService$1@abc\n", "")
+        )
+        assert await backend.is_screen_on("dev") is True
+
+    async def test_wake_screen_noop_when_on(self):
+        backend = AdbBackend()
+        backend.is_screen_on = AsyncMock(return_value=True)
+        backend._run_adb_for_device = AsyncMock()
+        await backend.wake_screen("dev")
+        backend._run_adb_for_device.assert_not_called()
+
+    async def test_wake_screen_dismisses_keyguard_without_content_swipe(self):
+        backend = AdbBackend()
+        backend.is_screen_on = AsyncMock(return_value=False)
+        backend._run_adb_for_device = AsyncMock()
+        await backend.wake_screen("dev")
+        calls = [c.args for c in backend._run_adb_for_device.call_args_list]
+        assert ("dev", "shell", "input", "keyevent", "224") in calls
+        assert ("dev", "shell", "wm", "dismiss-keyguard") in calls
+        assert not any("swipe" in c for c in calls)


### PR DESCRIPTION
## The bug

`AdbBackend.is_screen_on` parsed `dumpsys power` by matching the first line starting with `Display Power:` and returning whether `"ON"` was in it. On modern Android (14+), that line is a **listener object reference**, not the state:

```
Display Power: com.android.server.power.PowerManagerService$1@7306ed6
```

It contains no `"ON"`, so `is_screen_on` returned **False even when the screen was awake** (`mWakefulness=Awake`, `Display State=ON`).

## The cascade

`is_screen_on` wrongly False → `wake_screen` runs on **every screenshot / UI read** on physical devices → and its lock-dismiss step was a full-screen swipe:

```
input swipe 540 1800 540 800
```

…which **scrolled whatever app was showing** (e.g. a cache-detail `RecyclerView`), silently corrupting scroll position. Emulators skip the wake path (`resolved.startswith("emulator-")`), so they were unaffected — which is exactly why this only reproduced on physical devices, and looked like flaky scrolling / "the screenshot moved the screen."

## The fix

- **`is_screen_on`**: prefer `mWakefulness` (authoritative on modern Android); require `Display Power: state=` so the object-ref line can't match; keep `mScreenOn=` fallback.
- **`wake_screen`**: dismiss a non-secure keyguard with `wm dismiss-keyguard` instead of the content-scrolling swipe (no-op when there's no keyguard; secure keyguards still require the passcode).
- **7 regression tests**: object-ref line, wakefulness states, legacy `state=ON/OFF`, and that `wake_screen` dismisses without any swipe.

## Validation

Live on a Pixel 5 (Android 14): `is_screen_on` now returns `True` for an awake screen, and repeated screenshots leave the cache-detail header (the Log button) **in place** instead of scrolling it away. Full suite green (1401 passed).

Separate from #50 — this corrupts *any* screenshot/UI-read on a physical device, not just scroll-to-element. (It was also the confound behind the scroll_to_element physical-device flakiness.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)