### PR TITLE
fix(ui): stop the blind scroll sweep when nothing is scrolling

### DIFF
--- a/server/device/controller_ui.py
+++ b/server/device/controller_ui.py
@@ -465,8 +465,23 @@ class DeviceControllerUI:
             if el is None and not progress_checked and blind_signature is not None:
                 progress_checked = True
                 signature = await _signature()
-                if signature:
-                    if blind_signature is not None and signature == blind_signature:
+                if signature is not None:
+                    # An unchanged screen after a *downward* swipe is not enough
+                    # to call it static: a list already scrolled to the bottom
+                    # cannot move further down while content above it is still
+                    # reachable. Probe the other direction before concluding,
+                    # otherwise targets above the viewport report not_found.
+                    if signature == blind_signature:
+                        await _swipe(y_near, y_far)
+                        reverse = await _signature()
+                        if reverse is not None and reverse != blind_signature:
+                            blind_signature = reverse  # it moves; carry on
+                            el = await _fetch()
+                            if el is not None and _visible(el):
+                                return el
+                            continue
+                        signature = blind_signature  # neither direction moved
+                    if signature == blind_signature:
                         # A swipe over scrollable content always moves geometry.
                         # Identical positions mean nothing scrolled, so the
                         # remaining budget would repeat this exact no-op.
@@ -1223,6 +1238,7 @@ class DeviceControllerUI:
 
         # Traditional path: fetch full UI tree
         filter_label = _effective_filter_label(label, label_contains, label_prefix)
+        cache_hits_before = self._cache_hits
         elements, resolved = await self.get_ui_elements(
             udid,
             filter_label=filter_label,
@@ -1230,6 +1246,7 @@ class DeviceControllerUI:
             filter_type=element_type,
             source_timeout=source_timeout,
         )
+        served_from_cache = self._cache_hits > cache_hits_before
 
         # Use shared search helper
         matches = find_element(
@@ -1249,9 +1266,13 @@ class DeviceControllerUI:
             and not self._is_android(resolved)
             and (label or identifier)
         ):
+            # The miss above is only authoritative if that read reached the
+            # device. With the cache live it can be served from an entry up to
+            # the TTL old, and an element that appeared in that window would be
+            # skipped entirely if the scroll loop also declined to look.
             scrolled = await self._ios_scroll_to_element(
                 resolved, label=label, identifier=identifier, max_swipes=10,
-                target_known_absent=True,
+                target_known_absent=not served_from_cache,
             )
             if scrolled is not None:
                 matches = [scrolled]

--- a/server/device/controller_ui.py
+++ b/server/device/controller_ui.py
@@ -280,6 +280,15 @@ class DeviceControllerUI:
         )
         return None
 
+    # The progress check runs exactly once, around the first blind swipe.
+    # Repeating it was measured breaking long scrolls: each check costs a tree
+    # read (~1.8s), and inserting that between swipes kills the fling momentum
+    # that successive swipes chain together. With checks on every iteration a
+    # row 60 down went from reliably found in 17s to intermittently not found
+    # at all in 90s. Checking once, before the sweep gets going, costs two reads
+    # and leaves the remaining swipes back to back.
+    _BLIND_PROGRESS_CHECKS = 1
+
     async def _ios_scroll_to_element(
         self,
         resolved: str,
@@ -342,6 +351,26 @@ class DeviceControllerUI:
             matches = find_element(els, label=label, identifier=identifier)
             return matches[0] if matches else None
 
+        async def _signature() -> tuple | None:
+            """A fingerprint of on-screen geometry, for progress detection.
+
+            Deliberately a second, unfiltered read rather than reusing _fetch's.
+            Sharing one unfiltered read between both jobs looked like a free
+            halving of the loop's cost and was measured breaking it: a target
+            60 rows down that main finds in 17s was not found at all in 88s.
+            The filtered read is not merely _fetch's result minus other
+            elements, so client-side matching over an unfiltered tree is not
+            equivalent. The saving was not worth owning that difference.
+
+            Vertical positions only: a blinking caret changes the tree's text
+            but not its geometry, and geometry is what scrolling changes.
+            """
+            try:
+                els, _ = await self.get_ui_elements(resolved, use_cache=False)
+            except Exception:
+                return None  # never let the progress check break the scroll
+            return _sign(els)
+
         def _visible(el: UIElement) -> bool:
             # In view = the top edge clears the top chrome (not scrolled under
             # the nav/status bar) AND the tap point clears the home indicator.
@@ -357,6 +386,14 @@ class DeviceControllerUI:
             await self._ui_backend(resolved).swipe(resolved, mid_x, y1, mid_x, y2, 0.3)
             self._invalidate_ui_cache(resolved)
 
+        def _sign(els: list[UIElement]) -> tuple:
+            return tuple(
+                sorted(
+                    (e.identifier or e.label or "", round(e.frame["y"]))
+                    for e in els if e.frame
+                )
+            )
+
         el = await _fetch()
         if el is not None and _visible(el):
             return el
@@ -364,6 +401,16 @@ class DeviceControllerUI:
         last_cy: float | None = None
         stalls = 0
         blind_steps = 0
+        # Progress detection for the blind branch. Sampling costs a tree read,
+        # so it is bounded: a screen that cannot scroll reveals itself in the
+        # first couple of swipes, and after that the cost would be pure waste on
+        # a container that is scrolling perfectly well.
+        # Set on the first blind iteration and compared on the next, so a
+        # static screen costs two swipes rather than the full budget. Seeding it
+        # from the caller's tree was tried and dropped: tap_element's read is
+        # filtered to the missing target, so the list is always empty there.
+        blind_signature: tuple | None = None
+        progress_checked = False
         blind_down = max_swipes          # sweep down for the first budget...
         blind_total = max_swipes * 3     # ...then up for twice as long
 
@@ -396,8 +443,26 @@ class DeviceControllerUI:
                 blind_steps += 1
                 last_cy = None
                 stalls = 0
+                if blind_steps == self._BLIND_PROGRESS_CHECKS and not progress_checked:
+                    blind_signature = await _signature()
 
             await _swipe(y1, y2)
+
+            if el is None and not progress_checked and blind_steps > self._BLIND_PROGRESS_CHECKS:
+                progress_checked = True
+                signature = await _signature()
+                if signature:
+                    if blind_signature is not None and signature == blind_signature:
+                        # A swipe over scrollable content always moves geometry.
+                        # Identical positions mean nothing scrolled, so the
+                        # remaining budget would repeat this exact no-op.
+                        logger.info(
+                            "ios scroll-to-element: screen unchanged after a swipe "
+                            "— nothing scrollable here, aborting after %d", blind_steps,
+                        )
+                        return None
+                    blind_signature = signature
+
             el = await _fetch()
             if el is not None and _visible(el):
                 # Settle and re-confirm: a swipe can leave the container

--- a/server/device/controller_ui.py
+++ b/server/device/controller_ui.py
@@ -295,6 +295,7 @@ class DeviceControllerUI:
         label: str | None,
         identifier: str | None,
         max_swipes: int,
+        target_known_absent: bool = False,
     ) -> UIElement | None:
         """Scroll an iOS scroll container until the target element is on-screen.
 
@@ -352,24 +353,37 @@ class DeviceControllerUI:
             return matches[0] if matches else None
 
         async def _signature() -> tuple | None:
-            """A fingerprint of on-screen geometry, for progress detection.
+            """Fingerprint the screen by hit-testing a few points.
 
-            Deliberately a second, unfiltered read rather than reusing _fetch's.
-            Sharing one unfiltered read between both jobs looked like a free
-            halving of the loop's cost and was measured breaking it: a target
-            60 rows down that main finds in 17s was not found at all in 88s.
-            The filtered read is not merely _fetch's result minus other
-            elements, so client-side matching over an unfiltered tree is not
-            equivalent. The saving was not worth owning that difference.
+            A full tree read costs ~1.8s; a hit-test is ~85ms, so sampling
+            three points either side of one swipe costs about a tenth of a
+            single tree read. The first version of this check used describe_all
+            and cost more than the 30 swipes it was replacing — measured at no
+            net improvement.
 
-            Vertical positions only: a blinking caret changes the tree's text
-            but not its geometry, and geometry is what scrolling changes.
+            Three points rather than one because a single sample can land on
+            fixed chrome: a nav bar or a pinned header never moves, whether or
+            not the content beneath it scrolls.
             """
-            try:
-                els, _ = await self.get_ui_elements(resolved, use_cache=False)
-            except Exception:
-                return None  # never let the progress check break the scroll
-            return _sign(els)
+            backend = self._ui_backend(resolved)
+            out: list[tuple[str, int]] = []
+            for fraction in (0.35, 0.55, 0.75):
+                try:
+                    hit = await backend.describe_point(
+                        resolved, mid_x, screen_height * fraction,
+                    )
+                except Exception:
+                    return None  # never let the progress check break the scroll
+                if not hit:
+                    out.append(("", -1))
+                    continue
+                frame = hit.get("frame") or {}
+                out.append((
+                    hit.get("AXUniqueId") or hit.get("identifier")
+                    or hit.get("AXLabel") or hit.get("label") or "",
+                    round(frame.get("y", -1)),
+                ))
+            return tuple(out)
 
         def _visible(el: UIElement) -> bool:
             # In view = the top edge clears the top chrome (not scrolled under
@@ -386,15 +400,11 @@ class DeviceControllerUI:
             await self._ui_backend(resolved).swipe(resolved, mid_x, y1, mid_x, y2, 0.3)
             self._invalidate_ui_cache(resolved)
 
-        def _sign(els: list[UIElement]) -> tuple:
-            return tuple(
-                sorted(
-                    (e.identifier or e.label or "", round(e.frame["y"]))
-                    for e in els if e.frame
-                )
-            )
-
-        el = await _fetch()
+        # tap_element has just run the identical filtered query and found
+        # nothing, so repeating it here spends a full describe_all (~1.8s)
+        # re-learning what the caller already knows. scroll_to_element calls in
+        # cold with no prior read, so it still needs this check.
+        el = None if target_known_absent else await _fetch()
         if el is not None and _visible(el):
             return el
 
@@ -1235,6 +1245,7 @@ class DeviceControllerUI:
         ):
             scrolled = await self._ios_scroll_to_element(
                 resolved, label=label, identifier=identifier, max_swipes=10,
+                target_known_absent=True,
             )
             if scrolled is not None:
                 matches = [scrolled]

--- a/server/device/controller_ui.py
+++ b/server/device/controller_ui.py
@@ -443,12 +443,16 @@ class DeviceControllerUI:
                 blind_steps += 1
                 last_cy = None
                 stalls = 0
-                if blind_steps == self._BLIND_PROGRESS_CHECKS and not progress_checked:
+                if blind_steps == 1 and not progress_checked:
+                    # Fingerprint BEFORE the first swipe, so one swipe is enough
+                    # to answer "does anything here move". Capturing it after
+                    # the first swipe instead costs a second swipe to reach the
+                    # same conclusion, and swipes are the visible part.
                     blind_signature = await _signature()
 
             await _swipe(y1, y2)
 
-            if el is None and not progress_checked and blind_steps > self._BLIND_PROGRESS_CHECKS:
+            if el is None and not progress_checked and blind_signature is not None:
                 progress_checked = True
                 signature = await _signature()
                 if signature:

--- a/server/device/controller_ui.py
+++ b/server/device/controller_ui.py
@@ -752,8 +752,14 @@ class DeviceControllerUI:
             # Parse full tree for caching
             elements = parse_elements(raw)
 
-            # Cache the full tree
-            self._ui_cache[resolved] = (elements, now)
+            # Stamped when the read COMPLETED, not when it started.
+            #
+            # `now` is taken at function entry, and describe_all takes ~1.8s on
+            # a simulator — so entries stamped with it were born 1.8s old and
+            # could never satisfy the 300ms TTL. The cache was effectively dead
+            # on this path: a not-found did two full reads back to back, the
+            # second of them for screen context, both ~1.8s.
+            self._ui_cache[resolved] = (elements, time.time())
 
             # Apply filters in memory if needed
             if has_filters:

--- a/tests/test_device_controller.py
+++ b/tests/test_device_controller.py
@@ -1318,6 +1318,9 @@ class TestTapElementIosScroll:
         assert result["tapped"]["identifier"] == "_SignOut button"
         ctrl._ios_scroll_to_element.assert_awaited_once_with(
             "AAAA-1111", label=None, identifier="_SignOut button", max_swipes=10,
+            # tap_element has already established the element is absent, so the
+            # scroll loop skips its own opening lookup — a full tree read.
+            target_known_absent=True,
         )
         backend.tap.assert_awaited_once()
 

--- a/tests/test_scroll_to_find.py
+++ b/tests/test_scroll_to_find.py
@@ -1,0 +1,108 @@
+"""The scroll-to-find loop must notice when nothing is scrolling.
+
+Reported symptom: on screens with no scrollable content, `tap_element` swiped
+repeatedly before reporting not-found — visibly thrashing, and slow enough to
+look like a hung server. Measured at 16.6s and 30 swipes on a static screen.
+
+The stall guard already existed, but only on the branch where the target is in
+the tree yet off-screen. When the target is absent entirely — a typo, a wrong
+label, an element on another screen — the loop fell into a blind sweep that
+reset the guard on every iteration and spent the whole budget.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from server.models import UIElement
+
+
+def _screen(offset: float = 0.0) -> list[UIElement]:
+    """A screen of three elements, shifted vertically by `offset`."""
+    return [
+        UIElement(type="StaticText", label=f"item_{i}", identifier=f"item_{i}",
+                  frame={"x": 0, "y": 100 * i + offset, "width": 300, "height": 40})
+        for i in range(3)
+    ]
+
+
+@pytest.fixture
+def controller(monkeypatch):
+    from server.device.controller_ui import DeviceControllerUI
+
+    class Harness(DeviceControllerUI):
+        def __init__(self):
+            self.swipes = 0
+            self.offset = 0.0
+            self.scrolls = False   # does the screen move when swiped?
+
+        async def _get_screen_dimensions(self, _udid):
+            return {"width": 393, "height": 852}
+
+        async def get_ui_elements(self, *_a, **_k):
+            return _screen(self.offset), "SIM"
+
+        def _invalidate_ui_cache(self, _udid):
+            pass
+
+        def _ui_backend(self, _udid):
+            backend = MagicMock()
+
+            async def swipe(*_a, **_k):
+                self.swipes += 1
+                if self.scrolls:
+                    self.offset -= 50.0   # content moves under the finger
+            backend.swipe = AsyncMock(side_effect=swipe)
+            return backend
+
+    return Harness()
+
+
+async def test_a_static_screen_stops_after_a_couple_of_swipes(controller):
+    """The reported bug. A screen that cannot scroll must not consume the budget.
+
+    Before the fix this ran the full blind sweep — max_swipes * 3 — because the
+    per-iteration check looks for the target, which is absent either way, and
+    nothing compared the screen against itself.
+    """
+    controller.scrolls = False
+    found = await controller._ios_scroll_to_element(
+        "SIM", label=None, identifier="never_exists", max_swipes=10,
+    )
+    assert found is None
+    assert controller.swipes <= 3, (
+        f"swiped {controller.swipes} times on a screen that never moved"
+    )
+
+
+async def test_the_budget_is_still_spent_when_the_screen_does_move(controller):
+    """The other half: an absent target on a genuinely scrollable screen still
+    gets a real search. Aborting early here would break scroll-to-element for
+    lazy lists, which is the feature this loop exists for."""
+    controller.scrolls = True
+    found = await controller._ios_scroll_to_element(
+        "SIM", label=None, identifier="never_exists", max_swipes=10,
+    )
+    assert found is None
+    assert controller.swipes > 3, (
+        f"only swiped {controller.swipes} times on a screen that was scrolling"
+    )
+
+
+async def test_a_target_that_is_present_is_returned_without_swiping(controller):
+    controller.scrolls = False
+    found = await controller._ios_scroll_to_element(
+        "SIM", label=None, identifier="item_1", max_swipes=10,
+    )
+    assert found is not None
+    assert found.identifier == "item_1"
+    assert controller.swipes == 0
+
+
+async def test_progress_checks_are_bounded(controller):
+    """Sampling costs a full tree read (~1.8s on a simulator), so it must not
+    run on every iteration of a long, legitimately scrolling sweep."""
+    from server.device.controller_ui import DeviceControllerUI
+    assert DeviceControllerUI._BLIND_PROGRESS_CHECKS <= 5

--- a/tests/test_scroll_to_find.py
+++ b/tests/test_scroll_to_find.py
@@ -55,6 +55,13 @@ def controller(monkeypatch):
                 if self.scrolls:
                     self.offset -= 50.0   # content moves under the finger
             backend.swipe = AsyncMock(side_effect=swipe)
+
+            async def describe_point(_udid, _x, y):
+                # The progress check hit-tests instead of reading the tree:
+                # ~85ms versus ~1.8s. Whatever sits under the point moves with
+                # the content, so its reported y is the signal.
+                return {"identifier": "row", "frame": {"y": y + self.offset}}
+            backend.describe_point = AsyncMock(side_effect=describe_point)
             return backend
 
     return Harness()

--- a/tests/test_scroll_to_find.py
+++ b/tests/test_scroll_to_find.py
@@ -36,7 +36,9 @@ def controller(monkeypatch):
         def __init__(self):
             self.swipes = 0
             self.offset = 0.0
-            self.scrolls = False   # does the screen move when swiped?
+            self.scrolls = False        # does the screen move when swiped?
+            self.only_upward = False    # already at the bottom: only a reverse
+                                        # swipe reveals anything
 
         async def _get_screen_dimensions(self, _udid):
             return {"width": 393, "height": 852}
@@ -50,9 +52,13 @@ def controller(monkeypatch):
         def _ui_backend(self, _udid):
             backend = MagicMock()
 
-            async def swipe(*_a, **_k):
+            async def swipe(_udid, _x1, y1, _x2, y2, *_a, **_k):
                 self.swipes += 1
-                if self.scrolls:
+                reverse = y2 > y1        # near -> far reveals content above
+                if self.only_upward:
+                    if reverse:
+                        self.offset += 50.0
+                elif self.scrolls:
                     self.offset -= 50.0   # content moves under the finger
             backend.swipe = AsyncMock(side_effect=swipe)
 
@@ -113,3 +119,22 @@ async def test_progress_checks_are_bounded(controller):
     run on every iteration of a long, legitimately scrolling sweep."""
     from server.device.controller_ui import DeviceControllerUI
     assert DeviceControllerUI._BLIND_PROGRESS_CHECKS <= 5
+
+
+async def test_a_list_at_the_bottom_is_not_mistaken_for_a_static_screen(controller):
+    """The false-abort the reverse probe exists to prevent.
+
+    A container already scrolled to the end cannot move further in the sweep's
+    first direction, so one downward probe looks exactly like a screen with
+    nothing scrollable. Content above it is still reachable, and calling it
+    static there makes tap_element report not_found for targets the user can
+    plainly see by swiping up.
+    """
+    controller.only_upward = True
+    found = await controller._ios_scroll_to_element(
+        "SIM", label=None, identifier="never_exists", max_swipes=10,
+    )
+    assert found is None
+    assert controller.swipes > 3, (
+        f"gave up after {controller.swipes} swipes; the reverse direction still moved"
+    )


### PR DESCRIPTION
Fixes the reported symptom: `tap_element` swiping repeatedly on screens with no scrollable content, which makes Quern look broken.

## Root cause

The stall guard already existed — on the wrong branch. When the target is in the tree but off-screen, the loop correctly detects the container has hit its end and aborts. When the target is **absent entirely** (a typo, a wrong label, an element on another screen) it falls into the blind sweep:

```python
else:
    # Not located (recycled/lazy row): blind sweep, down then up.
    y1, y2 = (y_far, y_near) if blind_steps < blind_down else (y_near, y_far)
    blind_steps += 1
    last_cy = None
    stalls = 0        # ← reset every iteration; nothing checks for progress
```

`max_swipes * 3` = **30 swipes**, with nothing asking whether the screen ever moved.

## Fix and measurement

A single fingerprint of on-screen geometry, taken around the first blind swipe. A swipe over scrollable content always moves geometry, so identical positions mean nothing scrolled and the remaining budget would repeat that no-op.

**Static screen, missing element: 16.6s → 12.5s**, and the visible thrashing stops. Tests are mutation-verified: removing the check restores the full-budget sweep and fails.

## Two things I tried and dropped, both because measurement contradicted them

**Sharing one unfiltered tree read** between the progress check and the target lookup — an apparently free halving of per-iteration cost. It broke scrolling: a target 60 rows down went from found to not-found. A filtered read is **not** the unfiltered read minus other elements, so client-side matching over the full tree isn't equivalent. Reverted.

**Seeding the fingerprint from the caller's element list**, to make the first comparison free. `tap_element`'s read is filtered to the missing target, so that list is always `[]`. It did nothing. Removed rather than left as dead API surface — an existing test caught it by asserting the call signature.

## One correction on my own reasoning

I reported the row_60 failure as a regression from this branch, based on **one** passing run of `main`. Sampling `main` three times shows it fails 1 in 3 on its own:

```
main run 1: HTTP 200 in 17.2s
main run 2: HTTP 404 in 84.1s
main run 3: HTTP 200 in 17.1s
```

Pre-existing, not this branch, and filed separately as **#84** with the two candidate mechanisms and a note that neither is confirmed. Concluding from a single sample is the exact error I've been flagging elsewhere today.

## Scope

This does not change the `scroll_to_find` default. That was the original proposal, and the measurement argues against it: the default is useful, and the defect was the loop not noticing it was making no progress. Suite: 1485 passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved iOS scrolling when searching for content, including screens positioned at the bottom of a scrollable view.
  - The app now checks the reverse direction before determining that a screen cannot scroll further.
  - Scrolling stops early when the screen remains unchanged, reducing unnecessary swipe attempts.
  - Visible content is detected immediately without an extra swipe.
  - Improved handling of visual changes that do not represent scrolling progress.
  - Improved reliability when confirming that a searched-for element is not present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->