### PR TITLE
docs: add a user-facing update channels guide

### DIFF
--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -11,6 +11,7 @@ For the AI agent's reference, see the [Agent Guide](../agent-guide.md). For inst
 - [Installation & Setup](getting-started.md) — Get Quern running and connected to your AI agent
 - [Device Pool & Resolution](device-pool.md) — How Quern manages devices, the iOS 17+ complexity it hides, and what you should know
 - [Build & Install](build-and-install.md) — Building and deploying to multiple devices at once
+- [Update Channels](update-channels.md) — Staying on stable, or opting into beta to see releases early
 
 ---
 

--- a/docs/guides/update-channels.md
+++ b/docs/guides/update-channels.md
@@ -16,7 +16,7 @@ quern set-channel
 With no argument it prints the current channel and the branch it tracks, plus
 the valid names:
 
-```
+```text
 Current update channel: stable (tracks origin/release/stable)
 Valid channels: stable, beta
 ```
@@ -42,11 +42,18 @@ What that update does depends on how you installed Quern:
   GitHub Release is the newest one marked as a prerelease. If there are no
   prereleases at the moment, it falls back to the latest stable, so you are
   never served *older* content than a stable user.
-- **Installed as a git clone:** you need to be on `release/beta`, or on `main`
-  and willing to switch. If you are sitting on a feature branch, the updater
-  will tell you beta updates exist but will not move your workspace for you.
-  That is deliberate — silently switching branches under someone's uncommitted
-  work is not a trade Quern makes.
+- **Installed as a git clone:** your checkout has to be on the branch your
+  channel tracks — `release/beta` for beta. Any other branch, including `main`,
+  is treated the same way: `quern update` tells you how far ahead the release
+  branch is, prints the exact `git checkout` to run, and applies nothing.
+
+  ```sh
+  git checkout release/beta
+  quern update
+  ```
+
+  It will not move your workspace for you, by design — silently switching
+  branches under someone's uncommitted work is not a trade Quern makes.
 
 ## Switching back
 
@@ -55,9 +62,20 @@ quern set-channel stable
 quern update
 ```
 
-The same two steps in reverse. Stable is always a safe target: because stable
-releases are cut from content that has already been through beta, going back
-does not mean losing fixes you were relying on.
+On a tarball install that is all of it. **On a git clone you also have to move
+the checkout back**, because `set-channel` changes your preference and nothing
+else — a clone left sitting on `release/beta` will keep being told it is on the
+wrong branch rather than being returned to stable:
+
+```sh
+quern set-channel stable
+git checkout release/stable
+quern update
+```
+
+Stable is always a safe target: stable releases are cut from content that has
+already been through beta, so going back does not mean losing fixes you were
+relying on.
 
 ## What to expect on beta
 

--- a/docs/guides/update-channels.md
+++ b/docs/guides/update-channels.md
@@ -1,0 +1,71 @@
+# Update Channels
+
+Quern ships on two channels. **`stable`** is the default and tracks tagged
+releases. **`beta`** is opt-in, and gets the same content earlier — usually days
+to a couple of weeks ahead — so problems are found before they reach everyone.
+
+If you never think about channels, you are on `stable`, and that is the right
+place to be.
+
+## Which channel am I on?
+
+```sh
+quern set-channel
+```
+
+With no argument it prints the current channel and the branch it tracks, plus
+the valid names:
+
+```
+Current update channel: stable (tracks origin/release/stable)
+Valid channels: stable, beta
+```
+
+You can also just ask Claude — "what's my Quern channel?" — since the channel and
+update status come back with `ensure_server` in the normal course of a session.
+
+## Switching to beta
+
+```sh
+quern set-channel beta
+quern update
+```
+
+Both steps are needed. `set-channel` writes your preference to
+`~/.quern/config.json` and nothing else: it does not switch branches, download
+anything, or change the running server. The next `quern update` is what actually
+moves you.
+
+What that update does depends on how you installed Quern:
+
+- **Installed with the install script (tarball):** the updater takes whichever
+  GitHub Release is the newest one marked as a prerelease. If there are no
+  prereleases at the moment, it falls back to the latest stable, so you are
+  never served *older* content than a stable user.
+- **Installed as a git clone:** you need to be on `release/beta`, or on `main`
+  and willing to switch. If you are sitting on a feature branch, the updater
+  will tell you beta updates exist but will not move your workspace for you.
+  That is deliberate — silently switching branches under someone's uncommitted
+  work is not a trade Quern makes.
+
+## Switching back
+
+```sh
+quern set-channel stable
+quern update
+```
+
+The same two steps in reverse. Stable is always a safe target: because stable
+releases are cut from content that has already been through beta, going back
+does not mean losing fixes you were relying on.
+
+## What to expect on beta
+
+Beta is where a release is checked against real projects before it is tagged. In
+practice that means you see fixes sooner and you are the one who finds anything
+that was missed. If you use Quern daily on work you care about, `stable` is the
+better default. If you would rather catch a regression early — and are willing
+to report it — beta is genuinely useful, and switching back takes two commands.
+
+The daily update notice respects your channel, so on beta it tells you about
+beta releases rather than nagging you toward stable.


### PR DESCRIPTION
Update channels shipped in 0.14.0 and have had no user-facing documentation since — the site doesn't mention them at all, and its installation page refers to `quern update` twice without saying channels exist.

`docs/release-channels.md` does cover them, but ~200 of its 246 lines are the maintainer release-cut procedure, including the GitHub quirk about publishing a Release before moving branches. That's the wrong thing to hand a user who just wants to know whether to try beta.

**Nobody can opt into a channel they can't discover**, so this is the user half only: how to check what you're on, how to switch, what actually happens on the next `quern update`, and how that differs between a tarball install and a git clone.

Claims were checked against the source rather than lifted from the maintainer doc:

- the sample output is what `quern set-channel` actually prints today
- the "no prereleases yet → fall back to stable" behaviour is real, in `_fetch_release_tarball`
- `set-channel` writing only `~/.quern/config.json` and changing nothing else is from `_cmd_set_channel`

The paired quern.dev change publishes this at `/getting-started/update-channels/`, alongside the deep-link guide that had been sitting unpublished. It'll go up once this merges, so `sync-docs.py --check` stays honest against `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added an Update Channels guide covering stable and opt-in beta releases.
  - Documented how to identify the current update channel and switch between stable and beta.
  - Clarified that beta updates for git clones require the `release/beta` checkout.
  - Explained how to manually switch git clones to `release/stable` before updating.
  - Added the guide to the Getting Started documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->