### PR TITLE
fix(wda): never install a Runner app with a stale signature

### DIFF
--- a/server/device/wda.py
+++ b/server/device/wda.py
@@ -444,11 +444,20 @@ async def _post_process_runner_app(team_id: str) -> None:
 
     # Re-sign the app since we modified its contents.
     # Find the signing identity that matches the team_id from the keychain.
+    # We just modified the app's Info.plist and icon assets, so its existing
+    # signature no longer matches. Re-signing is mandatory: a half-customized
+    # app whose signature seals a stale Info.plist installs on-device with
+    # 0xe8008001 (ApplicationVerificationFailed). Fail loudly rather than
+    # leave a broken bundle behind.
     logger.info("Re-signing Runner app after post-processing")
     signing_identity = await _find_signing_identity(team_id)
     if not signing_identity:
-        logger.warning("No signing identity found for team %s — skipping re-sign", team_id)
-        return
+        raise RuntimeError(
+            f"Post-processed the WDA Runner app but found no signing identity "
+            f"for team {team_id} to re-sign it. The app's signature no longer "
+            f"matches its patched Info.plist and would fail to install. "
+            f"Re-run setup_wda with force:true."
+        )
 
     # Re-sign inner xctest first, then outer app
     for bundle in [xctest_dir, runner_app]:
@@ -461,8 +470,10 @@ async def _post_process_runner_app(team_id: str) -> None:
         )
         stdout, stderr = await proc.communicate()
         if proc.returncode != 0:
-            logger.warning("Re-signing %s failed: %s", bundle.name, stderr.decode())
-            return
+            raise RuntimeError(
+                f"Re-signing {bundle.name} failed after post-processing: "
+                f"{stderr.decode()}"
+            )
 
     logger.info("Post-processed Runner app: display name, icon, and signature updated")
 
@@ -492,6 +503,24 @@ async def _find_signing_identity(team_id: str) -> str | None:
             return line.split("=", 1)[1]
 
     return None
+
+
+async def _runner_app_signature_valid() -> bool:
+    """Return True if the built Runner app's code signature verifies on disk.
+
+    A False here (with the app present) means a prior post-process patched the
+    Info.plist/icons but the signature was left sealing the old contents — the
+    app would fail to install with 0xe8008001. Missing app also returns False.
+    """
+    if not WDA_APP.exists():
+        return False
+    proc = await asyncio.create_subprocess_exec(
+        "codesign", "--verify", "--deep", "--strict", str(WDA_APP),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    await proc.communicate()
+    return proc.returncode == 0
 
 
 # ---------------------------------------------------------------------------
@@ -934,6 +963,18 @@ async def setup_wda(
 
     # Step 5: Build (device-independent, keyed by team_id only)
     built = await build_wda(team_id, force=force)
+
+    # Step 5b: Self-heal a stale signature. build_wda is cached by team, so a
+    # skipped build won't re-run the post-process re-sign. If a *previous* run
+    # left the on-disk app with a signature that no longer verifies (patched
+    # Info.plist, interrupted re-sign), installing it fails with 0xe8008001.
+    # Re-run the post-process (re-patch + re-sign) so we never install a broken
+    # bundle — without forcing a full rebuild.
+    if not built and not await _runner_app_signature_valid():
+        logger.warning(
+            "WDA Runner app signature does not verify — re-signing before install"
+        )
+        await _post_process_runner_app(team_id)
 
     # Step 6: Install
     await install_wda(udid, os_version)

--- a/tests/test_wda.py
+++ b/tests/test_wda.py
@@ -18,6 +18,7 @@ from server.device.wda import (
     ICON_PATH,
     _find_xctestrun,
     _parse_ios_major_version,
+    _post_process_runner_app,
     _rename_xctestrun,
     build_wda,
     clone_wda,
@@ -379,6 +380,7 @@ class TestBuildWda:
             patch("server.device.wda.WDA_REPO", repo),
             patch("server.device.wda.WDA_DERIVED", tmp_path / "build"),
             patch("server.device.wda.asyncio.create_subprocess_exec", return_value=proc),
+            patch("server.device.wda._post_process_runner_app", AsyncMock()),
         ):
             result = await build_wda("TEAM123")
 
@@ -401,6 +403,7 @@ class TestBuildWda:
             patch("server.device.wda.WDA_REPO", repo),
             patch("server.device.wda.WDA_DERIVED", tmp_path / "build"),
             patch("server.device.wda.asyncio.create_subprocess_exec", return_value=proc),
+            patch("server.device.wda._post_process_runner_app", AsyncMock()),
         ):
             result = await build_wda("NEW_TEAM")
 
@@ -428,6 +431,7 @@ class TestBuildWda:
             patch("server.device.wda.WDA_REPO", repo),
             patch("server.device.wda.WDA_DERIVED", derived),
             patch("server.device.wda.asyncio.create_subprocess_exec", return_value=proc),
+            patch("server.device.wda._post_process_runner_app", AsyncMock()),
         ):
             result = await build_wda("TEAM123", force=True)
 
@@ -616,12 +620,72 @@ class TestSetupWda:
             patch("server.device.wda.save_wda_state"),
             patch("server.device.wda.customize_wda", return_value=False),
             patch("server.device.wda.build_wda", return_value=False),
+            patch("server.device.wda._runner_app_signature_valid", return_value=True),
             patch("server.device.wda.install_wda", return_value=None),
         ):
             result = await setup_wda("DEV1", "iOS 17.4")
 
         assert result["status"] == "ok"
         assert result["team_id"] == "TEAM1"
+
+    async def test_self_heal_resigns_stale_signature(self):
+        """A skipped build with an invalid on-disk signature re-runs post-process."""
+        identities = [{"team_id": "TEAM1", "team_name": "Acme", "team_type": "Company"}]
+        post_process = AsyncMock()
+        with (
+            patch("server.device.wda.discover_signing_identities", return_value=identities),
+            patch("server.device.wda.clone_wda", return_value=False),
+            patch("server.device.wda.read_wda_state", return_value={"cloned": False}),
+            patch("server.device.wda.save_wda_state"),
+            patch("server.device.wda.customize_wda", return_value=False),
+            patch("server.device.wda.build_wda", return_value=False),  # skipped
+            patch("server.device.wda._runner_app_signature_valid", return_value=False),
+            patch("server.device.wda._post_process_runner_app", post_process),
+            patch("server.device.wda.install_wda", return_value=None),
+        ):
+            result = await setup_wda("DEV1", "iOS 17.4")
+
+        assert result["status"] == "ok"
+        post_process.assert_awaited_once_with("TEAM1")
+
+    async def test_no_resign_when_signature_valid(self):
+        """A skipped build with a valid signature does not re-run post-process."""
+        identities = [{"team_id": "TEAM1", "team_name": "Acme", "team_type": "Company"}]
+        post_process = AsyncMock()
+        with (
+            patch("server.device.wda.discover_signing_identities", return_value=identities),
+            patch("server.device.wda.clone_wda", return_value=False),
+            patch("server.device.wda.read_wda_state", return_value={"cloned": False}),
+            patch("server.device.wda.save_wda_state"),
+            patch("server.device.wda.customize_wda", return_value=False),
+            patch("server.device.wda.build_wda", return_value=False),  # skipped
+            patch("server.device.wda._runner_app_signature_valid", return_value=True),
+            patch("server.device.wda._post_process_runner_app", post_process),
+            patch("server.device.wda.install_wda", return_value=None),
+        ):
+            result = await setup_wda("DEV1", "iOS 17.4")
+
+        assert result["status"] == "ok"
+        post_process.assert_not_awaited()
+
+    async def test_fresh_build_skips_signature_check(self):
+        """A fresh build already re-signed; no extra verify/re-sign."""
+        identities = [{"team_id": "TEAM1", "team_name": "Acme", "team_type": "Company"}]
+        sig_check = AsyncMock(return_value=True)
+        with (
+            patch("server.device.wda.discover_signing_identities", return_value=identities),
+            patch("server.device.wda.clone_wda", return_value=False),
+            patch("server.device.wda.read_wda_state", return_value={"cloned": False}),
+            patch("server.device.wda.save_wda_state"),
+            patch("server.device.wda.customize_wda", return_value=False),
+            patch("server.device.wda.build_wda", return_value=True),  # fresh build
+            patch("server.device.wda._runner_app_signature_valid", sig_check),
+            patch("server.device.wda.install_wda", return_value=None),
+        ):
+            result = await setup_wda("DEV1", "iOS 17.4")
+
+        assert result["status"] == "ok"
+        sig_check.assert_not_awaited()
 
     async def test_explicit_team_id(self):
         identities = [
@@ -651,6 +715,42 @@ class TestSetupWda:
 
         assert result["status"] == "error"
         assert "BOGUS" in result["error"]
+
+
+class TestPostProcessResign:
+    async def test_missing_signing_identity_is_fatal(self, tmp_path):
+        """Post-process patches the app, so an un-resignable app must raise —
+        never leave a bundle whose signature seals a stale Info.plist."""
+        runner_app = tmp_path / "WebDriverAgentRunner-Runner.app"
+        runner_app.mkdir()
+        with (
+            patch("server.device.wda.WDA_APP", runner_app),
+            patch("server.device.wda._find_signing_identity", AsyncMock(return_value=None)),
+        ):
+            with pytest.raises(RuntimeError, match="no signing identity"):
+                await _post_process_runner_app("TEAM1")
+
+    async def test_resign_failure_is_fatal(self, tmp_path):
+        """A failing codesign re-sign raises rather than shipping a broken app."""
+        runner_app = tmp_path / "WebDriverAgentRunner-Runner.app"
+        runner_app.mkdir()
+
+        async def _fake_codesign(*args, **kwargs):
+            proc = MagicMock()
+            proc.communicate = AsyncMock(return_value=(b"", b"codesign boom"))
+            proc.returncode = 1
+            return proc
+
+        with (
+            patch("server.device.wda.WDA_APP", runner_app),
+            patch(
+                "server.device.wda._find_signing_identity",
+                AsyncMock(return_value="Apple Development: Tester (ABC123)"),
+            ),
+            patch("asyncio.create_subprocess_exec", _fake_codesign),
+        ):
+            with pytest.raises(RuntimeError, match="Re-signing"):
+                await _post_process_runner_app("TEAM1")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`setup_wda` can install a WebDriverAgent Runner app whose code signature no longer matches its own contents, so the device rejects it with `0xe8008001` (`ApplicationVerificationFailed`). Two gaps combine:

1. `_post_process_runner_app` patches the Runner app's `Info.plist` + icon assets, then re-signs — but the re-sign step **returned silently** when no signing identity was found or `codesign` failed, leaving the app signed for its pre-patch contents.
2. `build_wda` is cached by team, so a later `setup_wda` **skips the build entirely** (and thus the re-sign). A once-broken app then stays broken across every subsequent run.

This surfaced right after an OS upgrade and looked like device-side signing trouble, but `codesign --verify` showed the on-disk app's `_CodeSignature` predated its patched `Info.plist` — a genuinely stale signature.

## Fix

- **Fail loud:** re-sign failures in `_post_process_runner_app` (no identity / `codesign` non-zero) now raise `RuntimeError` instead of warning, so a half-customized bundle is never left behind.
- **Self-heal:** `setup_wda` now `codesign --verify`s the on-disk app when the build was skipped and, if it doesn't verify, re-runs the post-process (re-patch + re-sign) **before install** — without forcing a full rebuild.

## Tests

- `_post_process_runner_app` raises when the signing identity is missing and when `codesign` fails.
- `setup_wda` re-runs post-process on a skipped build with an invalid signature, and does **not** when the signature is valid or when a fresh build already re-signed.
- Full suite green (1406 passed).
