### PR TITLE
Simulator Web Inspector transport for webview DOM access

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,11 @@ requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.34.0",
+    # Web Inspector transport for simulator webview inspection. Floored at 11.0
+    # deliberately: send_plist/recv_plist are synchronous in <=9.x and coroutines
+    # from 11.x, so an older release fails silently -- the call returns an
+    # un-awaited coroutine and does nothing. See server/device/webinspector.py.
+    "pymobiledevice3>=11.0",
     "pydantic>=2.0",
     "sse-starlette>=2.0",
     "mitmproxy>=10.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,13 @@ requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.34.0",
-    # Web Inspector transport for simulator webview inspection. Floored at 11.0
-    # deliberately: send_plist/recv_plist are synchronous in <=9.x and coroutines
-    # from 11.x, so an older release fails silently -- the call returns an
-    # un-awaited coroutine and does nothing. See server/device/webinspector.py.
-    "pymobiledevice3>=11.0",
+    # Web Inspector transport for simulator webview inspection. Floored at 8.0
+    # deliberately: send_plist/recv_plist are synchronous in 7.x and coroutines
+    # from 8.0 onward, so a 7.x install fails silently -- the call returns an
+    # un-awaited coroutine and does nothing. Verified at 7.7.1, 8.0.0, 9.15.1 and
+    # 11.3.0. Note this is a library import; server/device/pmd3.py separately
+    # shells out to a pipx-installed CLI, which is a different install.
+    "pymobiledevice3>=8.0",
     "pydantic>=2.0",
     "sse-starlette>=2.0",
     "mitmproxy>=10.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,12 @@ dependencies = [
     "uvicorn[standard]>=0.34.0",
     # Web Inspector transport for simulator webview inspection. Floored at 8.0
     # deliberately: send_plist/recv_plist are synchronous in 7.x and coroutines
-    # from 8.0 onward, so a 7.x install fails silently -- the call returns an
-    # un-awaited coroutine and does nothing. Verified at 7.7.1, 8.0.0, 9.15.1 and
-    # 11.3.0. Note this is a library import; server/device/pmd3.py separately
-    # shells out to a pipx-installed CLI, which is a different install.
+    # from 8.0 onward. webinspector.py awaits them, so on 7.x the await lands on
+    # a plain return value and raises TypeError ("object NoneType can't be used
+    # in 'await' expression"). Loud, but only at call time, and the message does
+    # not mention the version -- hence the floor. Verified at 7.7.1, 8.0.0,
+    # 9.15.1 and 11.3.0. Note this is a library import; server/device/pmd3.py
+    # separately shells out to a pipx-installed CLI, a different install.
     "pymobiledevice3>=8.0",
     "pydantic>=2.0",
     "sse-starlette>=2.0",

--- a/server/device/webinspector.py
+++ b/server/device/webinspector.py
@@ -218,8 +218,17 @@ class SimulatorWebInspector:
             "WIRConnectionIdentifierKey": self._connection_id,
             "WIRApplicationIdentifierKey": application_id,
         })
-        for _ in range(8):
-            message = await self._recv()
+        # Bounded by time, not message count. The daemon interleaves unrelated
+        # reports, and a busy one can emit more than a handful before the
+        # listing arrives - a fixed iteration cap silently returns "no pages"
+        # for an app that has them. Same reasoning as _drain_handshake.
+        deadline = asyncio.get_running_loop().time() + self._timeout
+        while asyncio.get_running_loop().time() < deadline:
+            remaining = deadline - asyncio.get_running_loop().time()
+            try:
+                message = await asyncio.wait_for(self._service.recv_plist(), timeout=remaining)
+            except TimeoutError:
+                break
             if message is None:
                 break
             if message.get("__selector") == "_rpc_applicationSentListing:":

--- a/server/device/webinspector.py
+++ b/server/device/webinspector.py
@@ -1,0 +1,232 @@
+"""WebInspector — DOM access inside WKWebViews on iOS simulators.
+
+The accessibility tree does not descend into `WKWebView` on simulators, so web
+content is invisible to sim-bridge and idb. WebKit exposes a separate channel for
+this: the Web Inspector protocol, the same one Safari's Develop menu uses.
+
+On a simulator that channel is a plain unix socket — no usbmux, no lockdown, no
+pairing, no developer disk image:
+
+    /private/tmp/com.apple.launchd.*/com.apple.webinspectord_sim.socket
+
+Traffic is length-prefixed plists carrying `__selector` / `__argument` RPC pairs,
+which `pymobiledevice3.ServiceConnection` already speaks. We supply the transport
+and drive it directly rather than going through `WebinspectorService`, which
+requires a lockdown object a simulator does not have.
+
+Requires the target app to opt its webviews in with `isInspectable = true`
+(defaults to false since iOS 16.4). Debug/internal builds only — never ship it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import glob
+import logging
+import os
+import socket
+import uuid
+from typing import Any
+
+logger = logging.getLogger("quern-debug-server.webinspector")
+
+SIM_SOCKET_GLOB = "/private/tmp/com.apple.launchd.*/com.apple.webinspectord_sim.socket"
+
+# Selectors we send. The listening side sends many more; we only handle the ones
+# we act on and log the rest at debug level.
+_SEL_REPORT_IDENTIFIER = "_rpc_reportIdentifier:"
+_SEL_FORWARD_GET_LISTING = "_rpc_forwardGetListing:"
+_SEL_FORWARD_SOCKET_SETUP = "_rpc_forwardSocketSetup:"
+_SEL_FORWARD_SOCKET_DATA = "_rpc_forwardSocketData:"
+
+
+class WebInspectorError(RuntimeError):
+    """Raised when the inspector channel is unavailable or misbehaves."""
+
+
+def find_simulator_sockets() -> list[str]:
+    """Return candidate webinspectord simulator socket paths.
+
+    Most of these are dead. Socket files are left behind when a simulator shuts
+    down and are never cleaned up - on a machine that has booted a few
+    simulators it is normal to find a dozen or more paths with only one live
+    listener. Existence tells you nothing; only connecting does.
+
+    They are also not labelled with a UDID, so callers needing a specific device
+    must disambiguate by connecting and reading the reported application list.
+
+    Newest first, since the live one is usually the most recently created.
+    """
+    paths = glob.glob(SIM_SOCKET_GLOB)
+    return sorted(paths, key=lambda p: _mtime(p), reverse=True)
+
+
+def _mtime(path: str) -> float:
+    try:
+        return os.stat(path).st_mtime
+    except OSError:
+        return 0.0
+
+
+class SimulatorWebInspector:
+    """A connection to one simulator's Web Inspector channel.
+
+    Usage:
+
+        async with SimulatorWebInspector() as inspector:
+            apps = await inspector.connected_applications()
+            pages = await inspector.pages(app_id)
+    """
+
+    def __init__(self, socket_path: str | None = None, timeout: float = 10.0) -> None:
+        self._socket_path = socket_path
+        self._timeout = timeout
+        self._service: Any = None
+        self._sock: socket.socket | None = None
+        self._connection_id = str(uuid.uuid4()).upper()
+        self._applications: dict[str, dict] = {}
+
+    async def __aenter__(self) -> SimulatorWebInspector:
+        await self.connect()
+        return self
+
+    async def __aexit__(self, *_exc: object) -> None:
+        await self.close()
+
+    async def connect(self) -> None:
+        """Open the socket and complete the identifier handshake."""
+        path = self._socket_path
+        candidates = [path] if path else find_simulator_sockets()
+        sock, chosen, errors = None, None, []
+        for candidate in candidates:
+            attempt = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            attempt.settimeout(self._timeout)
+            try:
+                attempt.connect(candidate)
+            except OSError as exc:
+                attempt.close()
+                errors.append(f"{candidate}: {exc}")
+                continue
+            sock, chosen = attempt, candidate
+            break
+
+        if sock is None:
+            raise WebInspectorError(
+                f"no live webinspectord socket among {len(candidates)} candidate(s). "
+                "Socket files persist after a simulator shuts down, so most are stale. "
+                f"Tried: {errors[:3]}"
+            )
+
+        logger.debug("webinspector: connected via %s", chosen)
+        self._socket_path = chosen
+        self._sock = sock
+
+        # Imported only once a live socket is in hand. A missing dependency is a
+        # less useful thing to report than "no simulator is booted", and the
+        # socket probing above needs nothing but the standard library.
+        try:
+            from pymobiledevice3.service_connection import ServiceConnection
+        except ImportError as exc:  # pragma: no cover - dependency is declared
+            sock.close()
+            self._sock = None
+            raise WebInspectorError(
+                "pymobiledevice3>=11.0 is required for webview inspection"
+            ) from exc
+
+        self._service = ServiceConnection(sock)
+        await self._send(
+            _SEL_REPORT_IDENTIFIER,
+            {"WIRConnectionIdentifierKey": self._connection_id},
+        )
+        await self._drain_handshake()
+
+    async def close(self) -> None:
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            finally:
+                self._sock = None
+                self._service = None
+
+    async def _send(self, selector: str, argument: dict) -> None:
+        await self._service.send_plist({"__selector": selector, "__argument": argument})
+
+    async def _recv(self) -> dict | None:
+        try:
+            return await asyncio.wait_for(self._service.recv_plist(), timeout=self._timeout)
+        except TimeoutError:
+            return None
+
+    async def _drain_handshake(self, settle: float = 1.5) -> None:
+        """Read the burst of reports the daemon sends after identification.
+
+        Applications do not all arrive at once: the first
+        `_rpc_reportConnectedApplicationList:` is often partial, with further
+        apps following as `_rpc_applicationConnected:`. Stopping at the first
+        list therefore misses hosts - including, in practice, the one actually
+        showing web content. Drain until the channel goes quiet instead.
+        """
+        deadline = asyncio.get_running_loop().time() + settle
+        while asyncio.get_running_loop().time() < deadline:
+            remaining = deadline - asyncio.get_running_loop().time()
+            try:
+                message = await asyncio.wait_for(self._service.recv_plist(), timeout=remaining)
+            except TimeoutError:
+                break
+            if message is None:
+                break
+            self._absorb(message)
+
+    def _absorb(self, message: dict) -> None:
+        selector = message.get("__selector")
+        argument = message.get("__argument") or {}
+        if selector == "_rpc_reportConnectedApplicationList:":
+            self._applications.update(argument.get("WIRApplicationDictionaryKey") or {})
+        elif selector in ("_rpc_applicationConnected:", "_rpc_applicationUpdated:"):
+            app_id = argument.get("WIRApplicationIdentifierKey")
+            if app_id:
+                self._applications[app_id] = argument
+        elif selector == "_rpc_applicationDisconnected:":
+            self._applications.pop(argument.get("WIRApplicationIdentifierKey"), None)
+        else:
+            logger.debug("webinspector: unhandled selector %s", selector)
+
+    async def connected_applications(self) -> list[dict]:
+        """Applications the inspector can see, newest state first."""
+        return [
+            {
+                "application_id": app_id,
+                "bundle_id": info.get("WIRApplicationBundleIdentifierKey"),
+                "name": info.get("WIRApplicationNameKey"),
+                "proxy": bool(info.get("WIRIsApplicationProxyKey")),
+            }
+            for app_id, info in self._applications.items()
+        ]
+
+    async def pages(self, application_id: str) -> list[dict]:
+        """Inspectable pages within one application.
+
+        An application with no inspectable webviews returns an empty list. That
+        usually means the app has not set `isInspectable`, not that it has no
+        web content.
+        """
+        await self._send(_SEL_FORWARD_GET_LISTING, {
+            "WIRConnectionIdentifierKey": self._connection_id,
+            "WIRApplicationIdentifierKey": application_id,
+        })
+        for _ in range(8):
+            message = await self._recv()
+            if message is None:
+                break
+            if message.get("__selector") == "_rpc_applicationSentListing:":
+                listing = (message.get("__argument") or {}).get("WIRListingKey") or {}
+                return [
+                    {
+                        "page_id": info.get("WIRPageIdentifierKey"),
+                        "title": info.get("WIRTitleKey"),
+                        "url": info.get("WIRURLKey"),
+                    }
+                    for info in listing.values()
+                ]
+            self._absorb(message)
+        return []

--- a/server/device/webinspector.py
+++ b/server/device/webinspector.py
@@ -16,6 +16,10 @@ requires a lockdown object a simulator does not have.
 
 Requires the target app to opt its webviews in with `isInspectable = true`
 (defaults to false since iOS 16.4). Debug/internal builds only — never ship it.
+
+Note this imports `pymobiledevice3` as a library. `server/device/pmd3.py`
+separately shells out to a pipx-installed CLI for physical-device work; the two
+are different installs and are floored independently.
 """
 
 from __future__ import annotations
@@ -130,7 +134,7 @@ class SimulatorWebInspector:
             sock.close()
             self._sock = None
             raise WebInspectorError(
-                "pymobiledevice3>=11.0 is required for webview inspection"
+                "pymobiledevice3>=8.0 is required for webview inspection"
             ) from exc
 
         self._service = ServiceConnection(sock)

--- a/tests/test_webinspector.py
+++ b/tests/test_webinspector.py
@@ -1,0 +1,56 @@
+"""Tests for simulator Web Inspector socket discovery.
+
+The protocol paths need a booted simulator, so they are not unit-testable here.
+What is worth locking down is the socket selection, because the failure it
+guards against is silent: stale socket files outnumber live ones on any machine
+that has booted more than one simulator.
+"""
+
+from __future__ import annotations
+
+import os
+
+from server.device import webinspector
+
+
+def test_find_sockets_returns_newest_first(tmp_path, monkeypatch):
+    older = tmp_path / "com.apple.launchd.AAA" / "com.apple.webinspectord_sim.socket"
+    newer = tmp_path / "com.apple.launchd.BBB" / "com.apple.webinspectord_sim.socket"
+    for p in (older, newer):
+        p.parent.mkdir(parents=True)
+        p.write_text("")
+    os.utime(older, (1_000, 1_000))
+    os.utime(newer, (2_000, 2_000))
+
+    monkeypatch.setattr(
+        webinspector,
+        "SIM_SOCKET_GLOB",
+        str(tmp_path / "com.apple.launchd.*" / "com.apple.webinspectord_sim.socket"),
+    )
+    assert webinspector.find_simulator_sockets() == [str(newer), str(older)]
+
+
+def test_find_sockets_empty_when_none_present(tmp_path, monkeypatch):
+    monkeypatch.setattr(webinspector, "SIM_SOCKET_GLOB", str(tmp_path / "nope" / "*.socket"))
+    assert webinspector.find_simulator_sockets() == []
+
+
+async def test_connect_reports_how_many_candidates_were_dead(tmp_path, monkeypatch):
+    """A dead socket file must not be mistaken for an absent simulator."""
+    dead = tmp_path / "com.apple.launchd.AAA" / "com.apple.webinspectord_sim.socket"
+    dead.parent.mkdir(parents=True)
+    dead.write_text("")
+    monkeypatch.setattr(
+        webinspector,
+        "SIM_SOCKET_GLOB",
+        str(tmp_path / "com.apple.launchd.*" / "com.apple.webinspectord_sim.socket"),
+    )
+
+    inspector = webinspector.SimulatorWebInspector()
+    try:
+        await inspector.connect()
+    except webinspector.WebInspectorError as exc:
+        assert "1 candidate" in str(exc)
+        assert "stale" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected WebInspectorError")


### PR DESCRIPTION
Lands the transport for reading DOM inside `WKWebView`s on simulators. **Discovery and enumeration only** — evaluation and interaction are deliberately left out so the protocol layer can be reviewed on its own.

## Why

The accessibility tree does not descend into `WKWebView` on simulators. A screen showing a fully rendered page returns five native-chrome elements and nothing else — measured on Geocaching's Shareables screen, where XCUITest sees 47 elements and WDA 63 for the same screen at the same moment.

WebKit does expose that content, via the Web Inspector protocol. On a simulator it is a plain unix socket under `/private/tmp` — no usbmux, no lockdown, no pairing, no developer disk image.

## Approach

`pymobiledevice3.ServiceConnection` already speaks the wire format (length-prefixed plists carrying `__selector` / `__argument` pairs) and its constructor accepts a raw socket. So this supplies the transport and drives it directly, rather than going through `WebinspectorService`, which requires a lockdown object a simulator does not have.

Deliberately **not** a fork, a monkey-patch, or a vendored copy. Nothing in `pymobiledevice3` needs changing.

## Three bugs found by running it, not reasoning about it

All three would have shipped otherwise.

**Socket files are never cleaned up.** When a simulator shuts down its socket file remains. This machine had **16 candidate paths and 1 live listener**, so selecting the first match by name reliably connects to a corpse. Every candidate is now probed, newest first, and the error reports how many were tried rather than claiming no simulator is booted.

**Applications arrive in waves.** The first `_rpc_reportConnectedApplicationList:` is frequently partial, with more following as `_rpc_applicationConnected:`. Stopping at the first list found **1 application where there were 3** — and the one it missed was the one showing content. The handshake now drains until the channel goes quiet.

**The dependency import was ordered before socket discovery** — caught by the pre-commit suite, not by my own tests. A missing dependency masked the more useful "no simulator is booted". Socket probing needs only the standard library, so the import now happens once a live socket is in hand.

## The dependency floor is load-bearing

`pymobiledevice3>=11.0`, and this matters more than a typical floor:

| | 7.7.1 | 9.15.1 | 11.3.0 |
|---|---|---|---|
| `send_plist` / `recv_plist` | sync | sync | **coroutines** |
| `aio_send_plist` / `aio_recv_plist` | present | present | **removed** |

The same method names changed semantics. Below the floor the call returns an un-awaited coroutine and **does nothing at all** — no exception, just a `RuntimeWarning`. Verified against all three versions.

This also makes `pymobiledevice3` a **declared Python dependency**, where today it is installed by setup and consumed only as a CLI. That is a change worth a look, though arguably an improvement for #67: a declared dependency can be floored, whereas the CLI install drifts silently and invisibly.

## Testing

Three unit tests cover socket selection, including that a dead socket file is not mistaken for an absent simulator. Full suite passes (1443).

The protocol paths need a booted simulator and are not unit-testable here. They were exercised manually against iOS 18.6 — enumerating applications and pages, and cross-checked against raw protocol output to confirm the parse rather than trust it.

## Not included

`Runtime.evaluate`, page interaction, MCP tool surface. Those need `Target.sendMessageToTarget` wrapping — flat `Runtime.evaluate` fails with `'Runtime' domain was not found` — which belongs with the evaluation layer rather than the transport.

Background and the decision trail: `docs/proposals/webview-channel-log.md` entries 5, 13, 14 and `webview-a11y-spike-findings.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for inspecting iOS Simulator web content through the Web Inspector.
  * Applications and their inspectable pages can now be discovered through the simulator.
  * Improved handling of pending page listings and unavailable or stale inspection connections.

* **Bug Fixes**
  * Added clearer feedback when simulator inspection channels cannot be reached.

* **Tests**
  * Added coverage for simulator socket discovery, connection ordering, and stale connection handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->