### PR TITLE
fix(device): recover the accessibility bridge wedged by XCUITest (#66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to Quern are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **A simulator no longer stays unusable after an XCUITest or WDA run** (#66) — any XCTest-based run leaves that simulator's `CoreSimulatorBridge` holding a stale mach-port cache, after which every foregrounded app reports a single bare `Application` element with a `0x0` frame. Not just the app under test: Safari breaks too, and only SpringBoard keeps reading normally. The empty tree is indistinguishable from every landmark on every screen drifting at once, so the usual response was to go and edit knowledge bases that were never wrong. Quern now recognises the signature and restarts that simulator's bridge, which is launchd-on-demand, so the retried query comes back against a fresh cache. Around a second, app state preserved, and scoped to the one simulator — there is one bridge per booted simulator, so the others are undisturbed. Recovery is attempted once per read; if the tree still looks wedged afterwards the cause is something else, and retrying would only be a slower way to return the same answer.
+
+### Notes
+- The detection is deliberately narrow. An app mid-launch legitimately reports a single `Application` element, so the zero frame and absent label are what separate "nothing has rendered yet" from "the bridge cannot see anything", and a false positive costs a needless restart.
+- There is no reload path short of killing the process: the port cache belongs to the AX runtime loaded into the bridge, which holds no handle to invalidate it, and `SIGHUP` is not handled. Kill-and-respawn is the only lever available, and at ~1s it does not need to be a better one.
+
+
 ## [0.14.1] - 2026-09-02
 
 Twenty-one commits since 0.14.1-beta.2. The theme is correctness under

--- a/server/device/ax_recovery.py
+++ b/server/device/ax_recovery.py
@@ -1,0 +1,113 @@
+"""Recover a simulator's accessibility bridge after XCUITest poisons it (#66).
+
+Any XCUITest or WDA run against a simulator leaves `CoreSimulatorBridge` with a
+stale mach-port cache, after which every foregrounded app reports a single bare
+`Application` element. The app under test is not special — Safari breaks too,
+and only SpringBoard keeps reading normally. `os_log` names it directly:
+
+    CoreSimulatorBridge [com.apple.Accessibility:AXRuntimeCommon]
+        AX Lookup problem - errorCode:1102 error:Unknown service name port
+
+The empty tree looks exactly like every landmark on every screen drifting at
+once, which is a long way from the truth and sends people editing knowledge
+bases that are fine.
+
+There is no reload path: the port cache belongs to the AX runtime loaded into
+the process, the bridge holds no handle to invalidate it, and `SIGHUP` is not
+handled. Kill and respawn is the only lever — and it is enough, because the
+bridge is launchd-on-demand, so the next query brings it back against a fresh
+cache. Measured at ~1s, including with six simulators booted at load average
+672, so recovery does not degrade under a loaded pool.
+
+One bridge exists per booted simulator, so this is scoped to the simulator that
+needs it and leaves the others undisturbed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+logger = logging.getLogger("quern-debug-server.device")
+
+
+def looks_poisoned(elements: list[dict]) -> bool:
+    """Whether a tree carries the signature of a wedged accessibility bridge.
+
+    The signature is narrow on purpose. An app mid-launch legitimately reports
+    a single `Application` element, so the zero frame and absent label are what
+    separate "nothing has rendered yet" from "the bridge cannot see anything at
+    all" — and a false positive here costs a needless kill.
+    """
+    if len(elements) != 1:
+        return False
+    el = elements[0]
+    if el.get("type") != "Application":
+        return False
+    frame = el.get("frame") or {}
+    if (frame.get("width") or 0) or (frame.get("height") or 0):
+        return False
+    return not (el.get("AXLabel") or el.get("label") or "")
+
+
+async def _run(*args: str, timeout: float = 5.0) -> tuple[int, str]:
+    proc = await asyncio.create_subprocess_exec(
+        *args, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
+    )
+    try:
+        out, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except TimeoutError:
+        proc.kill()
+        return 1, ""
+    return proc.returncode or 0, out.decode(errors="replace")
+
+
+async def bridge_pids_for(udid: str) -> list[int]:
+    """PIDs of the CoreSimulatorBridge serving this simulator.
+
+    `pgrep -x` rather than a `ps | grep`: a loose match also matches the shell
+    running the grep, and killing the first hit kills the caller.
+    """
+    rc, out = await _run("pgrep", "-x", "CoreSimulatorBridge")
+    if rc != 0:
+        return []
+
+    pids: list[int] = []
+    for line in out.split():
+        try:
+            pid = int(line)
+        except ValueError:
+            continue
+        # One bridge per simulator; lsof maps it to the UDID whose data
+        # directory it holds open. Killing every match would disturb every
+        # other booted simulator for no reason.
+        _, files = await _run("lsof", "-p", str(pid), timeout=10.0)
+        if udid in files:
+            pids.append(pid)
+    return pids
+
+
+async def reset_bridge(udid: str) -> bool:
+    """Kill this simulator's accessibility bridge. Returns whether one was killed.
+
+    Deliberately does not wait or poll afterwards. The bridge is respawned on
+    demand by the next query, and hammering it with retries is worse than
+    useless: sim-bridge serialises commands and does not cancel abandoned ones,
+    so a retry storm turns into a multi-minute drain that looks like a hang.
+    """
+    pids = await bridge_pids_for(udid)
+    if not pids:
+        logger.warning(
+            "accessibility bridge looks wedged for %s but no CoreSimulatorBridge "
+            "process could be matched to it — leaving it alone", udid[:8],
+        )
+        return False
+
+    for pid in pids:
+        await _run("kill", "-9", str(pid))
+    logger.info(
+        "reset the accessibility bridge for %s (killed %s) — an XCUITest or WDA "
+        "run leaves it with a stale port cache; the next query respawns it",
+        udid[:8], ", ".join(str(p) for p in pids),
+    )
+    return True

--- a/server/device/ax_recovery.py
+++ b/server/device/ax_recovery.py
@@ -27,8 +27,16 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 
 logger = logging.getLogger("quern-debug-server.device")
+
+# simctl UDIDs are canonical uppercase UUIDs. Anything else is refused rather
+# than matched loosely: an empty string is a substring of every lsof line, so
+# `udid in files` would match every bridge and SIGKILL the lot. A short or
+# partial identifier has the same shape of problem against a neighbouring
+# simulator.
+_SIM_UDID = re.compile(r"^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$")
 
 
 def looks_poisoned(elements: list[dict]) -> bool:
@@ -68,6 +76,14 @@ async def bridge_pids_for(udid: str) -> list[int]:
     `pgrep -x` rather than a `ps | grep`: a loose match also matches the shell
     running the grep, and killing the first hit kills the caller.
     """
+    if not _SIM_UDID.match(udid or ""):
+        logger.warning(
+            "refusing to look for an accessibility bridge for %r: not a canonical "
+            "simulator UDID, and a loose match here kills unrelated simulators",
+            udid,
+        )
+        return []
+
     rc, out = await _run("pgrep", "-x", "CoreSimulatorBridge")
     if rc != 0:
         return []
@@ -82,7 +98,10 @@ async def bridge_pids_for(udid: str) -> list[int]:
         # directory it holds open. Killing every match would disturb every
         # other booted simulator for no reason.
         _, files = await _run("lsof", "-p", str(pid), timeout=10.0)
-        if udid in files:
+        # As a path component, not a bare substring: the UDID appears in the
+        # bridge's open data directory, and anchoring on the separators keeps a
+        # partial overlap with another simulator's UDID from matching.
+        if f"/{udid}/" in files or files.rstrip().endswith(f"/{udid}"):
             pids.append(pid)
     return pids
 

--- a/server/device/sim_bridge.py
+++ b/server/device/sim_bridge.py
@@ -21,7 +21,7 @@ from contextlib import asynccontextmanager
 from contextvars import ContextVar
 from pathlib import Path
 
-from server.device import probing
+from server.device import ax_recovery, probing
 from server.models import SimBridgeSaturatedError
 
 logger = logging.getLogger("quern-debug-server.sim-bridge")
@@ -408,7 +408,7 @@ class SimBridgeBackend:
 
     async def describe_all(
         self, udid: str, *, snapshot_depth: int | None = None,
-        source_timeout: float | None = None,
+        source_timeout: float | None = None, _recovered: bool = False,
     ) -> list[dict]:
         """Return flat list of UI elements.
 
@@ -443,6 +443,23 @@ class SimBridgeBackend:
                 "[PERF] sim-bridge.describe_all COMPLETE: total=%.1fms elements=%d",
                 (time.perf_counter() - start) * 1000, len(flat),
             )
+
+            # An XCUITest or WDA run leaves this simulator's accessibility
+            # bridge with a stale port cache, after which every app reports a
+            # single bare Application element (#66). Recovery is a kill away and
+            # the respawn is automatic, so heal it rather than handing back an
+            # empty tree that reads as mass landmark drift.
+            #
+            # Once only. If the tree still looks poisoned after a reset, the
+            # cause is something else and retrying would just be a slower way to
+            # return the same answer.
+            if not _recovered and ax_recovery.looks_poisoned(flat):
+                if await ax_recovery.reset_bridge(udid):
+                    return await self.describe_all(
+                        udid, snapshot_depth=snapshot_depth,
+                        source_timeout=source_timeout, _recovered=True,
+                    )
+
             return flat
 
     async def describe_all_nested(

--- a/tests/test_ax_recovery.py
+++ b/tests/test_ax_recovery.py
@@ -1,0 +1,124 @@
+"""Detection and recovery for the XCUITest-poisoned accessibility bridge (#66).
+
+The wedge is real and deterministic: one XCUITest run against a simulator, and
+every foregrounded app reports a single bare Application element until the
+bridge is restarted. What makes it worth automating is that the empty tree is
+indistinguishable from every landmark on every screen drifting at once, so
+people go and edit knowledge bases that were never wrong.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from server.device import ax_recovery
+
+
+def _app(width=0.0, height=0.0, label=None, type_="Application"):
+    return {"type": type_, "AXLabel": label,
+            "frame": {"x": 0.0, "y": 0.0, "width": width, "height": height}}
+
+
+def test_the_poisoned_signature_is_recognised():
+    assert ax_recovery.looks_poisoned([_app()])
+
+
+def test_a_launching_app_is_not_mistaken_for_a_wedge():
+    """The false positive that would cost a needless kill.
+
+    An app mid-launch legitimately reports one Application element. The zero
+    frame is what separates "nothing has rendered yet" from "the bridge cannot
+    see anything", so a sized root must not trigger recovery.
+    """
+    assert not ax_recovery.looks_poisoned([_app(width=393.0, height=852.0)])
+
+
+def test_a_labelled_root_is_not_a_wedge():
+    assert not ax_recovery.looks_poisoned([_app(label="Metatext")])
+
+
+def test_a_populated_tree_is_never_a_wedge():
+    assert not ax_recovery.looks_poisoned([_app(), _app(type_="Button")])
+
+
+def test_an_empty_tree_is_not_the_wedge_signature():
+    """Nothing at all is a different failure — the signature is exactly one
+    element, and treating a zero-length read as the wedge would kill the bridge
+    every time a query came back empty for any other reason."""
+    assert not ax_recovery.looks_poisoned([])
+
+
+async def test_only_the_bridge_serving_this_simulator_is_killed():
+    """One bridge exists per booted simulator. Killing every match would
+    disturb every other simulator in the pool to fix one of them."""
+    killed: list[str] = []
+
+    async def fake_run(*args, timeout=5.0):
+        if args[0] == "pgrep":
+            return 0, "111\n222\n"
+        if args[0] == "lsof":
+            pid = args[2]
+            return 0, ("/path/AAAA-1111/data" if pid == "111" else "/path/BBBB-2222/data")
+        if args[0] == "kill":
+            killed.append(args[2])
+            return 0, ""
+        return 1, ""
+
+    with patch.object(ax_recovery, "_run", side_effect=fake_run):
+        assert await ax_recovery.reset_bridge("AAAA-1111") is True
+    assert killed == ["111"], f"killed {killed}, expected only the matching bridge"
+
+
+async def test_nothing_is_killed_when_no_bridge_matches():
+    """Better to report an unhealthy tree than to kill an unrelated process."""
+    async def fake_run(*args, timeout=5.0):
+        if args[0] == "pgrep":
+            return 0, "111\n"
+        if args[0] == "lsof":
+            return 0, "/path/OTHER-SIM/data"
+        raise AssertionError(f"should not have run {args[0]}")
+
+    with patch.object(ax_recovery, "_run", side_effect=fake_run):
+        assert await ax_recovery.reset_bridge("AAAA-1111") is False
+
+
+async def test_recovery_is_attempted_once_and_not_looped():
+    """A retry storm here is actively harmful: sim-bridge serialises commands
+    and does not cancel abandoned ones, so repeated recovery attempts turn into
+    a multi-minute drain that presents as a hang (#68)."""
+    from server.device.sim_bridge import SimBridgeBackend, SimBridgeManager
+
+    backend = SimBridgeBackend(SimBridgeManager())
+    calls = {"fetch": 0}
+
+    async def always_poisoned(_udid):
+        calls["fetch"] += 1
+        return [_app()]
+
+    with patch.object(backend, "_fetch_nested", side_effect=always_poisoned), \
+         patch.object(ax_recovery, "reset_bridge", AsyncMock(return_value=True)) as reset:
+        result = await backend.describe_all("AAAA-1111")
+
+    assert reset.await_count == 1, "recovery must not loop"
+    assert calls["fetch"] == 2, "one original read plus exactly one retry"
+    assert ax_recovery.looks_poisoned(result), "the unhealthy tree is still returned"
+
+
+@pytest.mark.parametrize("healthy_second_read", [True])
+async def test_a_healthy_tree_after_recovery_is_returned(healthy_second_read):
+    from server.device.sim_bridge import SimBridgeBackend, SimBridgeManager
+
+    backend = SimBridgeBackend(SimBridgeManager())
+    reads = iter([[_app()], [_app(width=393.0, height=852.0, label="Probe")]])
+
+    async def two_reads(_udid):
+        return next(reads)
+
+    with patch.object(backend, "_fetch_nested", side_effect=two_reads), \
+         patch.object(ax_recovery, "reset_bridge", AsyncMock(return_value=True)):
+        result = await backend.describe_all("AAAA-1111")
+
+    assert not ax_recovery.looks_poisoned(result)
+    assert result[0]["AXLabel"] == "Probe"

--- a/tests/test_ax_recovery.py
+++ b/tests/test_ax_recovery.py
@@ -15,6 +15,11 @@ import pytest
 
 from server.device import ax_recovery
 
+# Canonical simctl UDIDs: the code refuses anything else, because a loose match
+# against a short placeholder is exactly how it would kill the wrong bridge.
+SIM_A = "F5AF3736-C05F-493F-AA52-CA883B13B18C"
+SIM_B = "C5D36699-A47F-4A03-8D1C-01503E10DD2F"
+
 
 def _app(width=0.0, height=0.0, label=None, type_="Application"):
     return {"type": type_, "AXLabel": label,
@@ -60,14 +65,14 @@ async def test_only_the_bridge_serving_this_simulator_is_killed():
             return 0, "111\n222\n"
         if args[0] == "lsof":
             pid = args[2]
-            return 0, ("/path/AAAA-1111/data" if pid == "111" else "/path/BBBB-2222/data")
+            return 0, (f"/path/{SIM_A}/data" if pid == "111" else f"/path/{SIM_B}/data")
         if args[0] == "kill":
             killed.append(args[2])
             return 0, ""
         return 1, ""
 
     with patch.object(ax_recovery, "_run", side_effect=fake_run):
-        assert await ax_recovery.reset_bridge("AAAA-1111") is True
+        assert await ax_recovery.reset_bridge(SIM_A) is True
     assert killed == ["111"], f"killed {killed}, expected only the matching bridge"
 
 
@@ -77,11 +82,11 @@ async def test_nothing_is_killed_when_no_bridge_matches():
         if args[0] == "pgrep":
             return 0, "111\n"
         if args[0] == "lsof":
-            return 0, "/path/OTHER-SIM/data"
+            return 0, f"/path/{SIM_B}/data"
         raise AssertionError(f"should not have run {args[0]}")
 
     with patch.object(ax_recovery, "_run", side_effect=fake_run):
-        assert await ax_recovery.reset_bridge("AAAA-1111") is False
+        assert await ax_recovery.reset_bridge(SIM_A) is False
 
 
 async def test_recovery_is_attempted_once_and_not_looped():
@@ -99,7 +104,7 @@ async def test_recovery_is_attempted_once_and_not_looped():
 
     with patch.object(backend, "_fetch_nested", side_effect=always_poisoned), \
          patch.object(ax_recovery, "reset_bridge", AsyncMock(return_value=True)) as reset:
-        result = await backend.describe_all("AAAA-1111")
+        result = await backend.describe_all(SIM_A)
 
     assert reset.await_count == 1, "recovery must not loop"
     assert calls["fetch"] == 2, "one original read plus exactly one retry"
@@ -118,7 +123,49 @@ async def test_a_healthy_tree_after_recovery_is_returned(healthy_second_read):
 
     with patch.object(backend, "_fetch_nested", side_effect=two_reads), \
          patch.object(ax_recovery, "reset_bridge", AsyncMock(return_value=True)):
-        result = await backend.describe_all("AAAA-1111")
+        result = await backend.describe_all(SIM_A)
 
     assert not ax_recovery.looks_poisoned(result)
     assert result[0]["AXLabel"] == "Probe"
+
+
+async def test_an_empty_udid_kills_nothing():
+    """The dangerous input. `"" in files` is true for every lsof line, so a
+    loose match would SIGKILL every simulator's bridge to recover none."""
+    async def fake_run(*args, timeout=5.0):
+        raise AssertionError(f"should not have run {args[0]} for an empty udid")
+
+    with patch.object(ax_recovery, "_run", side_effect=fake_run):
+        assert await ax_recovery.bridge_pids_for("") == []
+        assert await ax_recovery.reset_bridge("") is False
+
+
+@pytest.mark.parametrize("udid", [
+    "not-a-uuid",
+    "F5AF3736",                                  # a prefix, not the whole thing
+    "f5af3736-c05f-493f-aa52-ca883b13b18c",      # simctl emits uppercase
+    "../../etc",
+])
+async def test_non_canonical_identifiers_are_refused(udid):
+    async def fake_run(*args, timeout=5.0):
+        raise AssertionError(f"should not have run {args[0]} for {udid!r}")
+
+    with patch.object(ax_recovery, "_run", side_effect=fake_run):
+        assert await ax_recovery.bridge_pids_for(udid) == []
+
+
+async def test_a_partial_udid_overlap_does_not_match_another_simulator():
+    """Matched as a path component, so one UDID cannot match a longer one."""
+    target = "F5AF3736-C05F-493F-AA52-CA883B13B18C"
+
+    async def fake_run(*args, timeout=5.0):
+        if args[0] == "pgrep":
+            return 0, "111\n"
+        if args[0] == "lsof":
+            # A different simulator whose path merely contains the target as a
+            # substring of a longer component.
+            return 0, f"/data/Devices/{target}EXTRA/data/foo\n"
+        raise AssertionError("should not have killed anything")
+
+    with patch.object(ax_recovery, "_run", side_effect=fake_run):
+        assert await ax_recovery.bridge_pids_for(target) == []


### PR DESCRIPTION
Closes the last step of #66. The investigation there was already conclusive; what was missing is that the fix lived as a command to remember rather than something Quern does.

## The problem

Any XCTest-based run against a simulator — XCUITest **or WDA** — leaves that simulator's `CoreSimulatorBridge` holding a stale mach-port cache. Every foregrounded app then reports a single bare `Application` element with a `0x0` frame. Not just the app under test: **Safari breaks too**, and only SpringBoard keeps reading normally.

What makes it worth automating is the misdiagnosis. An empty tree is indistinguishable from every landmark on every screen drifting at once, so the natural response is to go and fix knowledge bases that were never wrong — and to suspect the bridge you'd have to already know about this.

## What it does

Recognise the signature, restart that simulator's bridge, retry once. The bridge is launchd-on-demand, so the retried query comes back against a fresh cache.

- **~1s**, app state preserved
- **Scoped to one simulator** — there's one bridge per booted simulator, and `lsof` maps it to the UDID. The others are undisturbed.
- **Once per read.** If the tree still looks wedged afterwards, the cause is something else — and a retry storm is actively harmful here, since sim-bridge serialises commands without cancelling abandoned ones, so repeated attempts drain into something that presents as a hang (#68).

## Detection is deliberately narrow

An app mid-launch legitimately reports a single `Application` element. The **zero frame and absent label** are what separate "nothing has rendered yet" from "the bridge cannot see anything at all", and a false positive costs a needless restart. Tested both ways.

## Verification

Nine tests, mutation-verified against two plausible regressions — killing every bridge instead of the matching one, and dropping the zero-frame check.

Kill and respawn verified live rather than only mocked:

```
bridge pids for F5AF3736: [28920]     ← correctly matched to the UDID
reset_bridge -> True
bridge after query: 91862             ← launchd respawned it
fresh read: 10 elements in 2.25s      ← healthy
```

One note on that verification: my first attempt "confirmed" recovery with a query that returned in 0.05s — which was the UI cache, not the bridge. It only became possible to be fooled that way because the cache timestamp fix earlier today made the cache actually serve reads for the first time. Worth knowing generally: **a test that reads twice in quick succession may now be measuring the cache rather than the thing under test.** The numbers above are with `use_cache=false`.

Suite: 1495.

## Not included

A manual `reset_ax_bridge` tool, suggested in the issue as a follow-on. Auto-recovery makes it unnecessary for the common case; it would only earn its place if a partially-wedged state turns up that detection misses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved simulator accessibility recovery after XCUITest/WDA runs.
  - Automatically refreshes a stale accessibility state once for the affected simulator.
  - Preserves the app state during recovery and limits changes to the relevant simulator.

- **Bug Fixes**
  - Prevents stale accessibility trees from blocking simulator interaction.
  - Retains healthy accessibility results after recovery.
  - Avoids repeated recovery attempts when accessibility data remains unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->