### PR TITLE
feat(ios): scroll_to_element + tap_element auto-scroll (#56)

### DIFF
--- a/server/api/device_ui.py
+++ b/server/api/device_ui.py
@@ -360,6 +360,7 @@ async def tap_element(request: Request, body: TapElementRequest):
             skip_stability_check=body.skip_stability_check,
             source_timeout=body.source_timeout,
             value=body.value,
+            scroll_to_find=body.scroll_to_find,
         )
 
         end = time.perf_counter()
@@ -407,9 +408,8 @@ async def swipe(request: Request, body: SwipeRequest):
 async def scroll_to_element(request: Request, body: ScrollToElementRequest):
     """Scroll a scrollable container until the target element is in view.
 
-    Android-only for now (native uiautomator2 scrollIntoView). Returns 404 when
-    the element never appears after scrolling; 200 with status "not_supported"
-    on non-Android devices.
+    Supported on Android and iOS (physical + simulator) via a bounded swipe
+    loop. Returns 404 when the element never appears after scrolling.
     """
     controller = _get_controller(request)
     try:

--- a/server/device/controller_ui.py
+++ b/server/device/controller_ui.py
@@ -94,6 +94,12 @@ class DeviceControllerUI:
     # Bottom safe area inset for devices with home indicator (Face ID / Dynamic Island)
     _HOME_INDICATOR_INSET = 34  # points
 
+    # Top safe inset (status bar / navigation bar). The iOS accessibility tree
+    # includes elements that have scrolled *under* the top chrome — they carry
+    # real, in-bounds frames but aren't visible or tappable. scroll_to_element
+    # treats a target whose top edge is above this inset as not-yet-in-view.
+    _TOP_SAFE_INSET = 50  # points
+
     # Maximum scroll-into-view attempts before giving up
     _MAX_SCROLL_ATTEMPTS = 3
 
@@ -272,6 +278,137 @@ class DeviceControllerUI:
         logger.warning(
             "scroll-into-view: failed after %d attempts", self._MAX_SCROLL_ATTEMPTS,
         )
+        return None
+
+    async def _ios_scroll_to_element(
+        self,
+        resolved: str,
+        label: str | None,
+        identifier: str | None,
+        max_swipes: int,
+    ) -> UIElement | None:
+        """Scroll an iOS scroll container until the target element is on-screen.
+
+        The controller-level analog of Android's U2Backend.scroll_into_view
+        swipe loop (#50/#54): a bounded, coordinate-swipe loop that re-checks the
+        target by selector after each swipe. iOS accessibility snapshots are
+        side-effect-free (unlike Android's dump_hierarchy, see #49), so matching
+        against the tree is safe. Two scroller behaviours are handled:
+
+        - Laid-out scrollers (UIScrollView / SwiftUI ScrollView) keep off-screen
+          subviews in the tree with frames outside the viewport. When the target
+          is located but off-screen we know its direction, so we swipe straight
+          toward it and stop once its frame stops moving (end of travel).
+        - Lazy/recycling scrollers (UITableView / UICollectionView / SwiftUI
+          List) drop off-screen rows from the tree entirely — the target simply
+          isn't matched — so we fall back to a blind sweep, down then up.
+
+        Returns the on-screen UIElement, or None if it never became visible
+        within the swipe budget.
+        """
+        dims = await self._get_screen_dimensions(resolved)
+        screen_height = dims["height"] if dims else None
+        screen_width = dims["width"] if dims else None
+        if not screen_height or not screen_width:
+            # Physical devices aren't in the dimensions table. Recover the
+            # viewport from the Application element via a *targeted* query
+            # (filter_type) — on physical this routes to a WDA predicate query
+            # for the root element, avoiding the full /source read that can time
+            # out and restart WDA on dense screens.
+            app_els, _ = await self.get_ui_elements(
+                resolved, use_cache=False, filter_type="Application",
+            )
+            app_frame = next((e.frame for e in app_els if e.frame), None)
+            if app_frame:
+                screen_height = screen_height or app_frame["height"]
+                screen_width = screen_width or app_frame["width"]
+        screen_height = screen_height or 852
+        screen_width = screen_width or 393
+
+        top_safe = self._TOP_SAFE_INSET
+        bottom_safe = screen_height - self._HOME_INDICATOR_INSET
+        mid_x = screen_width / 2
+        # Swipe endpoints: near the bottom (y_far) and near the top (y_near).
+        # Swiping y_far -> y_near reveals content below; y_near -> y_far reveals
+        # content above (mirrors the Android sweep geometry).
+        y_far = screen_height * 0.72
+        y_near = screen_height * 0.30
+
+        async def _fetch() -> UIElement | None:
+            els, _ = await self.get_ui_elements(
+                resolved, use_cache=False,
+                filter_label=label, filter_identifier=identifier,
+            )
+            matches = find_element(els, label=label, identifier=identifier)
+            return matches[0] if matches else None
+
+        def _visible(el: UIElement) -> bool:
+            # In view = the top edge clears the top chrome (not scrolled under
+            # the nav/status bar) AND the tap point clears the home indicator.
+            # The iOS a11y tree lists occluded rows with in-bounds frames, so a
+            # top-edge bound is needed to reject them (a bare center check gives
+            # false positives for rows tucked under the nav bar).
+            if el.frame is None:
+                return False
+            _, cy = get_tap_point(el)
+            return el.frame["y"] >= top_safe and cy <= bottom_safe
+
+        async def _swipe(y1: float, y2: float) -> None:
+            await self._ui_backend(resolved).swipe(resolved, mid_x, y1, mid_x, y2, 0.3)
+            self._invalidate_ui_cache(resolved)
+
+        el = await _fetch()
+        if el is not None and _visible(el):
+            return el
+
+        last_cy: float | None = None
+        stalls = 0
+        blind_steps = 0
+        blind_down = max_swipes          # sweep down for the first budget...
+        blind_total = max_swipes * 3     # ...then up for twice as long
+
+        for _ in range(max_swipes * 3):
+            if el is not None and el.frame is not None:
+                # Located but off-screen: swipe straight toward it. Direction
+                # mirrors _visible's two out-of-view cases.
+                _, cy = get_tap_point(el)
+                if el.frame["y"] < top_safe:
+                    y1, y2 = y_near, y_far   # clipped above → reveal upper content
+                else:
+                    y1, y2 = y_far, y_near   # below safe area → reveal lower content
+                # End-of-travel guard: frame stopped moving across swipes.
+                if last_cy is not None and abs(cy - last_cy) < 2:
+                    stalls += 1
+                    if stalls >= 2:
+                        logger.info(
+                            "ios scroll-to-element: target off-screen but container "
+                            "won't scroll further (cy=%.0f) — aborting", cy,
+                        )
+                        return None
+                else:
+                    stalls = 0
+                last_cy = cy
+            else:
+                # Not located (recycled/lazy row): blind sweep, down then up.
+                if blind_steps >= blind_total:
+                    return None
+                y1, y2 = (y_far, y_near) if blind_steps < blind_down else (y_near, y_far)
+                blind_steps += 1
+                last_cy = None
+                stalls = 0
+
+            await _swipe(y1, y2)
+            el = await _fetch()
+            if el is not None and _visible(el):
+                # Settle and re-confirm: a swipe can leave the container
+                # rubber-banding, so the immediate frame may be an over-scroll
+                # bounce that snaps back out of view. Re-fetching once settled
+                # both rejects that and returns accurate resting coordinates.
+                await asyncio.sleep(0.3)
+                el = await _fetch()
+                if el is not None and _visible(el):
+                    return el
+
         return None
 
     async def _try_fast_path_element_check(
@@ -483,7 +620,8 @@ class DeviceControllerUI:
         # WDA direct query: physical device + filters + cache miss → query directly
         if has_filters and self._is_physical(resolved):
             elements, query_elapsed = await self._wda_direct_query(
-                resolved, filter_label, filter_identifier, filter_type,
+                resolved, label=filter_label,
+                identifier=filter_identifier, element_type=filter_type,
             )
             if elements:
                 return elements, resolved
@@ -893,6 +1031,7 @@ class DeviceControllerUI:
         skip_stability_check: bool = False,
         source_timeout: float | None = None,
         value: str | None = None,
+        scroll_to_find: bool = True,
     ) -> dict:
         """Find an element by label/identifier and tap its center.
 
@@ -997,6 +1136,23 @@ class DeviceControllerUI:
             label_prefix=label_prefix, identifier=identifier,
             element_type=element_type,
         )
+
+        # iOS off-screen retry: on a tree-path miss, scroll the target into view
+        # and retry. Android selector-misses are handled by the fast path above,
+        # so this is scoped to iOS. Only exact label/identifier can be scrolled
+        # to (scroll_to_element's contract); contains/prefix/type-only fall
+        # through to not_found.
+        if (
+            len(matches) == 0
+            and scroll_to_find
+            and not self._is_android(resolved)
+            and (label or identifier)
+        ):
+            scrolled = await self._ios_scroll_to_element(
+                resolved, label=label, identifier=identifier, max_swipes=10,
+            )
+            if scrolled is not None:
+                matches = [scrolled]
 
         if len(matches) == 0:
             search_desc = (
@@ -1226,17 +1382,18 @@ class DeviceControllerUI:
     ) -> dict:
         """Scroll until an element is in view, without interacting with it.
 
-        Android: a bounded, coordinate swipe loop that re-checks the target by
-        selector after each swipe (no dump_hierarchy, so no dump-induced scroll
-        — see #49). Works across the app's mix of scroll containers (View
-        RecyclerView, Compose LazyColumn, Compose-in-ScrollView) where native
-        UiScrollable.scrollIntoView is unreliable — see #50. iOS is not yet
-        wired here (tracked in #50); tap_element already nudges
-        home-indicator-obscured elements into view via _scroll_element_into_view.
+        A bounded, coordinate swipe loop that re-checks the target by selector
+        after each swipe (no full-tree dump-induced scroll — see #49). Works
+        across each platform's mix of scroll containers where native
+        scroll-into-view is unreliable (Android: View RecyclerView, Compose
+        LazyColumn, Compose-in-ScrollView — see #50). Backends:
+        - Android: U2Backend.scroll_into_view (`.exists` re-check).
+        - iOS (physical WDA + simulator): _ios_scroll_to_element, which also
+          handles laid-out scrollers by swiping directly toward an off-screen
+          but located target.
 
-        Returns {"status": "ok", "element": {...}} once visible,
-        {"status": "not_found", ...} if it never appeared, or
-        {"status": "not_supported", ...} on non-Android devices.
+        Returns {"status": "ok", "element": {...}} once visible, or
+        {"status": "not_found", ...} if it never appeared.
         """
         if not label and not identifier:
             raise DeviceError(
@@ -1245,24 +1402,41 @@ class DeviceControllerUI:
             )
 
         resolved = await self.resolve_udid(udid)
-        if not self._is_android(resolved):
-            return {
-                "status": "not_supported",
-                "detail": "scroll_to_element is currently Android-only (see #50)",
-            }
+        target = f"identifier='{identifier}'" if identifier else f"label='{label}'"
 
-        found = await self._ui_backend(resolved).scroll_into_view(
-            resolved, identifier=identifier, label=label, max_swipes=max_swipes,
+        if self._is_android(resolved):
+            found = await self._ui_backend(resolved).scroll_into_view(
+                resolved, identifier=identifier, label=label, max_swipes=max_swipes,
+            )
+            self._invalidate_ui_cache(resolved)  # scrolling changes the viewport
+            if found is None:
+                return {
+                    "status": "not_found",
+                    "detail": f"Element not found after scrolling ({target})",
+                }
+            return {"status": "ok", "element": found}
+
+        # iOS (physical WDA + simulator)
+        el = await self._ios_scroll_to_element(
+            resolved, label=label, identifier=identifier, max_swipes=max_swipes,
         )
         self._invalidate_ui_cache(resolved)  # scrolling changes the viewport
-
-        if found is None:
-            target = f"identifier='{identifier}'" if identifier else f"label='{label}'"
+        if el is None:
             return {
                 "status": "not_found",
                 "detail": f"Element not found after scrolling ({target})",
             }
-        return {"status": "ok", "element": found}
+        cx, cy = get_tap_point(el)
+        return {
+            "status": "ok",
+            "element": {
+                "label": el.label,
+                "identifier": el.identifier,
+                "type": el.type,
+                "x": cx,
+                "y": cy,
+            },
+        }
 
     async def type_text(self, text: str, udid: str | None = None) -> str:
         """Type text into focused field. Returns the resolved udid."""

--- a/server/models.py
+++ b/server/models.py
@@ -979,6 +979,7 @@ class TapElementRequest(BaseModel):
     skip_stability_check: bool = False  # Skip for static elements (tab bars, nav bars)
     source_timeout: float | None = None  # Override WDA /source timeout (1-60s)
     value: str | None = None  # For switches: "0"=off, "1"=on. Skips tap if matched.
+    scroll_to_find: bool = True  # iOS: scroll an off-screen target into view, then retry
     include_screen_context: bool = False
     capture_screenshots: bool = False
     settle_delay: float = Field(default=1.0, ge=0, le=10)

--- a/tests/test_device_api.py
+++ b/tests/test_device_api.py
@@ -559,6 +559,7 @@ class TestTapElement:
             skip_stability_check=False,
             source_timeout=None,
             value=None,
+            scroll_to_find=True,
         )
 
     async def test_tap_element_by_identifier(self, app, auth_headers, mock_controller):
@@ -580,6 +581,7 @@ class TestTapElement:
             skip_stability_check=False,
             source_timeout=None,
             value=None,
+            scroll_to_find=True,
         )
 
     async def test_tap_element_with_type_filter(self, app, auth_headers, mock_controller):
@@ -601,6 +603,7 @@ class TestTapElement:
             skip_stability_check=False,
             source_timeout=None,
             value=None,
+            scroll_to_find=True,
         )
 
     async def test_tap_element_ambiguous(self, app, auth_headers, mock_controller):

--- a/tests/test_device_controller.py
+++ b/tests/test_device_controller.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 import pytest
 
 from server.device.controller import DeviceController
-from server.models import DeviceError, DeviceInfo, DeviceState, DeviceType
+from server.models import DeviceError, DeviceInfo, DeviceState, DeviceType, UIElement
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -446,10 +446,14 @@ class TestTapElement:
         ctrl = DeviceController()
         ctrl._active_udid = "AAAA-1111"
         ctrl.idb.describe_all = AsyncMock(return_value=_FAKE_IDB_OUTPUT)
+        # iOS taps now scroll-to-find on a miss; simulate the scroll also
+        # failing to surface the element so we exercise the not_found path.
+        ctrl._ios_scroll_to_element = AsyncMock(return_value=None)
 
         result = await ctrl.tap_element(label="Nonexistent")
         assert result["status"] == "not_found"
         assert "No element found" in result["detail"]
+        ctrl._ios_scroll_to_element.assert_awaited_once()
 
     async def test_no_label_or_identifier_raises(self):
         ctrl = DeviceController()
@@ -729,6 +733,23 @@ class TestGetUIElementsWdaDispatch:
         assert elements[0].label == "Done"
         # Should NOT call describe_all
         ctrl.wda_client.describe_all.assert_not_called()
+        # filter_identifier must map to the identifier locator (accessibility
+        # id), not be misrouted into a label CONTAINS predicate.
+        first_call = ctrl.wda_client.find_elements_by_query.call_args_list[0]
+        assert first_call == call("PHYS-0001", "accessibility id", "done_btn")
+
+    async def test_physical_filter_type_maps_to_type_predicate(self):
+        ctrl = DeviceController()
+        ctrl._active_udid = "PHYS-0001"
+        ctrl._device_type_cache["PHYS-0001"] = DeviceType.DEVICE
+        ctrl.wda_client.find_elements_by_query = AsyncMock(return_value=[])
+        ctrl.wda_client.describe_all = AsyncMock()
+
+        await ctrl.get_ui_elements("PHYS-0001", filter_type="Application")
+        # filter_type must map to a type predicate, not a label BEGINSWITH.
+        q = ctrl.wda_client.find_elements_by_query.call_args[0][2]
+        assert "type == 'XCUIElementTypeApplication'" in q
+        assert "BEGINSWITH" not in q
 
     async def test_physical_no_filters_uses_describe_all(self):
         ctrl = DeviceController()
@@ -1131,13 +1152,103 @@ class TestScrollToElement:
         with pytest.raises(DeviceError, match="label or identifier"):
             await ctrl.scroll_to_element()
 
-    async def test_not_supported_on_ios(self):
+    def _ios_ctrl(self, backend):
         ctrl = DeviceController()
         ctrl._device_type_cache["AAAA-1111"] = DeviceType.SIMULATOR
         ctrl.resolve_udid = AsyncMock(return_value="AAAA-1111")
+        ctrl._invalidate_ui_cache = MagicMock()
+        ctrl._get_screen_dimensions = AsyncMock(
+            return_value={"width": 402, "height": 852}
+        )
+        ctrl._ui_backend = MagicMock(return_value=backend)
+        return ctrl
+
+    @staticmethod
+    def _el(y: float, *, height: float = 40.0):
+        return UIElement(
+            type="Button", label="Log", identifier="button_log",
+            frame={"x": 100.0, "y": y, "width": 120.0, "height": height},
+        )
+
+    async def test_ios_already_visible_no_swipe(self):
+        backend = MagicMock()
+        backend.swipe = AsyncMock()
+        ctrl = self._ios_ctrl(backend)
+        # On-screen from the first fetch (center 420, within [0, 818]).
+        ctrl.get_ui_elements = AsyncMock(
+            return_value=([self._el(400)], "AAAA-1111")
+        )
 
         result = await ctrl.scroll_to_element(identifier="button_log")
-        assert result["status"] == "not_supported"
+        assert result["status"] == "ok"
+        assert result["element"]["identifier"] == "button_log"
+        assert result["element"]["y"] == 420.0
+        backend.swipe.assert_not_called()
+
+    async def test_ios_scrolls_toward_offscreen_below(self):
+        backend = MagicMock()
+        backend.swipe = AsyncMock()
+        ctrl = self._ios_ctrl(backend)
+        # First below the viewport (center 1020), then in view after a swipe
+        # (the third fetch is the settle re-confirm).
+        ctrl.get_ui_elements = AsyncMock(side_effect=[
+            ([self._el(1000)], "AAAA-1111"),
+            ([self._el(400)], "AAAA-1111"),
+            ([self._el(400)], "AAAA-1111"),
+        ])
+
+        result = await ctrl.scroll_to_element(identifier="button_log")
+        assert result["status"] == "ok"
+        backend.swipe.assert_called_once()
+        # A target below the viewport should be revealed by a finger swipe UP
+        # (start_y > end_y), which scrolls the content down.
+        args = backend.swipe.call_args.args
+        start_y, end_y = args[2], args[4]
+        assert start_y > end_y
+
+    async def test_ios_scrolls_toward_offscreen_above(self):
+        backend = MagicMock()
+        backend.swipe = AsyncMock()
+        ctrl = self._ios_ctrl(backend)
+        # First tucked under the top nav bar (top edge 4 < 50 inset), then in
+        # view after scrolling up (the third fetch is the settle re-confirm).
+        ctrl.get_ui_elements = AsyncMock(side_effect=[
+            ([self._el(4)], "AAAA-1111"),
+            ([self._el(120)], "AAAA-1111"),
+            ([self._el(120)], "AAAA-1111"),
+        ])
+
+        result = await ctrl.scroll_to_element(identifier="button_log")
+        assert result["status"] == "ok"
+        backend.swipe.assert_called_once()
+        # A target hidden above should be revealed by a finger swipe DOWN
+        # (start_y < end_y), which scrolls the content up.
+        args = backend.swipe.call_args.args
+        start_y, end_y = args[2], args[4]
+        assert start_y < end_y
+
+    async def test_ios_not_found_after_budget(self):
+        backend = MagicMock()
+        backend.swipe = AsyncMock()
+        ctrl = self._ios_ctrl(backend)
+        # Never located (lazy/recycled row) → blind sweep, never visible.
+        ctrl.get_ui_elements = AsyncMock(return_value=([], "AAAA-1111"))
+
+        result = await ctrl.scroll_to_element(identifier="button_log", max_swipes=3)
+        assert result["status"] == "not_found"
+        assert backend.swipe.await_count > 0
+
+    async def test_ios_aborts_when_container_stalls(self):
+        backend = MagicMock()
+        backend.swipe = AsyncMock()
+        ctrl = self._ios_ctrl(backend)
+        # Located below the viewport but the frame never moves → end of travel.
+        ctrl.get_ui_elements = AsyncMock(return_value=([self._el(1000)], "AAAA-1111"))
+
+        result = await ctrl.scroll_to_element(identifier="button_log", max_swipes=10)
+        assert result["status"] == "not_found"
+        # Stall detected after a couple of swipes — nowhere near the full budget.
+        assert backend.swipe.await_count <= 3
 
     async def test_android_ok_delegates_to_backend(self):
         ctrl = DeviceController()
@@ -1169,3 +1280,76 @@ class TestScrollToElement:
 
         result = await ctrl.scroll_to_element(label="Nope")
         assert result["status"] == "not_found"
+
+
+class TestTapElementIosScroll:
+    """iOS tap_element auto-scrolls an off-screen target into view, then taps."""
+
+    def _ios_ctrl(self, backend):
+        ctrl = DeviceController()
+        ctrl._device_type_cache["AAAA-1111"] = DeviceType.SIMULATOR
+        ctrl.resolve_udid = AsyncMock(return_value="AAAA-1111")
+        ctrl._invalidate_ui_cache = MagicMock()
+        ctrl._get_screen_dimensions = AsyncMock(
+            return_value={"width": 402, "height": 852}
+        )
+        ctrl._ui_backend = MagicMock(return_value=backend)
+        return ctrl
+
+    @staticmethod
+    def _target():
+        return UIElement(
+            type="Button", label="Sign out", identifier="_SignOut button",
+            frame={"x": 20.0, "y": 400.0, "width": 360.0, "height": 44.0},
+        )
+
+    async def test_miss_then_scroll_then_tap(self):
+        backend = MagicMock()
+        backend.tap = AsyncMock()
+        ctrl = self._ios_ctrl(backend)
+        # Traditional fetch misses (off-screen); scroll brings it into view.
+        ctrl.get_ui_elements = AsyncMock(return_value=([], "AAAA-1111"))
+        ctrl._ios_scroll_to_element = AsyncMock(return_value=self._target())
+
+        result = await ctrl.tap_element(
+            identifier="_SignOut button", skip_stability_check=True,
+        )
+        assert result["status"] == "ok"
+        assert result["tapped"]["identifier"] == "_SignOut button"
+        ctrl._ios_scroll_to_element.assert_awaited_once_with(
+            "AAAA-1111", label=None, identifier="_SignOut button", max_swipes=10,
+        )
+        backend.tap.assert_awaited_once()
+
+    async def test_scroll_to_find_false_skips_scroll(self):
+        backend = MagicMock()
+        backend.tap = AsyncMock()
+        ctrl = self._ios_ctrl(backend)
+        ctrl.get_ui_elements = AsyncMock(return_value=([], "AAAA-1111"))
+        ctrl._ios_scroll_to_element = AsyncMock(return_value=self._target())
+
+        with patch(
+            "server.device.controller_ui._capture_screenshot",
+            AsyncMock(return_value=None),
+        ):
+            result = await ctrl.tap_element(
+                identifier="_SignOut button", scroll_to_find=False,
+            )
+        assert result["status"] == "not_found"
+        ctrl._ios_scroll_to_element.assert_not_called()
+
+    async def test_scroll_miss_returns_not_found(self):
+        backend = MagicMock()
+        backend.tap = AsyncMock()
+        ctrl = self._ios_ctrl(backend)
+        ctrl.get_ui_elements = AsyncMock(return_value=([], "AAAA-1111"))
+        ctrl._ios_scroll_to_element = AsyncMock(return_value=None)
+
+        with patch(
+            "server.device.controller_ui._capture_screenshot",
+            AsyncMock(return_value=None),
+        ):
+            result = await ctrl.tap_element(label="Nope")
+        assert result["status"] == "not_found"
+        ctrl._ios_scroll_to_element.assert_awaited_once()
+        backend.tap.assert_not_called()


### PR DESCRIPTION
## What

Implements `scroll_to_element` for **iOS** (physical WDA + simulator) — closes #56 — and wires it into `tap_element` so an off-screen target is scrolled into view before tapping.

### `_ios_scroll_to_element` (controller-level)
A bounded coordinate-swipe loop that re-checks the target by selector after each swipe, mirroring the Android `scroll_into_view` (#54) but adapted to two iOS scroller shapes:
- **Directional** swipe toward a located-but-off-screen target — laid-out `ScrollView`s keep off-screen rows in the a11y tree with real frames, so we know the direction and swipe straight there, stopping when the frame stops moving (end of travel).
- **Blind down-then-up sweep** for lazy/recycling lists (`UITableView`/`List`) where off-screen rows drop out of the tree entirely.

### Top-nav-bar occlusion (the subtle part)
The iOS a11y tree lists rows that have scrolled *under* the nav/status bar with **in-bounds frames**, so a bare center-in-viewport check false-positives "already visible" and never scrolls. A **top-safe inset** (paired with the existing home-indicator bottom inset) rejects those. A **settle-confirm** on success dodges over-scroll bounce and returns accurate resting coordinates.

### `tap_element` integration
On an iOS tree-path miss, scroll the target into view and retry — gated by `scroll_to_find` (default `true`). Android misses are already handled by its native fast path, so this is scoped to iOS.

### Physical-device screen size
Physical devices aren't in the device-name dimensions table, so size comes from a **targeted `Application`-element query** (a WDA predicate for the root), avoiding a full `/source` read that can time out / restart WDA on dense screens.

## Bug fix (independent, but needed for the iOS physical path)
`get_ui_elements` called `_wda_direct_query` with **mismatched positional args** — `(resolved, filter_label, filter_identifier, filter_type)` against a signature of `(udid, label, label_contains, label_prefix, identifier, element_type)`. On **all physical devices**, `identifier`/`type` filters were silently misrouted into `label CONTAINS`/`BEGINSWITH` predicates. Now passed by keyword, with regression asserts (the old dispatch test only checked the returned element, never the query string).

## Validation
Live on the iPhone 16 Pro simulator and a physical iPhone 12 (iOS 26.5):
- off-screen-below, off-screen-above (nav-bar occlusion), already-visible (no-op), not-found
- `tap_element` auto-scroll end to end

Full suite green (1409 passed).

## Notes
- Independent of PR #57 (Android `tap_element` auto-scroll); both touch `tap_element` but in different paths — expect a trivial signature-line merge on whichever lands second.
- Follow-up: a WDA re-sign flow bug (customized `Info.plist` shipped with a stale signature) is being handled in a separate PR.
