### PR TITLE
feat(android): scroll_into_view via a metered swipe loop (handles Compose)

### DIFF
--- a/mcp/src/tools/device-ui.ts
+++ b/mcp/src/tools/device-ui.ts
@@ -504,7 +504,7 @@ Label matching modes (mutually exclusive — use only one):
   });
 
   server.registerTool("scroll_to_element", {
-    description: `Scroll a scrollable container until an element is in view, WITHOUT tapping it. Resolve by identifier or label. Android-only for now — uses native uiautomator2 scrollIntoView, so it does not trigger the dump-induced scroll that a full UI-tree read can cause. Returns the element's on-screen position once visible; 404 if it never appears after scrolling. On non-Android devices returns status "not_supported".`,
+    description: `Scroll a scrollable container until an element is in view, WITHOUT tapping it. Resolve by identifier or label. Android-only for now — drives a bounded swipe loop that re-checks the target by selector after each swipe (no full UI-tree dump, so it avoids the dump-induced scroll a tree read can cause, and works across View RecyclerView, Compose LazyColumn, and Compose-in-ScrollView screens). Returns the element's on-screen position once visible; 404 if it never appears within the swipe budget. On non-Android devices returns status "not_supported".`,
     inputSchema: strictParams({
       label: z
         .string()

--- a/server/device/controller_ui.py
+++ b/server/device/controller_ui.py
@@ -1226,10 +1226,13 @@ class DeviceControllerUI:
     ) -> dict:
         """Scroll until an element is in view, without interacting with it.
 
-        Android: native uiautomator2 scrollIntoView (no dump_hierarchy, so no
-        dump-induced scroll — see #49). iOS is not yet wired here (tracked in
-        #50); tap_element already nudges home-indicator-obscured elements into
-        view via _scroll_element_into_view.
+        Android: a bounded, coordinate swipe loop that re-checks the target by
+        selector after each swipe (no dump_hierarchy, so no dump-induced scroll
+        — see #49). Works across the app's mix of scroll containers (View
+        RecyclerView, Compose LazyColumn, Compose-in-ScrollView) where native
+        UiScrollable.scrollIntoView is unreliable — see #50. iOS is not yet
+        wired here (tracked in #50); tap_element already nudges
+        home-indicator-obscured elements into view via _scroll_element_into_view.
 
         Returns {"status": "ok", "element": {...}} once visible,
         {"status": "not_found", ...} if it never appeared, or

--- a/server/device/u2_client.py
+++ b/server/device/u2_client.py
@@ -402,19 +402,18 @@ class U2Backend:
         """Scroll a scrollable container until the target element is on-screen —
         WITHOUT dumping the full hierarchy.
 
-        Prefers uiautomator2's native scrollIntoView (UiScrollable) via
-        ``d(scrollable=True).scroll.to(**selector)``, which searches both
-        directions and stops at the element. Falls back to a bounded, targeted
-        swipe loop (checking ``obj.exists`` per selector, not dump_hierarchy) if
-        the native scroll helper is unavailable. Neither path triggers the
-        dump-induced scroll that motivated the selector-based tap (see #49/#50).
-
-        Returns a normalized ``{label, identifier, type, x, y}`` dict once the
-        element is present, or ``None`` if it never appeared.
+        A bounded, metered swipe loop that re-checks the target by selector
+        (``obj.exists`` — not ``dump_hierarchy``, so no dump-induced scroll, see
+        #49) after each swipe. Deliberately NOT native
+        ``UiScrollable.scrollIntoView``, which no-ops on Compose ``LazyColumn``
+        (not flagged ``scrollable``) and can't match lazily-composed rows (#50);
+        plain swipes work regardless. Sweeps down first, then up (for
+        top-anchored controls). Returns a normalized
+        ``{label, identifier, type, x, y}`` dict once the element is on-screen,
+        or ``None`` if it never appeared within the swipe budget.
         """
 
-        def _result(obj, fallback_label: str | None) -> dict:
-            info = obj.info or {}
+        def _result(info: dict) -> dict:
             bounds = info.get("bounds") or {}
             cx = (bounds.get("left", 0) + bounds.get("right", 0)) / 2
             cy = (bounds.get("top", 0) + bounds.get("bottom", 0)) / 2
@@ -422,7 +421,7 @@ class U2Backend:
             return {
                 "label": info.get("text")
                 or info.get("contentDescription")
-                or fallback_label
+                or label
                 or "",
                 "identifier": identifier,
                 "type": _map_class(cls) if cls else None,
@@ -438,46 +437,53 @@ class U2Backend:
             if label:
                 selectors.append({"text": label})
                 selectors.append({"description": label})
+            if not selectors:
+                return None
 
-            for sel in selectors:
-                target = device(**sel)
-                # Already in the hierarchy — no scrolling needed.
-                if target.exists:
-                    return _result(target, label)
+            def _match():
+                # These containers (RecyclerView, Compose LazyColumn/ScrollView)
+                # only keep on-screen rows in the accessibility tree, so
+                # `.exists` is equivalent to "visible" — no separate visibility
+                # check needed.
+                for sel in selectors:
+                    obj = device(**sel)
+                    if obj.exists:
+                        try:
+                            return obj.info or {}
+                        except Exception:
+                            return None
+                return None
 
-                scrollable = device(scrollable=True)
-                if not scrollable.exists:
-                    continue
+            info = _match()
+            if info is not None:  # already on-screen
+                return _result(info)
 
-                # Native scrollIntoView (both directions, stops at element).
-                found = False
-                try:
-                    found = bool(scrollable.scroll.to(**sel))
-                except AttributeError:
-                    # Older/newer u2 without .scroll.to — bounded manual fallback.
-                    try:
-                        w, h = device.window_size()
-                    except Exception:
-                        w, h = 1080, 1920
-                    mid_x = w // 2
-                    start_y, end_y = int(h * 0.7), int(h * 0.3)
-                    for _ in range(max_swipes):
-                        if target.exists:
-                            found = True
-                            break
-                        device.swipe(mid_x, start_y, mid_x, end_y, duration=0.3)
-                except Exception as e:
-                    logger.debug("scroll_into_view native scroll failed (%s)", e)
+            try:
+                w, h = device.window_size()
+            except Exception:
+                w, h = 1080, 2160
+            cx, y_lo, y_hi = w // 2, int(h * 0.30), int(h * 0.72)
 
-                if found and target.exists:
-                    return _result(target, label)
+            def _scroll(y1: int, y2: int) -> None:
+                # Metered stepped swipe: no fling (target stays where it lands)
+                # and no row press/long-press. A plain duration-swipe flings and
+                # a drag highlights rows.
+                device.swipe(cx, y1, cx, y2, steps=25)
 
+            # Sweep down (reveal rows below) then up (rows above / top-anchored
+            # controls), re-checking after each swipe.
+            sweeps = [(y_hi, y_lo)] * max_swipes + [(y_lo, y_hi)] * (max_swipes * 2)
+            for y1, y2 in sweeps:
+                _scroll(y1, y2)
+                info = _match()
+                if info is not None:
+                    return _result(info)
             return None
 
         try:
             return await asyncio.to_thread(_do)
         except Exception as e:
-            logger.debug("scroll_into_view fell back (%s)", e)
+            logger.debug("scroll_into_view failed (%s)", e)
             return None
 
     async def swipe(


### PR DESCRIPTION
Follow-up to #51 (scroll_to_element) — replaces the native `UiScrollable.scrollIntoView` implementation with a swipe loop that works across this app's mix of scroll containers.

## Why

Native `scroll.to()` is unreliable here (verified live, #50):
- **Compose `LazyColumn`** (Settings) — not flagged `scrollable=true`, so native scroll **no-ops entirely**.
- **Compose content in a classic `ScrollView`** (Profile) — native scroll runs but **can't match lazily-composed off-screen rows**.
- **View `RecyclerView`** (cache detail) — works, but recycles top-anchored items.

## What

A bounded, **metered coordinate-swipe loop** that re-checks the target by selector (`obj.exists` — no `dump_hierarchy`, so no dump-induced scroll, #49) after each swipe. Stepped swipes (`steps=25`) avoid fling (target stays where it lands) and don't register as a row press. Sweeps down first, then up (for top-anchored controls). Matching is `.exists` + `bounds` — these containers only keep on-screen rows in the tree, so that's equivalent to "visible."

## Verification (live)

All three container types, two OS versions, target scrolled into view **and stable after a screenshot**:

| Device | RecyclerView | Compose ScrollView | Compose LazyColumn |
|---|---|---|---|
| Pixel 10 (Android 16) | ✅ `button_log` | ✅ "Shop Geocaching" | ✅ "Sign out" |
| Emulator (Android 12) | ✅ `button_log` | — | — |

## Note

Depends on the screen-on-detection fix (#53, merged). Before that, the screenshot's `wake_screen` swipe scrolled the result back off-screen on physical devices — which masked this working and sent the investigation down a long rabbit hole. With #53 in, the swipe loop is stable.

Refs #50.