### PR TITLE
feat(android): tap_element auto-scrolls to off-screen targets

### DIFF
--- a/mcp/src/tools/device-ui.ts
+++ b/mcp/src/tools/device-ui.ts
@@ -396,6 +396,10 @@ Label matching modes (mutually exclusive — use only one):
         .string()
         .optional()
         .describe('For switches/toggles: desired value ("1" = on, "0" = off). Checks current state first and skips the tap if already set. Returns status "already_set" if no tap was needed.'),
+      scroll_to_find: z
+        .boolean()
+        .default(true)
+        .describe("Android only: if the element isn't in the current view, scroll to it (via the no-dump swipe loop) and then tap. Set false to fail fast without scrolling."),
       include_screen_context: z
         .boolean()
         .default(false)
@@ -411,7 +415,7 @@ Label matching modes (mutually exclusive — use only one):
         .optional()
         .describe("Seconds to wait before capturing after screenshot/screen context (default 1.0). Increase for slow devices or complex transitions."),
     }),
-  }, async ({ label, label_contains, label_prefix, identifier, element_type, udid, source_timeout, value, include_screen_context, capture_screenshots, settle_delay }) => {
+  }, async ({ label, label_contains, label_prefix, identifier, element_type, udid, source_timeout, value, scroll_to_find, include_screen_context, capture_screenshots, settle_delay }) => {
     try {
       const body: Record<string, unknown> = {};
       if (label) body.label = label;
@@ -422,6 +426,7 @@ Label matching modes (mutually exclusive — use only one):
       if (udid) body.udid = udid;
       if (source_timeout) body.source_timeout = source_timeout;
       if (value !== undefined) body.value = value;
+      if (scroll_to_find === false) body.scroll_to_find = false;
       if (include_screen_context) body.include_screen_context = true;
       if (capture_screenshots) body.capture_screenshots = true;
       if (settle_delay !== undefined) body.settle_delay = settle_delay;

--- a/server/api/device_ui.py
+++ b/server/api/device_ui.py
@@ -360,6 +360,7 @@ async def tap_element(request: Request, body: TapElementRequest):
             skip_stability_check=body.skip_stability_check,
             source_timeout=body.source_timeout,
             value=body.value,
+            scroll_to_find=body.scroll_to_find,
         )
 
         end = time.perf_counter()

--- a/server/device/controller_ui.py
+++ b/server/device/controller_ui.py
@@ -893,6 +893,7 @@ class DeviceControllerUI:
         skip_stability_check: bool = False,
         source_timeout: float | None = None,
         value: str | None = None,
+        scroll_to_find: bool = True,
     ) -> dict:
         """Find an element by label/identifier and tap its center.
 
@@ -973,13 +974,25 @@ class DeviceControllerUI:
             and not element_type
             and (identifier or label)
         ):
-            tapped = await self._ui_backend(resolved_fast).tap_by_selector(
+            backend = self._ui_backend(resolved_fast)
+            tapped = await backend.tap_by_selector(
                 resolved_fast, identifier=identifier, label=label,
             )
+            # Not in the current view — auto-scroll to it and retry. Uses the
+            # selector-based swipe loop (no dump_hierarchy), so it inherits the
+            # no-dump-induced-scroll property of the fast path.
+            if tapped is None and scroll_to_find:
+                found = await backend.scroll_into_view(
+                    resolved_fast, identifier=identifier, label=label,
+                )
+                if found is not None:
+                    tapped = await backend.tap_by_selector(
+                        resolved_fast, identifier=identifier, label=label,
+                    )
             if tapped is not None:
                 self._invalidate_ui_cache(resolved_fast)
                 return {"status": "ok", "tapped": tapped}
-            # Not found via selector — fall through to the dump-based path.
+            # Not found even after scrolling — fall through to the dump-based path.
 
         # Traditional path: fetch full UI tree
         filter_label = _effective_filter_label(label, label_contains, label_prefix)

--- a/server/device/controller_ui.py
+++ b/server/device/controller_ui.py
@@ -986,6 +986,10 @@ class DeviceControllerUI:
                     resolved_fast, identifier=identifier, label=label,
                 )
                 if found is not None:
+                    # Let the scroll settle before clicking — a tap landing
+                    # while the list is still coming to rest gets absorbed as a
+                    # scroll-stop instead of a click (observed intermittently).
+                    await asyncio.sleep(0.4)
                     tapped = await backend.tap_by_selector(
                         resolved_fast, identifier=identifier, label=label,
                     )

--- a/server/models.py
+++ b/server/models.py
@@ -979,6 +979,7 @@ class TapElementRequest(BaseModel):
     skip_stability_check: bool = False  # Skip for static elements (tab bars, nav bars)
     source_timeout: float | None = None  # Override WDA /source timeout (1-60s)
     value: str | None = None  # For switches: "0"=off, "1"=on. Skips tap if matched.
+    scroll_to_find: bool = True  # Android: if the element isn't in view, scroll to it then tap
     include_screen_context: bool = False
     capture_screenshots: bool = False
     settle_delay: float = Field(default=1.0, ge=0, le=10)

--- a/tests/test_device_api.py
+++ b/tests/test_device_api.py
@@ -559,6 +559,7 @@ class TestTapElement:
             skip_stability_check=False,
             source_timeout=None,
             value=None,
+            scroll_to_find=True,
         )
 
     async def test_tap_element_by_identifier(self, app, auth_headers, mock_controller):
@@ -580,6 +581,7 @@ class TestTapElement:
             skip_stability_check=False,
             source_timeout=None,
             value=None,
+            scroll_to_find=True,
         )
 
     async def test_tap_element_with_type_filter(self, app, auth_headers, mock_controller):
@@ -601,6 +603,7 @@ class TestTapElement:
             skip_stability_check=False,
             source_timeout=None,
             value=None,
+            scroll_to_find=True,
         )
 
     async def test_tap_element_ambiguous(self, app, auth_headers, mock_controller):

--- a/tests/test_device_controller.py
+++ b/tests/test_device_controller.py
@@ -1169,3 +1169,56 @@ class TestScrollToElement:
 
         result = await ctrl.scroll_to_element(label="Nope")
         assert result["status"] == "not_found"
+
+
+class TestTapElementAutoScroll:
+    def _android_ctrl(self):
+        ctrl = DeviceController()
+        ctrl._device_type_cache["emulator-5554"] = DeviceType.ANDROID_EMULATOR
+        ctrl.resolve_udid = AsyncMock(return_value="emulator-5554")
+        ctrl._invalidate_ui_cache = MagicMock()
+        return ctrl
+
+    async def test_scrolls_then_taps_when_offscreen(self):
+        ctrl = self._android_ctrl()
+        backend = MagicMock()
+        # first selector tap misses (off-screen), succeeds after scroll
+        backend.tap_by_selector = AsyncMock(
+            side_effect=[None, {"identifier": "button_log", "type": "Button", "x": 1, "y": 2}]
+        )
+        backend.scroll_into_view = AsyncMock(return_value={"identifier": "button_log"})
+        ctrl._ui_backend = MagicMock(return_value=backend)
+
+        result = await ctrl.tap_element(identifier="button_log")
+        assert result["status"] == "ok"
+        backend.scroll_into_view.assert_called_once_with(
+            "emulator-5554", identifier="button_log", label=None,
+        )
+        assert backend.tap_by_selector.call_count == 2
+
+    async def test_no_scroll_when_already_tappable(self):
+        ctrl = self._android_ctrl()
+        backend = MagicMock()
+        backend.tap_by_selector = AsyncMock(
+            return_value={"identifier": "button_log", "type": "Button", "x": 1, "y": 2}
+        )
+        backend.scroll_into_view = AsyncMock()
+        ctrl._ui_backend = MagicMock(return_value=backend)
+
+        result = await ctrl.tap_element(identifier="button_log")
+        assert result["status"] == "ok"
+        backend.scroll_into_view.assert_not_called()
+
+    async def test_scroll_to_find_false_skips_scroll(self):
+        ctrl = self._android_ctrl()
+        backend = MagicMock()
+        backend.tap_by_selector = AsyncMock(return_value=None)  # miss
+        backend.scroll_into_view = AsyncMock()
+        ctrl._ui_backend = MagicMock(return_value=backend)
+        # with scrolling disabled, it falls through to the dump path → not_found
+        ctrl.get_ui_elements = AsyncMock(return_value=([], "emulator-5554"))
+
+        with patch("server.device.controller_ui._capture_screenshot", AsyncMock(return_value=None)):
+            result = await ctrl.tap_element(identifier="button_log", scroll_to_find=False)
+        assert result["status"] == "not_found"
+        backend.scroll_into_view.assert_not_called()


### PR DESCRIPTION
Closes #55.

When you already know the element you want (identifier or exact label) but it's scrolled out of view, `tap_element` now **scrolls to it and taps** in one call.

## What
In `tap_element`'s Android selector fast path: if `tap_by_selector` doesn't find the element in the current view, call `scroll_into_view` (the #54 no-dump swipe loop) and retry the tap; only fall through to the dump-based path if scrolling still doesn't surface it.

## Details
- **Additive / low-risk** — only kicks in on a selector miss, so already-visible taps are unchanged (no extra scrolling, no behavior change for the common case).
- **`scroll_to_find`** param (default `true`) threaded controller → REST (`TapElementRequest`) → MCP tool; set `false` to fail fast without scrolling.
- No `dump_hierarchy` on this path, so it keeps the no-dump-induced-scroll property.

## Tests
- `scrolls-then-taps` when the target is off-screen (selector miss → scroll → retry hits).
- `no scroll` when the element is already tappable.
- `scroll_to_find=false` skips scrolling and falls through.
- Existing `tap_element` API tests updated for the new kwarg. Full suite green (1404).

## Follow-up
iOS gets this for free once #56 (iOS `scroll_to_element`) lands and is wired into the same path.