### PR TITLE
fix(scripts): refuse while GitHub's view of the head is stale

### DIFF
--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -38,7 +38,9 @@ else
   # review object, and the summary comment refreshes on every push whether or
   # not a review ran. Asking costs a comment, which is why the plain status
   # check stays read-only and only the merge path pays it.
-  python3 scripts/pr-review-status.py "$PR" --ask $WAIT || STATE=$?
+  HEAD_FILE=$(mktemp)
+  trap 'rm -f "$HEAD_FILE"' EXIT
+  python3 scripts/pr-review-status.py "$PR" --ask --emit-head "$HEAD_FILE" $WAIT || STATE=$?
 
   case "${STATE:-0}" in
     0) ;;
@@ -48,10 +50,19 @@ else
   esac
 fi
 
-# Bind the merge to the commit that was reviewed. Between the check above and
-# the merge below, a push can land -- and merging then ships a commit nothing
-# reviewed, which is the exact hole this script exists to close. GitHub refuses
-# the merge if the head has moved.
-HEAD_SHA=$(gh pr view "$PR" --repo jerimiah797/quern --json headRefOid -q .headRefOid)
+# Bind the merge to the commit the check actually verified, not to whatever the
+# head is now. Re-reading it here would let a push land in between and pin the
+# merge to the new, unreviewed commit -- protecting the wrong thing while
+# looking careful. --force has no verified SHA, so it falls back to the current
+# head, which is the point of --force.
+HEAD_SHA=""
+[ -n "${HEAD_FILE:-}" ] && [ -s "$HEAD_FILE" ] && HEAD_SHA=$(cat "$HEAD_FILE")
+if [ -z "$HEAD_SHA" ]; then
+  if [ -z "$FORCE" ]; then
+    echo "Not merging #$PR: the review check did not report a verified head."
+    exit 1
+  fi
+  HEAD_SHA=$(gh pr view "$PR" --repo jerimiah797/quern --json headRefOid -q .headRefOid)
+fi
 gh pr merge "$PR" --repo jerimiah797/quern --merge --delete-branch \
   --match-head-commit "$HEAD_SHA"

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -16,6 +16,10 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 PR="${1:?usage: merge-pr.sh <number> [--wait] [--force]}"; shift
+
+# Make sure the local view of the remote is current before anything compares
+# against it; the staleness check below is only as good as this.
+git fetch origin --quiet
 WAIT=""; FORCE=""
 for a in "$@"; do
   case "$a" in

--- a/scripts/pr-review-status.py
+++ b/scripts/pr-review-status.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import pathlib
 import subprocess
 import sys
 import time
@@ -52,6 +53,11 @@ EXIT_FINDINGS = 3
 EXIT_UNKNOWN = 4
 _EXIT = {"ok": EXIT_OK, "pending": EXIT_PENDING,
          "findings": EXIT_FINDINGS, "unknown": EXIT_UNKNOWN}
+
+# The head each PR was verified against, so a caller can bind its merge to the
+# same commit this check looked at. Re-reading the head afterwards would let a
+# push land in between and protect the new, unreviewed one instead.
+_VERIFIED_HEAD: dict[int, str] = {}
 
 
 class GhError(RuntimeError):
@@ -184,15 +190,27 @@ def _status(number: int, ask: bool = False) -> tuple[str, str]:
     # ref makes the staleness visible instead of invisible.
     head = pr.get("headRefOid") or ""
     branch = pr.get("headRefName") or ""
-    if branch and head:
-        local = subprocess.run(["git", "rev-parse", f"origin/{branch}"],
-                               capture_output=True, text=True)
-        local_sha = local.stdout.strip()
-        if local.returncode == 0 and local_sha and local_sha != head:
-            raise ValueError(
-                f"the API still reports head {head[:8]} while origin/{branch} is "
-                f"{local_sha[:8]} — it has not caught up with the push"
-            )
+    if not head or not branch:
+        raise ValueError("the PR did not report a head ref")
+
+    local = subprocess.run(["git", "rev-parse", f"origin/{branch}"],
+                           capture_output=True, text=True)
+    local_sha = local.stdout.strip()
+    if local.returncode != 0 or not local_sha:
+        # Unresolvable rather than verified. Skipping the comparison here would
+        # approve on the strength of a check that never ran — which is how the
+        # rest of this file kept failing open. A fork PR lands here, correctly:
+        # origin/<branch> does not exist locally, so freshness is unprovable.
+        raise ValueError(
+            f"could not resolve origin/{branch}; head freshness is unverifiable "
+            f"(a fork PR needs its head repository fetched first)"
+        )
+    if local_sha != head:
+        raise ValueError(
+            f"the API still reports head {head[:8]} while origin/{branch} is "
+            f"{local_sha[:8]} — it has not caught up with the push"
+        )
+    _VERIFIED_HEAD[number] = head
 
     commits = json.loads(gh("pr", "view", str(number), "--repo", REPO, "--json", "commits"))
     dates = [c["committedDate"] for c in commits["commits"]]
@@ -256,6 +274,9 @@ def main() -> int:
     ap.add_argument("prs", nargs="*", type=int)
     ap.add_argument("--wait", action="store_true",
                     help="poll until every PR is reviewed and clean")
+    ap.add_argument("--emit-head", metavar="FILE",
+                    help="write the verified head SHA here, for a caller that "
+                         "needs to bind a merge to the commit this check saw")
     ap.add_argument("--ask", action="store_true",
                     help="ask CodeRabbit whether the head is reviewed. Posts a "
                          "comment, so it is off by default: a status check "
@@ -273,6 +294,8 @@ def main() -> int:
         print(f"— review status @ {datetime.now().strftime('%H:%M:%S')}")
         code = report(numbers, args.ask)
         if code == EXIT_OK:
+            if args.emit_head and len(numbers) == 1:
+                pathlib.Path(args.emit_head).write_text(_VERIFIED_HEAD.get(numbers[0], ""))
             return EXIT_OK
         # Only pending resolves by waiting. Findings need a human, and unknown
         # means the check itself could not see the data.

--- a/scripts/pr-review-status.py
+++ b/scripts/pr-review-status.py
@@ -173,8 +173,26 @@ def status(number: int, ask: bool = False) -> tuple[str, str]:
 
 
 def _status(number: int, ask: bool = False) -> tuple[str, str]:
-    raw = gh("pr", "view", str(number), "--repo", REPO, "--json", "title")
+    raw = gh("pr", "view", str(number), "--repo", REPO,
+             "--json", "title,headRefName,headRefOid")
     pr = json.loads(raw)
+
+    # GitHub does not register a push instantly, and this check tends to run
+    # right after one. Reading commits inside that window returns the *previous*
+    # head, whose review looks current — which merged an unreviewed commit six
+    # seconds after it was pushed. Comparing the API's head against the local
+    # ref makes the staleness visible instead of invisible.
+    head = pr.get("headRefOid") or ""
+    branch = pr.get("headRefName") or ""
+    if branch and head:
+        local = subprocess.run(["git", "rev-parse", f"origin/{branch}"],
+                               capture_output=True, text=True)
+        local_sha = local.stdout.strip()
+        if local.returncode == 0 and local_sha and local_sha != head:
+            raise ValueError(
+                f"the API still reports head {head[:8]} while origin/{branch} is "
+                f"{local_sha[:8]} — it has not caught up with the push"
+            )
 
     commits = json.loads(gh("pr", "view", str(number), "--repo", REPO, "--json", "commits"))
     dates = [c["committedDate"] for c in commits["commits"]]

--- a/scripts/pr-review-status.py
+++ b/scripts/pr-review-status.py
@@ -174,7 +174,7 @@ def status(number: int, ask: bool = False) -> tuple[str, str]:
     """
     try:
         return _status(number, ask)
-    except (GhError, json.JSONDecodeError, KeyError, ValueError) as exc:
+    except (GhError, OSError, json.JSONDecodeError, KeyError, ValueError) as exc:
         return "unknown", f"#{number} — could not determine review state: {exc}"
 
 
@@ -193,8 +193,11 @@ def _status(number: int, ask: bool = False) -> tuple[str, str]:
     if not head or not branch:
         raise ValueError("the PR did not report a head ref")
 
-    local = subprocess.run(["git", "rev-parse", f"origin/{branch}"],
-                           capture_output=True, text=True)
+    try:
+        local = subprocess.run(["git", "rev-parse", f"origin/{branch}"],
+                               capture_output=True, text=True)
+    except OSError as exc:  # git missing, not executable, cwd gone
+        raise ValueError(f"could not run git: {exc}") from exc
     local_sha = local.stdout.strip()
     if local.returncode != 0 or not local_sha:
         # Unresolvable rather than verified. Skipping the comparison here would


### PR DESCRIPTION
**The gate merged an unreviewed commit.** Reporting that plainly because it's the third time this tool has failed open.

## What happened

```
22:11:39  commit pushed
22:11:40  gate ran → "reviewed, clean"
22:11:45  merged
22:09:30  ← the review it trusted, two minutes older than the commit
```

The check ran **one second** after the push. GitHub hadn't registered the new commit yet, so `gh pr view --json commits` returned the *previous* head — whose review genuinely was current. No review was ever requested; the comment count never moved.

The staleness was invisible because every timestamp involved was internally consistent. Only the head SHA disagreed, and nothing was looking at it.

## The fix

Compare the API's `headRefOid` against `origin/<branch>`. A mismatch raises, which reports `unknown` and **refuses** — `unknown` has never been a pass. `merge-pr.sh` now runs `git fetch` first so the comparison means something.

Simulated with a stale head:

```
state=unknown
detail=the API still reports head 00000000 while origin/main is ac9114d4 — it has not caught up with the push
exit would be 4 (0 would merge)
```

## The pattern worth noting

Three fail-opens in one small tool:

1. `gh` errors treated as data → empty result read as "no commits" → any prior review looked newer
2. the summary comment mistaken for a review signal → refreshes on every push
3. an API read racing a push → previous head's review accepted for the new commit

Every one produced a confident "reviewed, clean". None produced an error. For something whose entire purpose is refusing, the consistent failure direction is worth keeping in mind — it fails toward yes.

**No damage from the premature merge**: `main` is green at 1486 tests and lint-clean, and the merged commit was the review-handshake work, unreviewed but not wrong.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Review-status checks now confirm that the pull request’s latest commit is available locally before reporting success.
  - Merge operations now use the verified latest pull request commit, helping prevent merges based on stale information.
  - Added safeguards when the latest commit cannot be verified.
  - Forced merges can proceed using the current pull request commit when verification is unavailable.
  - Review-status checks now report an unknown status instead of exposing an execution error when Git operations fail.
  - Temporary verification data is cleaned up automatically after operations complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->