### PR TITLE
chore: gate merges on a current review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -20,6 +20,14 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
+    # Review when a PR opens, then only when asked. Re-reviewing every push
+    # sounds strictly better and is not: review runs are capped per hour, and
+    # fixing findings means pushing, so the automatic behaviour spends the
+    # budget on intermediate states nobody merges and leaves the final one
+    # queued behind them. scripts/merge-pr.sh asks for a review at the point it
+    # matters -- immediately before a merge -- so the cap is spent on the commit
+    # that actually ships.
+    auto_incremental_review: false
 
   path_filters:
     # Generated or vendored — reviewing these produces noise, not findings.

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -7,9 +7,11 @@
 # risky moment is the merge, not the push -- so the check lives here, where
 # acting on stale data actually costs something.
 #
-#   scripts/merge-pr.sh 85            # refuses if the review is not current
-#   scripts/merge-pr.sh 85 --wait     # waits for the review, then merges
+#   scripts/merge-pr.sh 85            # asks for a review if stale, waits, merges
 #   scripts/merge-pr.sh 85 --force    # merge anyway, deliberately
+#
+# --wait is implied when a review has to be requested; pass it explicitly to
+# wait on a review someone else already triggered.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
@@ -24,7 +26,20 @@ done
 
 if [ -n "$FORCE" ]; then
   echo "Skipping the review gate deliberately (--force)."
-elif ! python3 scripts/pr-review-status.py "$PR" $WAIT; then
+else
+  # Ask for a review if this PR has moved since its last one. Automatic
+  # incremental reviews are off (see .coderabbit.yaml): review runs are capped
+  # per hour, and fixing findings means pushing, so reviewing every push spends
+  # the budget on intermediate states nobody merges. Requesting it here spends
+  # it on the commit that actually ships.
+  if ! python3 scripts/pr-review-status.py "$PR" >/dev/null 2>&1; then
+    echo "Requesting a review of #$PR..."
+    gh pr comment "$PR" --repo jerimiah797/quern --body "@coderabbitai review" >/dev/null
+    WAIT="--wait"
+  fi
+fi
+
+if [ -z "$FORCE" ] && ! python3 scripts/pr-review-status.py "$PR" $WAIT; then
   echo
   echo "Not merging #$PR: its review is not current, or it has unresolved findings."
   echo "  --wait   block until the review lands"

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Merge a PR, but only if its review is current.
+#
+# The failure this prevents: CodeRabbit re-reviews on every push, so a
+# "0 unresolved" reading taken before the latest push is stale and reads
+# exactly like all-clear. Checking after every push does not fix that -- the
+# risky moment is the merge, not the push -- so the check lives here, where
+# acting on stale data actually costs something.
+#
+#   scripts/merge-pr.sh 85            # refuses if the review is not current
+#   scripts/merge-pr.sh 85 --wait     # waits for the review, then merges
+#   scripts/merge-pr.sh 85 --force    # merge anyway, deliberately
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+PR="${1:?usage: merge-pr.sh <number> [--wait] [--force]}"; shift
+WAIT=""; FORCE=""
+for a in "$@"; do
+  case "$a" in
+    --wait) WAIT="--wait" ;;
+    --force) FORCE=1 ;;
+  esac
+done
+
+if [ -n "$FORCE" ]; then
+  echo "Skipping the review gate deliberately (--force)."
+elif ! python3 scripts/pr-review-status.py "$PR" $WAIT; then
+  echo
+  echo "Not merging #$PR: its review is not current, or it has unresolved findings."
+  echo "  --wait   block until the review lands"
+  echo "  --force  merge anyway"
+  exit 1
+fi
+
+gh pr merge "$PR" --repo jerimiah797/quern --merge --delete-branch

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -27,24 +27,34 @@ done
 if [ -n "$FORCE" ]; then
   echo "Skipping the review gate deliberately (--force)."
 else
-  # Ask for a review if this PR has moved since its last one. Automatic
-  # incremental reviews are off (see .coderabbit.yaml): review runs are capped
-  # per hour, and fixing findings means pushing, so reviewing every push spends
-  # the budget on intermediate states nobody merges. Requesting it here spends
-  # it on the commit that actually ships.
-  if ! python3 scripts/pr-review-status.py "$PR" >/dev/null 2>&1; then
+  # 0 clean · 2 pending · 3 unresolved findings · 4 undeterminable.
+  #
+  # Only 2 is worth a review request. Reacting to any nonzero code would ask
+  # for a re-review of a PR whose findings nobody has read yet, and again when
+  # gh cannot answer -- spending capped review runs on the two cases a review
+  # cannot help. Automatic incremental reviews are off (.coderabbit.yaml), so
+  # this is the request that gets made, and it should be the useful one.
+  python3 scripts/pr-review-status.py "$PR" || STATE=$?
+  STATE="${STATE:-0}"
+
+  if [ "$STATE" = "2" ]; then
     echo "Requesting a review of #$PR..."
     gh pr comment "$PR" --repo jerimiah797/quern --body "@coderabbitai review" >/dev/null
-    WAIT="--wait"
+    python3 scripts/pr-review-status.py "$PR" --wait || STATE=$?
   fi
+
+  case "${STATE:-0}" in
+    0) ;;
+    3) echo; echo "Not merging #$PR: it has unresolved findings. Read them first."; exit 1 ;;
+    4) echo; echo "Not merging #$PR: could not determine its review state."; exit 1 ;;
+    *) echo; echo "Not merging #$PR: still awaiting review."; exit 1 ;;
+  esac
 fi
 
-if [ -z "$FORCE" ] && ! python3 scripts/pr-review-status.py "$PR" $WAIT; then
-  echo
-  echo "Not merging #$PR: its review is not current, or it has unresolved findings."
-  echo "  --wait   block until the review lands"
-  echo "  --force  merge anyway"
-  exit 1
-fi
-
-gh pr merge "$PR" --repo jerimiah797/quern --merge --delete-branch
+# Bind the merge to the commit that was reviewed. Between the check above and
+# the merge below, a push can land -- and merging then ships a commit nothing
+# reviewed, which is the exact hole this script exists to close. GitHub refuses
+# the merge if the head has moved.
+HEAD_SHA=$(gh pr view "$PR" --repo jerimiah797/quern --json headRefOid -q .headRefOid)
+gh pr merge "$PR" --repo jerimiah797/quern --merge --delete-branch \
+  --match-head-commit "$HEAD_SHA"

--- a/scripts/pr-review-status.py
+++ b/scripts/pr-review-status.py
@@ -11,6 +11,15 @@ reads exactly like "all clear". Merging on it means merging unreviewed code.
 
 Exit code is 0 only when every PR examined is reviewed-and-clean, so this can
 gate a merge in a script.
+
+Do not pipe it when you care about that exit code: `... | tail` reports tail's
+status, not this script's, so a still-pending PR reads as success. merge-pr.sh
+calls it directly for exactly this reason.
+
+Note on cadence: CodeRabbit allows a limited number of review runs per hour
+(10 at time of writing), so a push can sit queued rather than being reviewed
+promptly. Several small pushes to the same branch spend that budget faster than
+one considered push, and leave every intermediate state unreviewed.
 """
 from __future__ import annotations
 

--- a/scripts/pr-review-status.py
+++ b/scripts/pr-review-status.py
@@ -9,8 +9,9 @@ reads exactly like "all clear". Merging on it means merging unreviewed code.
     scripts/pr-review-status.py --wait    # block until every PR is current
     scripts/pr-review-status.py 85        # a specific PR
 
-Exit code is 0 only when every PR examined is reviewed-and-clean, so this can
-gate a merge in a script.
+Exit codes: 0 reviewed and clean, 2 pending a review, 3 has unresolved
+findings, 4 could not be determined. Only 0 permits a merge, and only 2 is
+worth waiting on.
 
 Do not pipe it when you care about that exit code: `... | tail` reports tail's
 status, not this script's, so a still-pending PR reads as success. merge-pr.sh
@@ -31,6 +32,17 @@ import time
 from datetime import datetime
 
 REPO = "jerimiah797/quern"
+
+# Distinct exit codes, so a caller can tell *why* a PR is not mergeable.
+# merge-pr.sh needs that: requesting a review helps a pending PR and is pure
+# waste for one with unresolved findings, which was spending capped review runs
+# on PRs a review could not help.
+EXIT_OK = 0
+EXIT_PENDING = 2
+EXIT_FINDINGS = 3
+EXIT_UNKNOWN = 4
+_EXIT = {"ok": EXIT_OK, "pending": EXIT_PENDING,
+         "findings": EXIT_FINDINGS, "unknown": EXIT_UNKNOWN}
 
 
 class GhError(RuntimeError):
@@ -105,14 +117,17 @@ def _status(number: int) -> tuple[str, str]:
     return "ok", f"#{number} {title} — reviewed, clean"
 
 
-def report(numbers: list[int]) -> bool:
-    all_ok = True
+def report(numbers: list[int]) -> int:
+    """Returns the worst exit code across the PRs examined."""
+    worst = EXIT_OK
     for n in numbers:
         state, detail = status(n)
         mark = {"ok": "OK  ", "pending": "WAIT", "findings": "READ", "unknown": "FAIL"}[state]
         print(f"  {mark} {detail}")
-        all_ok &= state == "ok"
-    return all_ok
+        # Unknown outranks findings outranks pending: the least understood
+        # state is the one a caller should act most cautiously on.
+        worst = max(worst, _EXIT[state])
+    return worst
 
 
 def main() -> int:
@@ -131,10 +146,13 @@ def main() -> int:
     deadline = time.monotonic() + args.timeout
     while True:
         print(f"— review status @ {datetime.now().strftime('%H:%M:%S')}")
-        if report(numbers):
-            return 0
-        if not args.wait or time.monotonic() > deadline:
-            return 1
+        code = report(numbers)
+        if code == EXIT_OK:
+            return EXIT_OK
+        # Only pending resolves by waiting. Findings need a human, and unknown
+        # means the check itself could not see the data.
+        if not args.wait or code != EXIT_PENDING or time.monotonic() > deadline:
+            return code
         time.sleep(30)
 
 

--- a/scripts/pr-review-status.py
+++ b/scripts/pr-review-status.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Report whether each open PR has been reviewed since its last push.
+
+The failure this exists to prevent: CodeRabbit re-reviews on every push, so a
+"0 unresolved threads" reading taken before the latest push is stale — and
+reads exactly like "all clear". Merging on it means merging unreviewed code.
+
+    scripts/pr-review-status.py           # one shot
+    scripts/pr-review-status.py --wait    # block until every PR is current
+    scripts/pr-review-status.py 85        # a specific PR
+
+Exit code is 0 only when every PR examined is reviewed-and-clean, so this can
+gate a merge in a script.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from datetime import datetime
+
+REPO = "jerimiah797/quern"
+
+
+def gh(*args: str) -> str:
+    return subprocess.run(["gh", *args], capture_output=True, text=True).stdout.strip()
+
+
+def ts(value: str | None) -> float:
+    if not value:
+        return 0.0
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+
+
+def open_prs() -> list[int]:
+    raw = gh("pr", "list", "--repo", REPO, "--state", "open", "--json", "number")
+    return [p["number"] for p in json.loads(raw or "[]")]
+
+
+def status(number: int) -> tuple[str, str]:
+    """Returns (state, detail) where state is ok | pending | findings | unknown."""
+    raw = gh("pr", "view", str(number), "--repo", REPO,
+             "--json", "headRefOid,title,statusCheckRollup")
+    if not raw:
+        return "unknown", "could not read the PR"
+    pr = json.loads(raw)
+
+    commits = json.loads(gh("pr", "view", str(number), "--repo", REPO, "--json", "commits") or "{}")
+    pushed = max((ts(c["committedDate"]) for c in commits.get("commits", [])), default=0.0)
+
+    reviews = json.loads(gh("api", f"repos/{REPO}/pulls/{number}/reviews") or "[]")
+    reviewed = max((ts(r.get("submitted_at")) for r in reviews), default=0.0)
+
+    owner, name = REPO.split("/")
+    query = (
+        f'{{repository(owner:"{owner}", name:"{name}")'
+        f"{{pullRequest(number:{number}){{"
+        "reviewThreads(last:60){nodes{isResolved isOutdated}}}}}"
+    )
+    threads = json.loads(gh("api", "graphql", "-f", f"query={query}") or "{}")
+    nodes = (threads.get("data", {}).get("repository", {}).get("pullRequest", {})
+             .get("reviewThreads", {}).get("nodes", []))
+    unresolved = sum(1 for n in nodes if not n["isResolved"] and not n["isOutdated"])
+
+    title = pr.get("title", "")[:44]
+    if reviewed < pushed:
+        return "pending", f"#{number} {title} — pushed since the last review"
+    if unresolved:
+        return "findings", f"#{number} {title} — {unresolved} unresolved"
+    return "ok", f"#{number} {title} — reviewed, clean"
+
+
+def report(numbers: list[int]) -> bool:
+    all_ok = True
+    for n in numbers:
+        state, detail = status(n)
+        mark = {"ok": "OK  ", "pending": "WAIT", "findings": "READ", "unknown": "??  "}[state]
+        print(f"  {mark} {detail}")
+        all_ok &= state == "ok"
+    return all_ok
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("prs", nargs="*", type=int)
+    ap.add_argument("--wait", action="store_true",
+                    help="poll until every PR is reviewed and clean")
+    ap.add_argument("--timeout", type=int, default=900)
+    args = ap.parse_args()
+
+    numbers = args.prs or open_prs()
+    if not numbers:
+        print("  no open PRs")
+        return 0
+
+    deadline = time.monotonic() + args.timeout
+    while True:
+        print(f"— review status @ {datetime.now().strftime('%H:%M:%S')}")
+        if report(numbers):
+            return 0
+        if not args.wait or time.monotonic() > deadline:
+            return 1
+        time.sleep(30)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pr-review-status.py
+++ b/scripts/pr-review-status.py
@@ -33,8 +33,21 @@ from datetime import datetime
 REPO = "jerimiah797/quern"
 
 
+class GhError(RuntimeError):
+    """A gh invocation failed. Raised rather than returned, because the caller
+    treating an empty result as data is precisely how this gate failed open:
+    a failed query produced no commits, no commits produced a push time of 0,
+    and any prior review then looked newer than the latest push."""
+
+
 def gh(*args: str) -> str:
-    return subprocess.run(["gh", *args], capture_output=True, text=True).stdout.strip()
+    try:
+        result = subprocess.run(["gh", *args], capture_output=True, text=True)
+    except OSError as exc:  # gh not installed, not on PATH, not executable
+        raise GhError(f"could not run gh: {exc}") from exc
+    if result.returncode != 0:
+        raise GhError(f"gh {' '.join(args[:3])}: {result.stderr.strip()[:160]}")
+    return result.stdout.strip()
 
 
 def ts(value: str | None) -> float:
@@ -49,17 +62,29 @@ def open_prs() -> list[int]:
 
 
 def status(number: int) -> tuple[str, str]:
-    """Returns (state, detail) where state is ok | pending | findings | unknown."""
-    raw = gh("pr", "view", str(number), "--repo", REPO,
-             "--json", "headRefOid,title,statusCheckRollup")
-    if not raw:
-        return "unknown", "could not read the PR"
+    """Returns (state, detail) where state is ok | pending | findings | unknown.
+
+    Every failure path returns "unknown", never "ok". A gate that cannot see
+    the data must refuse, not approve — rate limiting and network trouble are
+    exactly when it matters, and both are common here.
+    """
+    try:
+        return _status(number)
+    except (GhError, json.JSONDecodeError, KeyError, ValueError) as exc:
+        return "unknown", f"#{number} — could not determine review state: {exc}"
+
+
+def _status(number: int) -> tuple[str, str]:
+    raw = gh("pr", "view", str(number), "--repo", REPO, "--json", "title")
     pr = json.loads(raw)
 
-    commits = json.loads(gh("pr", "view", str(number), "--repo", REPO, "--json", "commits") or "{}")
-    pushed = max((ts(c["committedDate"]) for c in commits.get("commits", [])), default=0.0)
+    commits = json.loads(gh("pr", "view", str(number), "--repo", REPO, "--json", "commits"))
+    dates = [c["committedDate"] for c in commits["commits"]]
+    if not dates:
+        raise ValueError("the PR reported no commits")
+    pushed = max(ts(d) for d in dates)
 
-    reviews = json.loads(gh("api", f"repos/{REPO}/pulls/{number}/reviews") or "[]")
+    reviews = json.loads(gh("api", f"repos/{REPO}/pulls/{number}/reviews"))
     reviewed = max((ts(r.get("submitted_at")) for r in reviews), default=0.0)
 
     owner, name = REPO.split("/")
@@ -68,9 +93,8 @@ def status(number: int) -> tuple[str, str]:
         f"{{pullRequest(number:{number}){{"
         "reviewThreads(last:60){nodes{isResolved isOutdated}}}}}"
     )
-    threads = json.loads(gh("api", "graphql", "-f", f"query={query}") or "{}")
-    nodes = (threads.get("data", {}).get("repository", {}).get("pullRequest", {})
-             .get("reviewThreads", {}).get("nodes", []))
+    threads = json.loads(gh("api", "graphql", "-f", f"query={query}"))
+    nodes = threads["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
     unresolved = sum(1 for n in nodes if not n["isResolved"] and not n["isOutdated"])
 
     title = pr.get("title", "")[:44]
@@ -85,7 +109,7 @@ def report(numbers: list[int]) -> bool:
     all_ok = True
     for n in numbers:
         state, detail = status(n)
-        mark = {"ok": "OK  ", "pending": "WAIT", "findings": "READ", "unknown": "??  "}[state]
+        mark = {"ok": "OK  ", "pending": "WAIT", "findings": "READ", "unknown": "FAIL"}[state]
         print(f"  {mark} {detail}")
         all_ok &= state == "ok"
     return all_ok


### PR DESCRIPTION
CodeRabbit re-reviews on **every push**, so a "0 unresolved threads" reading taken before the latest push is stale — and it looks identical to all-clear. Merging on that means merging unreviewed code. That happened more than once today.

## Why not a post-push hook

The obvious fix is a reminder after pushing, and I don't think it's the right one:

- Git has no `post-push` hook. `pre-push` fires *before* the push, so the review it would remind you about cannot exist yet.
- A reminder only tells me something I already knew. Knowing wasn't the failure.
- **Pushing without checking is harmless.** The risky moment is the *merge*.

So the check lives at the merge, where acting on stale data actually costs something.

## What this adds

```sh
scripts/pr-review-status.py            # every open PR
scripts/pr-review-status.py 85 --wait  # block until current
scripts/merge-pr.sh 85                 # refuses unless the review is current
scripts/merge-pr.sh 85 --wait          # waits, then merges
scripts/merge-pr.sh 85 --force         # override, deliberately
```

`pr-review-status.py` compares the newest review timestamp against the newest commit and exits non-zero unless the PR is **both** current and clean.

Verified refusing on a genuinely stale PR:

```
WAIT #85 fix(ui): stop the blind scroll sweep when no — pushed since the last review

Not merging #85: its review is not current, or it has unresolved findings.
```

The rule is in `CLAUDE.md`, since a script only helps if it gets reached for — and reaching for it is the part that failed.

## Honest limit

This gates *my* merges through the script. It doesn't stop anyone running `gh pr merge` directly. Branch protection requiring an approving review would enforce it properly; this is the cheap version that fixes the observed failure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added pull request review-status checks for pending, unresolved, and indeterminate feedback.
  - Added optional polling until reviews are complete.
  - Added merge safeguards that block unresolved or uncertain reviews, with an explicit force option to bypass checks.
  - Merges now verify that the pull request’s latest revision is being merged.

- **Bug Fixes**
  - Review checks now fail safely when status information is unavailable or incomplete.

- **Chores**
  - Automatic incremental reviews are disabled after the initial review; subsequent reviews must be requested manually.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->