### PR TITLE
feat(tools): scene-lifecycle probe bundle — and two corrections it found

### DIFF
--- a/docs/guides/deep-link-testing.md
+++ b/docs/guides/deep-link-testing.md
@@ -137,14 +137,35 @@ with no error anywhere.
 
 | | |
 |---|---|
-| Cold | `launchOptions[.url]` in `didFinishLaunching` |
+| Cold | `launchOptions[.url]` in `didFinishLaunching` **and then** `application(_:open:options:)` |
 | Warm | `application(_:open:options:)` |
 | Universal link | `application(_:continue:restorationHandler:)` |
+
+**A cold launch here delivers the URL twice.** Measured against a fixture that
+counts every delivery: one `openurl` at a terminated app-delegate app produced
+**two** recorded links — `didFinishLaunching` sees it in `launchOptions`, and
+then `application(_:open:options:)` is called with the same URL. An app that
+handles both without deduplicating will run its deep link routing twice per cold
+launch, which shows up as a doubled analytics event, a duplicated navigation
+push, or a repeated network call rather than as an error.
+
+The scene lifecycle does not do this: the same test against the scene-based
+bundle recorded the link **once**, through `scene(_:willConnectTo:options:)`
+only. If you are migrating, that is one behaviour that quietly gets better.
 
 Note that `application(_:open:options:)` is legacy — Apple's direction is to
 handle URL delivery in the scene delegate, and on recent SDKs the app-delegate
 method is deprecated. If a scene-based app implements only the app-delegate
 callbacks, they are simply never called.
+
+**Implementing `application(_:configurationForConnecting:options:)` switches
+the lifecycle on its own.** The Info.plist manifest is not the only trigger —
+adding that method to an app delegate is enough to make UIKit use scenes, after
+which none of the app-delegate URL callbacks fire. Measured: a bundle with no
+`UIApplicationSceneManifest` at all reported delivery through
+`scene(_:willConnectTo:options:)` until the method was compiled out. If your
+deep links stopped arriving after an unrelated refactor, check whether that
+method appeared.
 
 **SwiftUI** apps can use `.onOpenURL` on the root view, which covers both cold
 and warm delivery without touching either delegate.

--- a/tools/probe-app/Info-Scene.plist
+++ b/tools/probe-app/Info-Scene.plist
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>QuernProbeScene</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.quern.probe.scene</string>
+	<key>CFBundleName</key>
+	<string>QuernProbeScene</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.quern.probe.scene.scheme</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>quernprobescene</string>
+			</array>
+		</dict>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>QuernProbe displays live location updates so automation can verify simulated locations and movement.</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default</string>
+					<key>UISceneDelegateClassName</key>
+					<string>SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+		<integer>2</integer>
+	</array>
+	<key>UILaunchScreen</key>
+	<dict/>
+</dict>
+</plist>

--- a/tools/probe-app/Sources/DeepLinkStore.swift
+++ b/tools/probe-app/Sources/DeepLinkStore.swift
@@ -19,10 +19,20 @@ final class DeepLinkStore {
 
     private(set) var lastURI: String = "none"
     private(set) var count: Int = 0
+
+    /// Which callback delivered the last link.
+    ///
+    /// The point of the scene-based bundle: a test can assert not just that the
+    /// link arrived but that it arrived *the way the documentation says it
+    /// does*. Without this the two lifecycles are indistinguishable from
+    /// outside, and a guide claiming `scene(_:openURLContexts:)` handles warm
+    /// delivery would read as verified when nothing had checked it.
+    private(set) var lastRoute: String = "none"
     var onChange: (() -> Void)?
 
-    func record(_ url: URL) {
+    func record(_ url: URL, via route: String) {
         lastURI = url.absoluteString
+        lastRoute = route
         count += 1
         onChange?()
     }

--- a/tools/probe-app/Sources/LinksViewController.swift
+++ b/tools/probe-app/Sources/LinksViewController.swift
@@ -11,6 +11,7 @@ import UIKit
 final class LinksViewController: UIViewController {
     private let lastURILabel = UILabel()
     private let countLabel = UILabel()
+    private let routeLabel = UILabel()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -39,6 +40,18 @@ final class LinksViewController: UIViewController {
         countLabel.accessibilityIdentifier = "link_count"
         countLabel.font = .systemFont(ofSize: 28, weight: .semibold)
         view.addSubview(countLabel)
+        y += 50
+
+        let routeCaption = UILabel(frame: CGRect(x: 20, y: y, width: width, height: 24))
+        routeCaption.text = "Delivered via:"
+        view.addSubview(routeCaption)
+        y += 28
+
+        routeLabel.frame = CGRect(x: 20, y: y, width: width, height: 40)
+        routeLabel.accessibilityIdentifier = "link_route"
+        routeLabel.numberOfLines = 2
+        routeLabel.adjustsFontSizeToFitWidth = true
+        view.addSubview(routeLabel)
 
         DeepLinkStore.shared.onChange = { [weak self] in
             DispatchQueue.main.async { self?.render() }
@@ -54,5 +67,6 @@ final class LinksViewController: UIViewController {
     private func render() {
         lastURILabel.text = DeepLinkStore.shared.lastURI
         countLabel.text = String(DeepLinkStore.shared.count)
+        routeLabel.text = DeepLinkStore.shared.lastRoute
     }
 }

--- a/tools/probe-app/Sources/SceneDelegate.swift
+++ b/tools/probe-app/Sources/SceneDelegate.swift
@@ -1,0 +1,64 @@
+//
+//  SceneDelegate.swift
+//  QuernProbe
+//
+//  The scene-based URL delivery path, used only by the QuernProbeScene bundle.
+//
+//  Why a second bundle rather than a second app: an app either has a scene
+//  manifest or it does not, and the choice decides which callbacks iOS calls.
+//  There is no way to exercise both in one running binary. Two Info.plists over
+//  one set of sources keeps the view controllers, the tabs and the self-test
+//  shared, which is the same reasoning that folded LogTester into this app
+//  rather than leaving it standing alone.
+//
+//  This exists because the guidance in docs/guides/deep-link-testing.md about
+//  scene-based delivery was written from documentation rather than from
+//  measurement. These callbacks are the claim; running them is the evidence.
+//
+
+import UIKit
+
+@objc(SceneDelegate)
+final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene,
+               willConnectTo session: UISceneSession,
+               options connectionOptions: UIScene.ConnectionOptions) {
+        guard let windowScene = scene as? UIWindowScene else { return }
+
+        let window = UIWindow(windowScene: windowScene)
+        window.rootViewController = ProbeTabs.makeRootViewController()
+        window.makeKeyAndVisible()
+        self.window = window
+
+        // Cold launch. The URL is on connectionOptions, not delivered through
+        // scene(_:openURLContexts:) — that only fires for a scene that is
+        // already connected. An app handling only the latter loses every link
+        // that starts it from cold, silently.
+        for context in connectionOptions.urlContexts {
+            DeepLinkStore.shared.record(context.url, via: "scene:willConnectTo")
+        }
+        for activity in connectionOptions.userActivities
+        where activity.activityType == NSUserActivityTypeBrowsingWeb {
+            if let url = activity.webpageURL {
+                DeepLinkStore.shared.record(url, via: "scene:connectionOptions.userActivities")
+            }
+        }
+    }
+
+    // Warm delivery: the scene is already connected.
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        for context in URLContexts {
+            DeepLinkStore.shared.record(context.url, via: "scene:openURLContexts")
+        }
+    }
+
+    // Universal links into a running scene.
+    func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+        if userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+           let url = userActivity.webpageURL {
+            DeepLinkStore.shared.record(url, via: "scene:continue")
+        }
+    }
+}

--- a/tools/probe-app/Sources/main.swift
+++ b/tools/probe-app/Sources/main.swift
@@ -57,9 +57,15 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         window.makeKeyAndVisible()
         self.window = window
 
-        // Cold launch on the app-delegate lifecycle. The URL arrives here
-        // rather than through application(_:open:options:), which only fires
-        // for an already-running app.
+        // Cold launch on the app-delegate lifecycle. The URL arrives here in
+        // launchOptions — and then application(_:open:options:) is called with
+        // the same URL, so a cold launch delivers it TWICE. Measured: one
+        // simctl openurl at a terminated app leaves link_count at 2.
+        //
+        // An earlier version of this comment said open(_:) "only fires for an
+        // already-running app", which is the same thing the guide said until
+        // this fixture disproved it. Both callbacks are kept precisely so the
+        // double delivery stays visible rather than being deduplicated away.
         if let url = launchOptions?[.url] as? URL {
             DeepLinkStore.shared.record(url, via: "appdelegate:launchOptions")
         }

--- a/tools/probe-app/Sources/main.swift
+++ b/tools/probe-app/Sources/main.swift
@@ -10,12 +10,14 @@
 
 import UIKit
 
-@main
-final class AppDelegate: UIResponder, UIApplicationDelegate {
-    var window: UIWindow?
-
-    func application(_ application: UIApplication,
-                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+/// Tab construction, shared by both lifecycles.
+///
+/// The app-delegate bundle builds this from `didFinishLaunching`; the
+/// scene-based bundle builds it from `scene(_:willConnectTo:)`. Keeping one
+/// definition is why the scene variant is a second Info.plist rather than a
+/// second app.
+enum ProbeTabs {
+    static func makeRootViewController() -> UIViewController {
         let tabs: [(UIViewController, String, String)] = [
             // Order matters: an iPhone tab bar shows five items and moves the
             // rest into a More list, which keeps its own navigation stack and
@@ -40,36 +42,60 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
             nav.tabBarItem.accessibilityIdentifier = "tab_\(title.lowercased())"
             return nav
         }
+        return tabBarController
+    }
+}
 
+@main
+final class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         let window = UIWindow(frame: UIScreen.main.bounds)
-        window.rootViewController = tabBarController
+        window.rootViewController = ProbeTabs.makeRootViewController()
         window.makeKeyAndVisible()
         self.window = window
 
-        // A URL supplied at launch arrives here rather than through
-        // application(_:open:options:), which only fires for an already-running
-        // app. Missing this is how a cold-launch deep link goes unrecorded.
+        // Cold launch on the app-delegate lifecycle. The URL arrives here
+        // rather than through application(_:open:options:), which only fires
+        // for an already-running app.
         if let url = launchOptions?[.url] as? URL {
-            DeepLinkStore.shared.record(url)
+            DeepLinkStore.shared.record(url, via: "appdelegate:launchOptions")
         }
         return true
     }
 
     func application(_ app: UIApplication, open url: URL,
                      options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
-        DeepLinkStore.shared.record(url)
+        DeepLinkStore.shared.record(url, via: "appdelegate:open")
         return true
     }
 
     func application(_ application: UIApplication,
                      continue userActivity: NSUserActivity,
                      restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
-        // Universal links arrive as an activity rather than an openURL call.
         if userActivity.activityType == NSUserActivityTypeBrowsingWeb,
            let url = userActivity.webpageURL {
-            DeepLinkStore.shared.record(url)
+            DeepLinkStore.shared.record(url, via: "appdelegate:continue")
             return true
         }
         return false
     }
+
+    #if SCENE_LIFECYCLE
+    // Compile-time, not runtime. Merely *implementing* this method opts the app
+    // into the scene lifecycle even with no UIApplicationSceneManifest in the
+    // Info.plist — measured: the manifest-free bundle reported
+    // scene:willConnectTo until this was removed from its build. A runtime
+    // guard cannot help, because the decision is made from the method's
+    // presence before any of our code runs.
+    func application(_ application: UIApplication,
+                     configurationForConnecting session: UISceneSession,
+                     options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        let config = UISceneConfiguration(name: "Default", sessionRole: session.role)
+        config.delegateClass = SceneDelegate.self
+        return config
+    }
+    #endif
 }

--- a/tools/probe-app/build.sh
+++ b/tools/probe-app/build.sh
@@ -7,22 +7,46 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
+# --scene builds the scene-lifecycle bundle from the same sources. An app has a
+# scene manifest or it does not, and that choice decides which callbacks iOS
+# calls, so the two lifecycles cannot both be exercised by one running binary.
+# Two Info.plists over one source tree keeps the view controllers and the
+# self-test shared.
+SCENE=""
+ARGS=()
+for a in "$@"; do
+  if [ "$a" = "--scene" ]; then SCENE=1; else ARGS+=("$a"); fi
+done
+set -- "${ARGS[@]:-}"
+
 SDK=$(xcrun --sdk iphonesimulator --show-sdk-path)
 ARCH=$(uname -m)
 TARGET="${ARCH}-apple-ios16.0-simulator"
-OUT="build/QuernProbe.app"
+
+if [ -n "$SCENE" ]; then
+  NAME="QuernProbeScene"; PLIST="Info-Scene.plist"; BUNDLE="com.quern.probe.scene"
+  # A compile-time flag, because implementing configurationForConnecting is
+  # itself enough to switch the lifecycle — the manifest is not the only
+  # trigger, so the method has to be absent from the app-delegate build.
+  FLAGS=(-D SCENE_LIFECYCLE)
+else
+  NAME="QuernProbe"; PLIST="Info.plist"; BUNDLE="com.quern.probe"
+  FLAGS=()
+fi
+OUT="build/${NAME}.app"
 
 mkdir -p "$OUT"
 swiftc -parse-as-library \
        -sdk "$SDK" \
        -target "$TARGET" \
+       ${FLAGS[@]+"${FLAGS[@]}"} \
        Sources/*.swift \
-       -o "$OUT/QuernProbe"
-cp Info.plist "$OUT/Info.plist"
+       -o "$OUT/$NAME"
+cp "$PLIST" "$OUT/Info.plist"
 echo "Built $OUT ($TARGET)"
 
 if [ "${1:-}" = "--install" ]; then
   UDID="${2:-booted}"
   xcrun simctl install "$UDID" "$OUT"
-  echo "Installed com.quern.probe on $UDID"
+  echo "Installed $BUNDLE on $UDID"
 fi

--- a/tools/probe-app/selftest.py
+++ b/tools/probe-app/selftest.py
@@ -269,6 +269,37 @@ def main() -> int:
     else:
         results.append(False)
 
+    # -- Cold launch: the app is terminated, and the URL starts it --
+    # This is the path the guide describes and nothing exercised. It is also
+    # where the lifecycles genuinely differ, so a test that only ever opens
+    # links into a running app would not have caught either behaviour.
+    print("cold launch:")
+    try:
+        call("POST", "/device/app/terminate", udid=udid, bundle_id=bundle_id)
+    except requests.HTTPError:
+        pass
+    time.sleep(2.0)
+    open_url(udid, f"{scheme}://open/cold/1")
+    time.sleep(3.0)
+    goto(udid, "Links", marker="link_count")
+    cold_count = element_text(udid, "link_count")
+    cold_route = element_text(udid, "link_route")
+
+    if args.scene:
+        # connectionOptions.urlContexts, delivered once.
+        results.append(check("cold launch reaches the app", cold_count == "1",
+                             f"link_count={cold_count}"))
+        results.append(check("cold launch routed via scene:willConnectTo",
+                             cold_route == "scene:willConnectTo", f"got {cold_route!r}"))
+    else:
+        # didFinishLaunching sees it in launchOptions, then open(_:) is called
+        # with the same URL. An app that handles both without deduplicating
+        # runs its routing twice per cold launch.
+        results.append(check("cold launch delivers the URL twice", cold_count == "2",
+                             f"link_count={cold_count} (expected 2)"))
+        results.append(check("the later delivery is appdelegate:open",
+                             cold_route == "appdelegate:open", f"got {cold_route!r}"))
+
     # -- Logs and web surfaces present --
     print("logs and web:")
     goto(udid, "Logs", marker="log_status")

--- a/tools/probe-app/selftest.py
+++ b/tools/probe-app/selftest.py
@@ -21,6 +21,7 @@ import requests
 
 BASE = "http://localhost:9100/api/v1"
 BUNDLE_ID = "com.quern.probe"
+SCENE_BUNDLE_ID = "com.quern.probe.scene"
 SHIFT_TEXT = "ab_CD!2@x"
 
 
@@ -160,6 +161,8 @@ def check(name: str, ok: bool, detail: str = "") -> bool:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--udid", default=None, help="Target simulator UDID")
+    parser.add_argument("--scene", action="store_true",
+                        help="Exercise the scene-lifecycle bundle instead")
     args = parser.parse_args()
 
     udid = args.udid
@@ -168,13 +171,17 @@ def main() -> int:
     print(f"target simulator: {udid}")
 
     here = Path(__file__).parent
-    subprocess.run([str(here / "build.sh"), "--install", udid], check=True)
+    bundle_id = SCENE_BUNDLE_ID if args.scene else BUNDLE_ID
+    scheme = "quernprobescene" if args.scene else "quernprobe"
+    build = [str(here / "build.sh")] + (["--scene"] if args.scene else []) + ["--install", udid]
+    subprocess.run(build, check=True)
+    print(f"lifecycle: {'scene' if args.scene else 'app delegate'} ({bundle_id})")
 
     try:
-        call("POST", "/device/app/terminate", udid=udid, bundle_id=BUNDLE_ID)
+        call("POST", "/device/app/terminate", udid=udid, bundle_id=bundle_id)
     except requests.HTTPError:
         pass  # not running — fine
-    call("POST", "/device/app/launch", udid=udid, bundle_id=BUNDLE_ID)
+    call("POST", "/device/app/launch", udid=udid, bundle_id=bundle_id)
     time.sleep(1.5)
 
     results: list[bool] = []
@@ -232,7 +239,7 @@ def main() -> int:
     goto(udid, "Links", marker="link_count")
     before = element_text(udid, "link_count")
     if check("Links tab reachable", before is not None, "link_count not found"):
-        reported, _ = open_url(udid, "quernprobe://open/product/abc123")
+        reported, _ = open_url(udid, f"{scheme}://open/product/abc123")
         time.sleep(2.0)
         goto(udid, "Links", marker="link_count")
         after = element_text(udid, "link_count")
@@ -240,8 +247,13 @@ def main() -> int:
                              after is not None and int(after) == int(before) + 1,
                              f"count {before} -> {after}"))
         results.append(check("registered scheme URI recorded",
-                             (element_text(udid, "link_last_uri") or "").startswith("quernprobe://"),
+                             (element_text(udid, "link_last_uri") or "").startswith(f"{scheme}://"),
                              f"got {element_text(udid, 'link_last_uri')!r}"))
+
+        route = element_text(udid, "link_route")
+        expected = "scene:openURLContexts" if args.scene else "appdelegate:open"
+        results.append(check(f"warm delivery routed via {expected}",
+                             route == expected, f"got {route!r}"))
 
         held = element_text(udid, "link_count")
         reported, detail = open_url(udid, "nonexistentapp12345://foo/bar")

--- a/tools/run-probes.py
+++ b/tools/run-probes.py
@@ -69,8 +69,13 @@ def main() -> int:
     if not args.android_only:
         udid = booted_simulator()
         if udid:
-            results.append(run("iOS — QuernProbe", HERE / "probe-app" / "selftest.py",
-                               ["--udid", udid]))
+            ios = HERE / "probe-app" / "selftest.py"
+            results.append(run("iOS — app-delegate lifecycle", ios, ["--udid", udid]))
+            # The same suite against the scene bundle. Which delegate callbacks
+            # fire is decided at build time, so one binary cannot cover both,
+            # and the guidance we publish about scene delivery is only verified
+            # if something runs it.
+            results.append(run("iOS — scene lifecycle", ios, ["--udid", udid, "--scene"]))
         else:
             skipped.append("iOS (no booted simulator)")
 


### PR DESCRIPTION
Built to verify guidance we'd already published. It found two of those claims wrong within an hour, which is roughly the point.

## Approach

Two `Info.plist`s over one source tree, not a second app. An app has a scene manifest or it doesn't, and that decides which callbacks iOS calls — no single running binary can exercise both. View controllers, tabs and the self-test stay shared, so this doesn't re-create the split we just spent a day undoing with LogTester.

```sh
./build.sh              # com.quern.probe        — app-delegate lifecycle
./build.sh --scene      # com.quern.probe.scene  — scene lifecycle
python3 selftest.py [--scene]
```

`DeepLinkStore` now records *which* callback delivered each link, surfaced as `link_route`, so the test asserts the route rather than merely that something arrived. **Both bundles: 12/12.**

## Correction 1 — a cold launch delivers the URL twice

On the app-delegate lifecycle, one `simctl openurl` at a terminated app produced **`link_count = 2`**. `didFinishLaunching` sees the URL in `launchOptions`, and *then* `application(_:open:options:)` is called with the same URL.

An app handling both without deduplicating runs its deep-link routing twice per cold launch — a doubled analytics event, a duplicated navigation push, a repeated fetch. It surfaces as wrong behaviour, not as an error.

The guide I wrote two PRs ago presented these as *alternatives*: cold → `launchOptions`, warm → `open`. They aren't. The scene bundle recorded the same link **once**, via `scene(_:willConnectTo:options:)` — so this is a genuine difference between the lifecycles, and one that improves on migration.

## Correction 2 — the manifest isn't the only trigger

Implementing `application(_:configurationForConnecting:options:)` switches the app to the scene lifecycle **on its own**, with no `UIApplicationSceneManifest` anywhere.

Measured: my manifest-free bundle reported `scene:willConnectTo` until that method was compiled out. So for a while my "app-delegate probe" was silently testing the scene path — the fixture was lying, and only the route label revealed it.

That's why the scene config sits behind `-D SCENE_LIFECYCLE` rather than a runtime check: the decision is made from the method's *presence*, before any of our code runs. A runtime guard cannot help.

Practical value for readers: if deep links stop arriving after an unrelated refactor, check whether that method appeared.

## What this says about the exercise

Neither correction was reachable by reading. Both came from a fixture that reports which path executed, rather than asserting the outcome I expected — the same discipline that made `link_count` more trustworthy than `open_url`'s status.

Worth being straight about the limit too: this only worked because I had *already been told* scene delivery existed. A fixture verifies claims you know to make. It doesn't tell you which claims you're missing.

`docs/guides/deep-link-testing.md` is updated with both findings. `run-probes.py` now runs the iOS suite against both bundles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded iOS deep-link guidance to explain cold-launch delivery, duplicate routing risks, and differences between app-delegate and scene-based lifecycles.
  - Documented how scene configuration affects URL callback behavior.

- **New Features**
  - Added scene-lifecycle support to the iOS deep-link probe app.
  - The probe now displays how each deep link was delivered.
  - Added support for building and testing both app-delegate and scene-based configurations.

- **Tests**
  - Automated probe runs now validate deep-link delivery across both lifecycle modes on an iOS simulator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->