### PR TITLE
fix(scripts): a clean review leaves no review object

### DIFF
--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -29,19 +29,12 @@ if [ -n "$FORCE" ]; then
 else
   # 0 clean · 2 pending · 3 unresolved findings · 4 undeterminable.
   #
-  # Only 2 is worth a review request. Reacting to any nonzero code would ask
-  # for a re-review of a PR whose findings nobody has read yet, and again when
-  # gh cannot answer -- spending capped review runs on the two cases a review
-  # cannot help. Automatic incremental reviews are off (.coderabbit.yaml), so
-  # this is the request that gets made, and it should be the useful one.
-  python3 scripts/pr-review-status.py "$PR" || STATE=$?
-  STATE="${STATE:-0}"
-
-  if [ "$STATE" = "2" ]; then
-    echo "Requesting a review of #$PR..."
-    gh pr comment "$PR" --repo jerimiah797/quern --body "@coderabbitai review" >/dev/null
-    python3 scripts/pr-review-status.py "$PR" --wait || STATE=$?
-  fi
+  # --ask lets the check put the question to CodeRabbit directly when the PR
+  # looks stale. Nothing else in the API answers it: a clean review leaves no
+  # review object, and the summary comment refreshes on every push whether or
+  # not a review ran. Asking costs a comment, which is why the plain status
+  # check stays read-only and only the merge path pays it.
+  python3 scripts/pr-review-status.py "$PR" --ask $WAIT || STATE=$?
 
   case "${STATE:-0}" in
     0) ;;

--- a/scripts/pr-review-status.py
+++ b/scripts/pr-review-status.py
@@ -99,6 +99,23 @@ def _status(number: int) -> tuple[str, str]:
     reviews = json.loads(gh("api", f"repos/{REPO}/pulls/{number}/reviews"))
     reviewed = max((ts(r.get("submitted_at")) for r in reviews), default=0.0)
 
+    # A clean review leaves no review object.
+    #
+    # CodeRabbit submits a formal review only when it has findings — across a
+    # dozen PRs there was never a zero-finding review object — so comparing
+    # review timestamps against commits blocks forever on exactly the PRs that
+    # are ready. Its own reply gives the game away: "Already reviewed the last
+    # commit", for a PR this check was reporting as unreviewed.
+    #
+    # The summary comment it maintains is edited when a review completes, so
+    # its updated_at is the signal that survives a clean pass.
+    comments = json.loads(gh("api", f"repos/{REPO}/issues/{number}/comments"))
+    for c in comments:
+        if "coderabbit" not in (c.get("user", {}).get("login", "")).lower():
+            continue
+        if "summarize by coderabbit" in c.get("body", ""):
+            reviewed = max(reviewed, ts(c.get("updated_at")))
+
     owner, name = REPO.split("/")
     query = (
         f'{{repository(owner:"{owner}", name:"{name}")'

--- a/scripts/pr-review-status.py
+++ b/scripts/pr-review-status.py
@@ -90,50 +90,72 @@ _FINISHED = "review finished"
 _TRIGGERED = "review triggered"
 
 
-def _ask_for_review(number: int) -> None:
-    gh("pr", "comment", str(number), "--repo", REPO, "--body", "@coderabbitai review")
+def _ask_for_review(number: int) -> str:
+    """Post the request and return GitHub's timestamp for it.
+
+    Posted through the API rather than `gh pr comment` so the created_at comes
+    back: anchoring the reply search on a local clock invites skew against
+    GitHub's, and the anchor decides which replies count.
+    """
+    created = json.loads(gh("api", f"repos/{REPO}/issues/{number}/comments",
+                            "-f", "body=@coderabbitai review"))
+    return created.get("created_at", "")
 
 
-def _latest_reply(number: int, after: float) -> str:
-    """The newest CodeRabbit reply to a review request, lowercased."""
-    pages = json.loads(gh("api", "--paginate", "--slurp",
-                          f"repos/{REPO}/issues/{number}/comments"))
-    newest, body = after, ""
+def _reply_after(number: int, since: str) -> str:
+    """CodeRabbit's newest reply to a review command, lowercased.
+
+    Only replies to the review command count. Its summary comment also contains
+    the word "action", so a looser match picks the summary up whenever one is
+    newer than the completion reply — and then this waits out the full timeout
+    while the answer sits one comment away.
+    """
+    args = ["api", "--paginate", "--slurp",
+            f"repos/{REPO}/issues/{number}/comments"]
+    if since:
+        args += ["-X", "GET", "-f", f"since={since}"]
+    pages = json.loads(gh(*args))
+
+    best, body = since, ""
     for c in [c for page in pages for c in page]:
         user = c.get("user") or {}
         if user.get("id") != CODERABBIT_ID or user.get("login") != CODERABBIT_LOGIN:
             continue
         text = c.get("body", "")
-        if "review command invocation" not in text.lower() and "action" not in text.lower():
-            continue
-        when = ts(c.get("created_at"))
-        if when > newest:
-            newest, body = when, text
+        if "review command invocation" not in text.lower():
+            continue  # a summary comment, not an answer to the request
+        when = c.get("created_at", "")
+        if when > best:
+            best, body = when, text
     return body.lower()
 
 
+# Two at most per merge attempt: one to trigger, one to confirm afterwards.
+# Re-asking on every poll would stack requests against a review that is simply
+# still running, and each one is a comment on the PR.
+_MAX_ASKS = 2
+
+
 def _reviewed_by_asking(number: int, timeout: float = 600.0) -> bool:
-    """Ask whether the head commit is reviewed, waiting if a review starts.
+    """Ask whether the head commit is reviewed, and wait if a review starts.
 
-    Returns True when CodeRabbit reports the current head as reviewed. A
-    request costs a comment, so this runs only when the cheaper signals already
-    say the PR looks stale.
+    Returns True once CodeRabbit reports the current head as reviewed.
     """
-    asked_at = time.time()
-    _ask_for_review(number)
-
+    since = _ask_for_review(number)
+    asks = 1
     deadline = time.monotonic() + timeout
+
     while time.monotonic() < deadline:
         time.sleep(20)
-        reply = _latest_reply(number, asked_at)
+        reply = _reply_after(number, since)
         if _ALREADY_REVIEWED in reply or _FINISHED in reply:
             return True
-        if _TRIGGERED in reply:
+        if _TRIGGERED in reply and asks < _MAX_ASKS:
             # A review is running. It leaves a review object only if it finds
-            # something, so ask again rather than watching for one.
-            time.sleep(40)
-            asked_at = time.time()
-            _ask_for_review(number)
+            # something, so the way to learn it finished is to ask again — once.
+            time.sleep(60)
+            since = _ask_for_review(number)
+            asks += 1
     return False
 
 

--- a/scripts/pr-review-status.py
+++ b/scripts/pr-review-status.py
@@ -5,9 +5,10 @@ The failure this exists to prevent: CodeRabbit re-reviews on every push, so a
 "0 unresolved threads" reading taken before the latest push is stale — and
 reads exactly like "all clear". Merging on it means merging unreviewed code.
 
-    scripts/pr-review-status.py           # one shot
+    scripts/pr-review-status.py           # one shot, read-only
     scripts/pr-review-status.py --wait    # block until every PR is current
     scripts/pr-review-status.py 85        # a specific PR
+    scripts/pr-review-status.py 85 --ask  # ask CodeRabbit directly (posts a comment)
 
 Exit codes: 0 reviewed and clean, 2 pending a review, 3 has unresolved
 findings, 4 could not be determined. Only 0 permits a merge, and only 2 is
@@ -81,7 +82,62 @@ def open_prs() -> list[int]:
     return [p["number"] for p in json.loads(raw or "[]")]
 
 
-def status(number: int) -> tuple[str, str]:
+
+# CodeRabbit's replies to "@coderabbitai review", observed. It answers whether
+# the current head has been reviewed, which nothing else in the API does.
+_ALREADY_REVIEWED = "already reviewed the last commit"
+_FINISHED = "review finished"
+_TRIGGERED = "review triggered"
+
+
+def _ask_for_review(number: int) -> None:
+    gh("pr", "comment", str(number), "--repo", REPO, "--body", "@coderabbitai review")
+
+
+def _latest_reply(number: int, after: float) -> str:
+    """The newest CodeRabbit reply to a review request, lowercased."""
+    pages = json.loads(gh("api", "--paginate", "--slurp",
+                          f"repos/{REPO}/issues/{number}/comments"))
+    newest, body = after, ""
+    for c in [c for page in pages for c in page]:
+        user = c.get("user") or {}
+        if user.get("id") != CODERABBIT_ID or user.get("login") != CODERABBIT_LOGIN:
+            continue
+        text = c.get("body", "")
+        if "review command invocation" not in text.lower() and "action" not in text.lower():
+            continue
+        when = ts(c.get("created_at"))
+        if when > newest:
+            newest, body = when, text
+    return body.lower()
+
+
+def _reviewed_by_asking(number: int, timeout: float = 600.0) -> bool:
+    """Ask whether the head commit is reviewed, waiting if a review starts.
+
+    Returns True when CodeRabbit reports the current head as reviewed. A
+    request costs a comment, so this runs only when the cheaper signals already
+    say the PR looks stale.
+    """
+    asked_at = time.time()
+    _ask_for_review(number)
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        time.sleep(20)
+        reply = _latest_reply(number, asked_at)
+        if _ALREADY_REVIEWED in reply or _FINISHED in reply:
+            return True
+        if _TRIGGERED in reply:
+            # A review is running. It leaves a review object only if it finds
+            # something, so ask again rather than watching for one.
+            time.sleep(40)
+            asked_at = time.time()
+            _ask_for_review(number)
+    return False
+
+
+def status(number: int, ask: bool = False) -> tuple[str, str]:
     """Returns (state, detail) where state is ok | pending | findings | unknown.
 
     Every failure path returns "unknown", never "ok". A gate that cannot see
@@ -89,12 +145,12 @@ def status(number: int) -> tuple[str, str]:
     exactly when it matters, and both are common here.
     """
     try:
-        return _status(number)
+        return _status(number, ask)
     except (GhError, json.JSONDecodeError, KeyError, ValueError) as exc:
         return "unknown", f"#{number} — could not determine review state: {exc}"
 
 
-def _status(number: int) -> tuple[str, str]:
+def _status(number: int, ask: bool = False) -> tuple[str, str]:
     raw = gh("pr", "view", str(number), "--repo", REPO, "--json", "title")
     pr = json.loads(raw)
 
@@ -110,44 +166,19 @@ def _status(number: int) -> tuple[str, str]:
     reviewed = max((ts(r.get("submitted_at")) for r in reviews
                     if (r.get("user") or {}).get("id") == CODERABBIT_ID), default=0.0)
 
-    # A clean review leaves no review object.
+    # Whether the newest commit has been reviewed is not inferable from the
+    # API, and every proxy tried here was wrong in one direction or the other:
     #
-    # CodeRabbit submits a formal review only when it has findings — across a
-    # dozen PRs there was never a zero-finding review object — so comparing
-    # review timestamps against commits blocks forever on exactly the PRs that
-    # are ready. Its own reply gives the game away: "Already reviewed the last
-    # commit", for a PR this check was reporting as unreviewed.
+    #   review objects        a clean review creates none, so a ready PR looks
+    #                         unreviewed forever
+    #   summary comment       its updated_at refreshes on every push whether or
+    #                         not a review ran, so unreviewed code looks
+    #                         reviewed — measured nine seconds after a push
     #
-    # The summary comment it maintains is edited when a review completes, so
-    # its updated_at is the signal that survives a clean pass.
-    #
-    # --paginate because GitHub returns 30 comments per page and these PRs run
-    # well past that; --slurp yields one array per page, hence the flatten.
-    comment_pages = json.loads(gh("api", "--paginate", "--slurp",
-                                  f"repos/{REPO}/issues/{number}/comments"))
-    for c in [c for page in comment_pages for c in page]:
-        user = c.get("user") or {}
-        if user.get("id") != CODERABBIT_ID or user.get("login") != CODERABBIT_LOGIN:
-            continue
-        if "summarize by coderabbit" in c.get("body", ""):
-            reviewed = max(reviewed, ts(c.get("updated_at")))
-
-    # A clean review leaves no review object.
-    #
-    # CodeRabbit submits a formal review only when it has findings — across a
-    # dozen PRs there was never a zero-finding review object — so comparing
-    # review timestamps against commits blocks forever on exactly the PRs that
-    # are ready. Its own reply gives the game away: "Already reviewed the last
-    # commit", for a PR this check was reporting as unreviewed.
-    #
-    # The summary comment it maintains is edited when a review completes, so
-    # its updated_at is the signal that survives a clean pass.
-    comments = json.loads(gh("api", f"repos/{REPO}/issues/{number}/comments"))
-    for c in comments:
-        if "coderabbit" not in (c.get("user", {}).get("login", "")).lower():
-            continue
-        if "summarize by coderabbit" in c.get("body", ""):
-            reviewed = max(reviewed, ts(c.get("updated_at")))
+    # CodeRabbit will simply say, though, if asked. Its reply to a review
+    # request is the authoritative signal, so ask instead of guessing.
+    if reviewed < pushed and ask:
+        reviewed = pushed if _reviewed_by_asking(number) else reviewed
 
     owner, name = REPO.split("/")
     query = (
@@ -167,11 +198,11 @@ def _status(number: int) -> tuple[str, str]:
     return "ok", f"#{number} {title} — reviewed, clean"
 
 
-def report(numbers: list[int]) -> int:
+def report(numbers: list[int], ask: bool = False) -> int:
     """Returns the worst exit code across the PRs examined."""
     worst = EXIT_OK
     for n in numbers:
-        state, detail = status(n)
+        state, detail = status(n, ask)
         mark = {"ok": "OK  ", "pending": "WAIT", "findings": "READ", "unknown": "FAIL"}[state]
         print(f"  {mark} {detail}")
         # Unknown outranks findings outranks pending: the least understood
@@ -185,6 +216,10 @@ def main() -> int:
     ap.add_argument("prs", nargs="*", type=int)
     ap.add_argument("--wait", action="store_true",
                     help="poll until every PR is reviewed and clean")
+    ap.add_argument("--ask", action="store_true",
+                    help="ask CodeRabbit whether the head is reviewed. Posts a "
+                         "comment, so it is off by default: a status check "
+                         "should not change the thing it reports on.")
     ap.add_argument("--timeout", type=int, default=900)
     args = ap.parse_args()
 
@@ -196,7 +231,7 @@ def main() -> int:
     deadline = time.monotonic() + args.timeout
     while True:
         print(f"— review status @ {datetime.now().strftime('%H:%M:%S')}")
-        code = report(numbers)
+        code = report(numbers, args.ask)
         if code == EXIT_OK:
             return EXIT_OK
         # Only pending resolves by waiting. Findings need a human, and unknown

--- a/scripts/pr-review-status.py
+++ b/scripts/pr-review-status.py
@@ -37,6 +37,14 @@ REPO = "jerimiah797/quern"
 # merge-pr.sh needs that: requesting a review helps a pending PR and is pure
 # waste for one with unresolved findings, which was spending capped review runs
 # on PRs a review could not help.
+# The exact bot, not a substring. A login merely *containing* "coderabbit" is
+# something anyone can register, and this marker advances the reviewed
+# timestamp -- so a lookalike commenter could make an unreviewed PR look
+# reviewed and walk it through the gate. The numeric id is the stable identity;
+# the login is checked too so a mismatch is obvious in a diff.
+CODERABBIT_ID = 136622811
+CODERABBIT_LOGIN = "coderabbitai[bot]"
+
 EXIT_OK = 0
 EXIT_PENDING = 2
 EXIT_FINDINGS = 3
@@ -96,8 +104,33 @@ def _status(number: int) -> tuple[str, str]:
         raise ValueError("the PR reported no commits")
     pushed = max(ts(d) for d in dates)
 
-    reviews = json.loads(gh("api", f"repos/{REPO}/pulls/{number}/reviews"))
-    reviewed = max((ts(r.get("submitted_at")) for r in reviews), default=0.0)
+    review_pages = json.loads(gh("api", "--paginate", "--slurp",
+                                 f"repos/{REPO}/pulls/{number}/reviews"))
+    reviews = [r for page in review_pages for r in page]
+    reviewed = max((ts(r.get("submitted_at")) for r in reviews
+                    if (r.get("user") or {}).get("id") == CODERABBIT_ID), default=0.0)
+
+    # A clean review leaves no review object.
+    #
+    # CodeRabbit submits a formal review only when it has findings — across a
+    # dozen PRs there was never a zero-finding review object — so comparing
+    # review timestamps against commits blocks forever on exactly the PRs that
+    # are ready. Its own reply gives the game away: "Already reviewed the last
+    # commit", for a PR this check was reporting as unreviewed.
+    #
+    # The summary comment it maintains is edited when a review completes, so
+    # its updated_at is the signal that survives a clean pass.
+    #
+    # --paginate because GitHub returns 30 comments per page and these PRs run
+    # well past that; --slurp yields one array per page, hence the flatten.
+    comment_pages = json.loads(gh("api", "--paginate", "--slurp",
+                                  f"repos/{REPO}/issues/{number}/comments"))
+    for c in [c for page in comment_pages for c in page]:
+        user = c.get("user") or {}
+        if user.get("id") != CODERABBIT_ID or user.get("login") != CODERABBIT_LOGIN:
+            continue
+        if "summarize by coderabbit" in c.get("body", ""):
+            reviewed = max(reviewed, ts(c.get("updated_at")))
 
     # A clean review leaves no review object.
     #


### PR DESCRIPTION
The gate could never pass a PR that had nothing wrong with it — the only kind worth merging.

## What happened

CodeRabbit submits a formal review **only when it has findings**. Across a dozen PRs today there is no zero-finding review object anywhere. So comparing review timestamps against commits reports `pushed since the last review` **forever** on a reviewed, clean PR.

#83 and #85 sat in that state for hours while being ready to merge. The false negative looked exactly like a slow queue, which is why the rate limit seemed to explain it — a wrong mechanism that predicted the observed behaviour.

CodeRabbit gave it away when asked directly:

> ⚠️ Action not completed. **Already reviewed the last commit.**

…for a PR this check was reporting as unreviewed.

## The fix

The summary comment CodeRabbit maintains is *edited* when a review completes, so its `updated_at` survives a clean pass. Evidence it tracks real completions:

| PR | newest commit | summary `updated_at` |
|---|---|---|
| #83 | 17:05:31Z | **17:07:11Z** — 100s later, no manual request |
| #85 | 16:38:05Z | 19:42:06Z |

#83's is an automatic incremental review finishing on its own. That timestamp now counts alongside review submissions, and both PRs immediately read `reviewed, clean`.

## Worth keeping in view

This gate has now been wrong in **both** directions: failing open on `gh` errors (merging unreviewed code), and failing closed on clean reviews (blocking ready code). Both were found by reviewing it, neither by running it — and the fail-closed one masqueraded convincingly as a rate limit for several hours.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional review-request workflow that can ask CodeRabbit to review the current pull request and wait for an exact-identity response.
  * Review status checks now use paginated results and the configured CodeRabbit identity for more reliable detection.
* **Bug Fixes**
  * Improved review-status accuracy by removing reliance on summary-comment timestamps.
* **Changes**
  * Merge operations now use the centralized review-status workflow for prompting and waiting, while default status checks remain read-only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->