### PR TITLE
feat(device): reach web content inside WKWebView

### DIFF
--- a/docs/app-knowledge-guide.md
+++ b/docs/app-knowledge-guide.md
@@ -243,6 +243,52 @@ This is a separate issue from identifier reliability. The label is *correct*, bu
 - **In the Key Elements table**, write the stable portion followed by `...` and explain the dynamic part in Notes. Example: `Attributes, ...` with note "Comma-separated list of cache attributes, varies per cache."
 - **Prefer identifier over label** for dynamic-label elements — this is the one case where identifiers are more reliable than labels, if one exists.
 
+### Documenting Web Views
+
+A screen built on web content looks almost empty to `get_ui_tree`: on iOS the
+accessibility tree does not descend into a `WKWebView`, and the out-of-process
+hosts are not in the app's hierarchy at all. The failure mode is a
+misdiagnosis, not an error — a near-empty tree reads as "the screen failed to
+load" or "every landmark drifted", and the agent goes looking for a problem
+that isn't there.
+
+Record it in the screen's `web_content:` block. The facts that matter are ones
+only the source can answer, which is exactly what a knowledge base is for.
+
+```yaml
+web_content:
+  - host: "WKWebView"
+    in_process: true
+    inspectable: "debug"
+    url: "https://joinmastodon.org/servers"
+    page_offset: [0, 100]
+```
+
+**`in_process` decides everything else.** When the app constructs the view, it
+can opt it into remote inspection and the page's own DOM becomes available.
+When the system constructs it — `SFSafariViewController`,
+`ASWebAuthenticationSession` — the app has no handle on it, so that route is
+closed no matter what the app does.
+
+**`inspectable` is about the view, not the content.** Since iOS 16.4 a
+`WKWebView` is only inspectable if the app sets `isInspectable` on it. That is
+the app's decision about a view it owns, so it can be true even when the HTML
+comes from a third party the team has no control over. Use `"debug"` when it is
+behind `#if DEBUG`, which is where it belongs.
+
+**Why record `page_offset`.** DOM geometry is viewport-relative, so it cannot be
+tapped directly. One accessibility hit-test on any element recovers the offset
+between page and screen space; writing it down saves doing that every session.
+Re-derive it if the screen's layout changes.
+
+**Note when the URL is third-party.** It can change without an app release —
+the example above moved from `/communities` to `/servers` between knowledge-base
+revisions. Prefer structural selectors (`h1`, `button[aria-label]`) over text
+the site can reword.
+
+None of this applies on Android, where the accessibility tree does descend into
+a `WebView` and web content appears as ordinary elements.
+
 ### Overlay Panels
 
 Some UI doesn't fit neatly into "screen" or "alert" categories: map pin summary cards, bottom sheets, floating panels, and similar overlays that are persistent (not transient like alerts), interactive (they have navigation edges), but not full screens (no navigation bar, they overlay the parent screen).

--- a/docs/guides/workflow-app-knowledge.md
+++ b/docs/guides/workflow-app-knowledge.md
@@ -42,7 +42,7 @@ Your agent logs in, handles any onboarding screens, and arrives at the home scre
 
 - *"That screen has a detail section that expands when you tap the username"*
 - *"The first time you interact with each item type, an explainer modal pops up"*
-- *"That's a web view — on iOS the accessibility tree won't see the content inside it"*
+- *"That's a web view — on iOS the tree walk won't see inside it, so ask whether it's `isInspectable`"*
 - *"There's also a celebration screen that appears after every successful submission"*
 
 These corrections become the most valuable entries in the knowledge base.
@@ -271,5 +271,5 @@ You don't need to redo the full tour. When the agent encounters something on scr
 - **Flow testing is non-negotiable.** Flows find interceptors that screen-by-screen tours miss. Always execute your flows on the simulator before considering them done.
 - **Save checkpoints aggressively.** A checkpoint takes seconds to create and saves minutes every time it's restored. Save one after any multi-step setup you don't want to repeat.
 - **The plist discovery is worth the time.** 20 minutes mapping coaching flags gives you programmatic control over every modal in the app. That's a permanent capability.
-- **Web view screens are a limitation on iOS, not on Android.** On iOS, sim-bridge does not descend into a `WKWebView`, so the accessibility tree stops at the container and the content inside is unreachable — document those screens prominently so agents know to fall back to coordinates. On Android the opposite is true: the accessibility tree *does* expose the document, so a web view's headings, paragraphs and buttons are addressable by their DOM ids like any other element. Measured on API 33 against a fixture web view: `web_heading` and `web_paragraph` both come back in the tree. Reaching for coordinates there gives up working identifier-based interaction for nothing.
+- **Web view screens need a different route on iOS, not coordinates.** The accessibility *tree walk* does not descend into a `WKWebView`, so those screens look nearly empty — but two other routes reach the content. If the app sets `isInspectable` on the view (a debug-build one-liner, and a property of the view the app owns rather than of the content it loads), the page's whole DOM is available in around 15ms, including controls with no text at all. Failing that, hit-testing reaches text content in about a second. Record which applies in the screen's `web_content:` block; see "Documenting Web Views" in the authoring guide. On Android none of this is needed: the accessibility tree *does* expose the document, so a web view's headings, paragraphs and buttons are addressable by their DOM ids like any other element — measured on API 33 against a fixture. Reaching for coordinates on either platform now gives up working identifier-based interaction for nothing.
 - **Share the knowledge base with the team.** It's not just for agents — the identifier audit, state flag reference, and flow documentation are useful for any developer working on the app.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,11 @@ dependencies = [
     "mitmproxy>=10.0",
     "httpx>=0.27",
     "Pillow>=10.0",
+    # Vision framework via pyobjc, for locating on-screen text to aim
+    # accessibility hit-tests at (see server/device/vision_ocr.py). In-process,
+    # so nothing to compile, sign or ship. macOS only, like the simulator path
+    # it serves; the module degrades to pixel analysis if the import fails.
+    "pyobjc-framework-Vision>=10.0",
     "fb-idb>=1.1.0",
     "uiautomator2>=3.2",
     "pyyaml>=6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     # accessibility hit-tests at (see server/device/vision_ocr.py). In-process,
     # so nothing to compile, sign or ship. macOS only, like the simulator path
     # it serves; the module degrades to pixel analysis if the import fails.
-    "pyobjc-framework-Vision>=10.0",
+    "pyobjc-framework-Vision>=10.0; sys_platform == 'darwin'",
     "fb-idb>=1.1.0",
     "uiautomator2>=3.2",
     "pyyaml>=6.0",

--- a/server/device/probing.py
+++ b/server/device/probing.py
@@ -87,7 +87,7 @@ def flatten_nested(items: list[dict]) -> list[dict]:
     return result
 
 
-def _frame_key(frame: dict | None) -> tuple[int, int, int, int] | None:
+def frame_key(frame: dict | None) -> tuple[int, int, int, int] | None:
     if not frame:
         return None
     return (
@@ -95,6 +95,11 @@ def _frame_key(frame: dict | None) -> tuple[int, int, int, int] | None:
         int(frame.get("width", 0)), int(frame.get("height", 0)),
     )
 
+
+# Kept so every existing caller and test in this module reads unchanged; the
+# public name exists because web_probing needs the same key to tell a web hit
+# from a native element it has already seen.
+_frame_key = frame_key
 
 DescribePointFn = Callable[[str, float, float], Awaitable[dict | None]]
 

--- a/server/device/vision_ocr.py
+++ b/server/device/vision_ocr.py
@@ -25,9 +25,6 @@ import logging
 
 logger = logging.getLogger("quern-debug-server.device")
 
-# Vision's accurate path. Slower than .fast and worth it: .fast misses small
-# type, which is most of a web page.
-_RECOGNITION_ACCURATE = 1
 
 _unavailable_logged = False
 
@@ -80,7 +77,10 @@ def text_regions(png: bytes, screen: dict) -> list[dict]:
             return []
 
         request = Vision.VNRecognizeTextRequest.alloc().init()
-        request.setRecognitionLevel_(_RECOGNITION_ACCURATE)
+        # Vision's accurate path. Slower than .fast and worth it: .fast misses
+        # small type, which is most of a web page. Named rather than hard-coded
+        # as 1, so a framework change cannot silently reinterpret it.
+        request.setRecognitionLevel_(Vision.VNRequestTextRecognitionLevelAccurate)
         # Language correction rewrites UI strings into dictionary words, and the
         # text is used to match against accessibility labels, so it has to stay
         # verbatim.

--- a/server/device/vision_ocr.py
+++ b/server/device/vision_ocr.py
@@ -1,0 +1,118 @@
+"""Locate on-screen text with Apple's Vision framework.
+
+Used to aim accessibility hit-tests at web content. `describe_point` reaches
+inside a `WKWebView` where the tree walk cannot, but each probe costs ~93ms, so
+the question is where to point. Vision answers it directly: text with precise
+bounding boxes, in one pass over a screenshot we already take.
+
+Measured against a remote page in an `SFSafariViewController`: 10 observations
+in 125ms. The pixel heuristic it replaces needed 75 probes and 6.9s to find
+four elements, because it could only say "something is on this row" and then
+had to hunt along it.
+
+Called through pyobjc rather than a Swift helper deliberately — it runs
+in-process, needs no compile step, and adds nothing that has to be signed or
+shipped. The call is short enough to keep here rather than take a wrapper
+library for it.
+
+macOS only, like the rest of the simulator path. A missing framework degrades to
+an empty result rather than raising, so callers fall back instead of failing.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("quern-debug-server.device")
+
+# Vision's accurate path. Slower than .fast and worth it: .fast misses small
+# type, which is most of a web page.
+_RECOGNITION_ACCURATE = 1
+
+_unavailable_logged = False
+
+
+def available() -> bool:
+    try:
+        import Quartz  # noqa: F401
+        import Vision  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def text_regions(png: bytes, screen: dict) -> list[dict]:
+    """Text found in a screenshot, as rects in device points.
+
+    Returns `{"text", "x", "y", "width", "height", "confidence"}` per run, with
+    coordinates in the same space as the accessibility tree so a caller can hand
+    them straight to a hit-test.
+    """
+    global _unavailable_logged
+    try:
+        import Quartz
+        import Vision
+        from Foundation import NSData
+    except ImportError:
+        if not _unavailable_logged:
+            logger.info(
+                "Vision framework unavailable (pyobjc-framework-Vision not "
+                "installed) — falling back to pixel analysis for web content",
+            )
+            _unavailable_logged = True
+        return []
+
+    screen_height = float(screen.get("height") or 0)
+    if not png or screen_height <= 0:
+        return []
+
+    try:
+        data = NSData.dataWithBytes_length_(png, len(png))
+        source = Quartz.CGImageSourceCreateWithData(data, None)
+        if source is None:
+            return []
+        image = Quartz.CGImageSourceCreateImageAtIndex(source, 0, None)
+        if image is None:
+            return []
+        width_px = Quartz.CGImageGetWidth(image)
+        height_px = Quartz.CGImageGetHeight(image)
+        if not width_px or not height_px:
+            return []
+
+        request = Vision.VNRecognizeTextRequest.alloc().init()
+        request.setRecognitionLevel_(_RECOGNITION_ACCURATE)
+        # Language correction rewrites UI strings into dictionary words, and the
+        # text is used to match against accessibility labels, so it has to stay
+        # verbatim.
+        request.setUsesLanguageCorrection_(False)
+
+        handler = Vision.VNImageRequestHandler.alloc().initWithCGImage_options_(image, None)
+        ok, _ = handler.performRequests_error_([request], None)
+        if not ok:
+            return []
+        observations = request.results() or []
+    except Exception as exc:  # pragma: no cover - defensive around a C bridge
+        logger.debug("vision OCR failed: %s", exc)
+        return []
+
+    scale = height_px / screen_height
+    if scale <= 0:
+        return []
+
+    regions: list[dict] = []
+    for observation in observations:
+        candidates = observation.topCandidates_(1)
+        if not candidates:
+            continue
+        box = observation.boundingBox()
+        # Vision normalises to 0..1 with the origin at the bottom left; the
+        # accessibility tree measures points from the top left.
+        regions.append({
+            "text": str(candidates[0].string()),
+            "confidence": float(candidates[0].confidence()),
+            "x": box.origin.x * width_px / scale,
+            "y": (1.0 - box.origin.y - box.size.height) * height_px / scale,
+            "width": box.size.width * width_px / scale,
+            "height": box.size.height * height_px / scale,
+        })
+    return regions

--- a/server/device/web_probing.py
+++ b/server/device/web_probing.py
@@ -37,6 +37,7 @@ import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 
+from server.device import vision_ocr
 from server.device.probing import DescribePointFn, frame_key
 
 logger = logging.getLogger("quern-debug-server.device")
@@ -242,11 +243,25 @@ async def sweep_web_content(
     native_keys = {frame_key(el.get("frame")) for el in native if el.get("frame")}
 
     png = await screenshot()
-    bands = content_bands(png, screen) if png else []
-    if not bands:
-        result.reason = (
-            "no screenshot available, or it showed no content bands to aim at"
-        )
+    if not png:
+        result.reason = "no screenshot available to aim with"
+        return result
+
+    # Vision names the text and boxes it, so each probe lands on something
+    # rather than hunting along a row that merely has ink somewhere on it.
+    # Measured on the same page: 10 boxes in 125ms against 75 probes and 6.9s
+    # for the pixel heuristic. Bands remain the fallback for a screen Vision
+    # cannot read, and for anything without text.
+    targets: list[tuple[float, float]] = []
+    for region in vision_ocr.text_regions(png, screen):
+        targets.append((
+            region["x"] + region["width"] / 2,
+            region["y"] + region["height"] / 2,
+        ))
+
+    bands = [] if targets else content_bands(png, screen)
+    if not targets and not bands:
+        result.reason = "nothing on screen to aim at"
         return result
 
     top = float(screen.get("y") or 0) + top_inset
@@ -256,6 +271,37 @@ async def sweep_web_content(
 
     seen: set[tuple] = set()
     deadline = started + time_budget
+
+    # Vision targets first: one probe each, at a known box centre.
+    for tx, ty in targets:
+        if result.probes >= max_probes or time.perf_counter() > deadline:
+            result.truncated = True
+            break
+        if not (top <= ty <= bottom) or _covered(covered, tx, ty):
+            continue
+        try:
+            hit = await describe_point(udid, tx, ty)
+        except Exception as exc:
+            logger.debug("web sweep: probe at (%.0f, %.0f) failed: %s", tx, ty, exc)
+            continue
+        result.probes += 1
+        frame = hit.get("frame") if hit else None
+        if not hit_contains(frame, tx, ty):
+            continue
+        covered.append(_rect(frame))
+        key = frame_key(frame)
+        if key in native_keys:
+            continue
+        dedupe = (key, hit.get("type"), hit.get("AXLabel") or "")
+        if dedupe in seen:
+            continue
+        seen.add(dedupe)
+        enriched = dict(hit)
+        attrs = dict(enriched.get("extra_attrs") or {})
+        attrs.update({"source": "web-probe",
+                      "probe_x": f"{tx:.0f}", "probe_y": f"{ty:.0f}"})
+        enriched["extra_attrs"] = attrs
+        result.elements.append(enriched)
 
     for band_top, band_bottom in bands:
         # Walk down the band rather than sampling its middle once. Bands merge

--- a/server/device/web_probing.py
+++ b/server/device/web_probing.py
@@ -1,0 +1,317 @@
+"""Find web content that the accessibility tree walk cannot see.
+
+On iOS simulators `describe_all` does not descend into `WKWebView`, so an agent
+looking at a screen with web content sees native chrome and nothing else. The
+web view is not merely empty in the tree — it is absent entirely, so there is no
+container to notice and nothing to bound a search with.
+
+`describe_point` (AXPTranslator's `objectAtPoint:`) *does* reach web content,
+with accurate frames in device points and useful types. Measured against a
+remote page in an `SFSafariViewController` belonging to an app that never opted
+into web inspection:
+
+    (200, 200) -> Link       "Mastodon"
+    (200, 380) -> StaticText "Mastodon is not a single website. To use it,"
+
+So the content is reachable one point at a time. The problem this module solves
+is *where to point*, cheaply.
+
+Two behaviours make that harder than it sounds, both measured:
+
+* A hit-test in whitespace does not return `None`. It returns the nearest
+  element, whose frame does not contain the probe point. `hit_contains` is
+  therefore the validity test, and without it a sweep records phantoms.
+* A blind lattice is slow and lossy: 57 probes and 5.3s to find 2 of 4 elements
+  on a simple page, because a fixed step jumps over short ones. Probes cost
+  ~93ms, so the lattice is the wrong instrument.
+
+A screenshot locates content far better. One capture, edge-filtered, yields
+bands that map onto the real elements closely enough to aim at — around five
+probes where the lattice needed 57.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+
+from server.device.probing import DescribePointFn, frame_key
+
+logger = logging.getLogger("quern-debug-server.device")
+
+ScreenshotFn = Callable[[], Awaitable[bytes | None]]
+
+# A native element only marks its area "already known" if it is a labelled or
+# interactive leaf covering less than this share of the screen. The cap is load
+# bearing: a labelled full-screen scroll view would otherwise mask the entire
+# page, and the web view's own host view is an unlabelled container that must
+# NOT contribute coverage, since its absence from the tree is the whole problem.
+MAX_COVERAGE_SHARE = 0.6
+
+# Content rows closer together than this are treated as one band, so a
+# paragraph is one band rather than one per line of text. Kept small: bands are
+# probed at more than one height, but a large gap merges genuinely separate
+# elements and costs a probe to untangle.
+_BAND_GAP_PT = 6.0
+
+# How far to advance inside a band when a probe finds nothing.
+_BAND_STEP_PT = 18.0
+
+# The status bar renders above any web content, and probing it only rediscovers
+# clock and cellular indicators the tree omits — real elements, but not what
+# this is for, and each one costs a probe. Overridable for a genuinely
+# fullscreen web view.
+STATUS_BAR_PT = 60.0
+
+INTERACTIVE_TYPES = frozenset({
+    "Button", "Link", "TextField", "SecureTextField", "Switch", "Slider",
+    "RadioButton", "CheckBox", "SearchField", "Stepper", "SegmentedControl",
+})
+
+
+@dataclass(slots=True)
+class WebSweepResult:
+    elements: list[dict] = field(default_factory=list)
+    regions: list[dict] = field(default_factory=list)
+    probes: int = 0
+    elapsed_ms: float = 0.0
+    truncated: bool = False
+    reason: str | None = None
+
+
+def hit_contains(frame: dict | None, x: float, y: float) -> bool:
+    """Whether a returned frame genuinely contains the probed point.
+
+    The hit-test answers a whitespace probe with the nearest element rather than
+    nothing, so a result is only evidence of something *at* the point if its own
+    frame says so.
+    """
+    if not frame:
+        return False
+    w = frame.get("width") or 0
+    h = frame.get("height") or 0
+    if w <= 0 or h <= 0:
+        return False
+    fx = frame.get("x") or 0
+    fy = frame.get("y") or 0
+    return fx <= x <= fx + w and fy <= y <= fy + h
+
+
+def _rect(frame: dict) -> tuple[float, float, float, float]:
+    return (
+        float(frame.get("x") or 0), float(frame.get("y") or 0),
+        float(frame.get("width") or 0), float(frame.get("height") or 0),
+    )
+
+
+def app_frame(native: list[dict]) -> dict | None:
+    """The screen rect, taken from the Application element or the largest frame."""
+    for el in native:
+        if el.get("type") == "Application" and el.get("frame"):
+            return el["frame"]
+    framed = [el["frame"] for el in native if el.get("frame")]
+    if not framed:
+        return None
+    return max(framed, key=lambda f: (f.get("width") or 0) * (f.get("height") or 0))
+
+
+def coverage_rects(native: list[dict], screen: dict) -> list[tuple[float, float, float, float]]:
+    """Areas whose contents the tree already reports, so probing them is waste."""
+    screen_area = (screen.get("width") or 0) * (screen.get("height") or 0)
+    covered: list[tuple[float, float, float, float]] = []
+    for el in native:
+        frame = el.get("frame")
+        if not frame:
+            continue
+        x, y, w, h = _rect(frame)
+        if w <= 0 or h <= 0:
+            continue
+        labelled = bool(el.get("AXLabel") or el.get("label"))
+        if not labelled and el.get("type") not in INTERACTIVE_TYPES:
+            continue
+        if screen_area and (w * h) > MAX_COVERAGE_SHARE * screen_area:
+            continue
+        covered.append((x, y, w, h))
+    return covered
+
+
+def _covered(rects: list[tuple[float, float, float, float]], x: float, y: float) -> bool:
+    return any(rx <= x <= rx + rw and ry <= y <= ry + rh for rx, ry, rw, rh in rects)
+
+
+def content_bands(png: bytes, screen: dict, min_band_pt: float = 4.0) -> list[tuple[float, float]]:
+    """Vertical bands that contain visible content, in device points.
+
+    Rows are judged by how many pixels differ from the page background, not by
+    edge energy. Edges were the first attempt and are wrong for this: an edge
+    filter marks a shape's border, so a solid-filled button arrives as two
+    hairlines as far apart as the button is tall, each too thin to survive a
+    minimum-height filter. Text has dense edges and hid the flaw until a
+    synthetic image exposed it.
+
+    The background is taken as the most common value rather than assumed white,
+    so a dark-mode page works the same way.
+    """
+    try:
+        import io
+
+        from PIL import Image
+    except ImportError:  # pragma: no cover - Pillow is a declared dependency
+        return []
+
+    try:
+        image = Image.open(io.BytesIO(png)).convert("L")
+    except Exception:
+        return []
+
+    width_px, height_px = image.size
+    screen_h = float(screen.get("height") or 0)
+    if not width_px or not height_px or screen_h <= 0:
+        return []
+    scale = height_px / screen_h
+
+    histogram = image.histogram()
+    background = histogram.index(max(histogram))
+    pixels = image.load()
+    # Every 4th column is enough to answer "is there anything on this row" and
+    # keeps the scan linear in height rather than in area.
+    xs = range(0, width_px, 4)
+    sampled = len(range(0, width_px, 4))
+    min_differing = max(1, int(sampled * 0.01))
+
+    rows = [
+        sum(1 for x in xs if abs(pixels[x, y] - background) > 24) >= min_differing
+        for y in range(height_px)
+    ]
+
+    runs: list[tuple[int, int]] = []
+    start_y: int | None = None
+    for y, has_content in enumerate(rows):
+        if has_content and start_y is None:
+            start_y = y
+        elif not has_content and start_y is not None:
+            runs.append((start_y, y))
+            start_y = None
+    if start_y is not None:
+        runs.append((start_y, height_px))
+
+    # Close hairline gaps from antialiasing and line spacing so a paragraph is
+    # one band rather than one per line of text.
+    gap_px = max(1, int(_BAND_GAP_PT * scale))
+    merged: list[tuple[int, int]] = []
+    for run_start, run_end in runs:
+        if merged and run_start - merged[-1][1] <= gap_px:
+            merged[-1] = (merged[-1][0], run_end)
+        else:
+            merged.append((run_start, run_end))
+
+    return [
+        (a / scale, b / scale) for a, b in merged
+        if (b - a) / scale >= min_band_pt
+    ]
+
+
+async def sweep_web_content(
+    udid: str,
+    describe_point: DescribePointFn,
+    screenshot: ScreenshotFn,
+    native: list[dict],
+    *,
+    region: dict | None = None,
+    top_inset: float = STATUS_BAR_PT,
+    max_probes: int = 60,
+    time_budget: float = 15.0,
+    columns: tuple[float, ...] = (0.5, 0.25, 0.75),
+) -> WebSweepResult:
+    """Find content the tree walk missed, by aiming hit-tests with a screenshot.
+
+    `describe_point` and `screenshot` are injected so this is testable without a
+    device, the same way `probing.probe_container` takes its `describe_point`.
+    """
+    started = time.perf_counter()
+    result = WebSweepResult()
+
+    screen = region or app_frame(native)
+    if not screen:
+        result.reason = "no application frame to search within"
+        return result
+
+    covered = coverage_rects(native, screen)
+    native_keys = {frame_key(el.get("frame")) for el in native if el.get("frame")}
+
+    png = await screenshot()
+    bands = content_bands(png, screen) if png else []
+    if not bands:
+        result.reason = (
+            "no screenshot available, or it showed no content bands to aim at"
+        )
+        return result
+
+    top = float(screen.get("y") or 0) + top_inset
+    bottom = top + float(screen.get("height") or 0)
+    left = float(screen.get("x") or 0)
+    width = float(screen.get("width") or 0)
+
+    seen: set[tuple] = set()
+    deadline = started + time_budget
+
+    for band_top, band_bottom in bands:
+        # Walk down the band rather than sampling its middle once. Bands merge
+        # when elements sit close together, and a single sample then finds
+        # whichever of them happens to be under it and silently drops the rest.
+        y = max(band_top + 1, top)
+        band_end = min(band_bottom, bottom)
+        while y <= band_end:
+            advanced_to: float | None = None
+            for fraction in columns:
+                if result.probes >= max_probes or time.perf_counter() > deadline:
+                    result.truncated = True
+                    break
+                x = left + width * fraction
+                # Anything already accounted for costs nothing to skip, and the
+                # skip list grows with every hit, so a wide element is probed
+                # once however many bands or columns cross it.
+                if _covered(covered, x, y):
+                    continue
+                try:
+                    hit = await describe_point(udid, x, y)
+                except Exception as exc:
+                    logger.debug("web sweep: probe at (%.0f, %.0f) failed: %s", x, y, exc)
+                    continue
+                result.probes += 1
+                frame = hit.get("frame") if hit else None
+                if not hit_contains(frame, x, y):
+                    continue  # whitespace: the nearest element, not one here
+
+                covered.append(_rect(frame))
+                fy, fh = float(frame.get("y") or 0), float(frame.get("height") or 0)
+                advanced_to = max(advanced_to or 0.0, fy + fh + 1)
+
+                key = frame_key(frame)
+                if key in native_keys:
+                    continue  # native chrome the tree already reported
+                dedupe = (key, hit.get("type"), hit.get("AXLabel") or "")
+                if dedupe in seen:
+                    continue
+                seen.add(dedupe)
+
+                enriched = dict(hit)
+                attrs = dict(enriched.get("extra_attrs") or {})
+                attrs.update({"source": "web-probe",
+                              "probe_x": f"{x:.0f}", "probe_y": f"{y:.0f}"})
+                enriched["extra_attrs"] = attrs
+                result.elements.append(enriched)
+
+            if result.truncated:
+                break
+            # Step past whatever was found here; if nothing was, move on by a
+            # line's worth so a tall blank band cannot spin.
+            y = advanced_to if advanced_to and advanced_to > y else y + _BAND_STEP_PT
+        if result.truncated:
+            break
+
+    result.regions = [dict(screen)]
+    result.elapsed_ms = (time.perf_counter() - started) * 1000
+    return result

--- a/server/device/webinspector.py
+++ b/server/device/webinspector.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import asyncio
 import glob
+import json
 import logging
 import os
 import socket
@@ -42,6 +43,60 @@ _SEL_REPORT_IDENTIFIER = "_rpc_reportIdentifier:"
 _SEL_FORWARD_GET_LISTING = "_rpc_forwardGetListing:"
 _SEL_FORWARD_SOCKET_SETUP = "_rpc_forwardSocketSetup:"
 _SEL_FORWARD_SOCKET_DATA = "_rpc_forwardSocketData:"
+
+# Replies to a forwarded WebKit message come back under this selector, carrying
+# the raw protocol JSON. Unlike the sim-bridge wire protocol, WebKit messages
+# carry their own ids, so a reply can be matched to its request rather than to
+# whatever arrived next.
+_SEL_APPLICATION_SENT_DATA = "_rpc_applicationSentData:"
+
+# Collects every element a page can show, with the geometry needed to touch it.
+# Written as one expression so a page yields its whole structure in a single
+# round trip: a DOM.getDocument walk would need one message per node, and the
+# channel is slow enough that the difference is seconds.
+_COLLECT_JS = """
+(function () {
+  var out = [];
+  var nodes = document.querySelectorAll(
+    'a, button, input, select, textarea, [role], [onclick], h1, h2, h3, h4, ' +
+    'h5, h6, p, li, label, span, div');
+  for (var i = 0; i < nodes.length && out.length < 400; i++) {
+    var n = nodes[i];
+    var r = n.getBoundingClientRect();
+    if (r.width <= 0 || r.height <= 0) continue;
+    if (r.bottom < 0 || r.top > window.innerHeight) continue;
+    var own = '';
+    for (var c = n.firstChild; c; c = c.nextSibling) {
+      if (c.nodeType === 3) own += c.nodeValue;
+    }
+    own = own.trim();
+    var tag = n.tagName.toLowerCase();
+    var interactive = (tag === 'a' || tag === 'button' || tag === 'input' ||
+                       tag === 'select' || tag === 'textarea' ||
+                       n.hasAttribute('onclick') || n.getAttribute('role'));
+    // Structural wrappers with no text of their own are noise; keep them only
+    // when they are something a user can act on.
+    if (!own && !interactive) continue;
+    out.push({
+      tag: tag,
+      id: n.id || null,
+      name: n.getAttribute('name'),
+      role: n.getAttribute('role'),
+      type: n.getAttribute('type'),
+      href: tag === 'a' ? n.getAttribute('href') : null,
+      text: (own || n.getAttribute('aria-label') || n.value || '').slice(0, 200),
+      x: r.left, y: r.top, width: r.width, height: r.height,
+      interactive: !!interactive
+    });
+  }
+  return JSON.stringify({
+    url: location.href, title: document.title,
+    viewport: {width: window.innerWidth, height: window.innerHeight},
+    scroll: {x: window.scrollX, y: window.scrollY},
+    elements: out
+  });
+})()
+"""
 
 
 class WebInspectorError(RuntimeError):
@@ -88,6 +143,10 @@ class SimulatorWebInspector:
         self._service: Any = None
         self._sock: socket.socket | None = None
         self._connection_id = str(uuid.uuid4()).upper()
+        self._sender_id = str(uuid.uuid4()).upper()
+        self._sessions: set[tuple[str, int]] = set()
+        self._targets: dict[tuple[str, int], str] = {}
+        self._message_id = 0
         self._applications: dict[str, dict] = {}
 
     async def __aenter__(self) -> SimulatorWebInspector:
@@ -206,6 +265,150 @@ class SimulatorWebInspector:
             }
             for app_id, info in self._applications.items()
         ]
+
+    async def _open_session(self, application_id: str, page_id: int) -> None:
+        session = (application_id, page_id)
+        if session in self._sessions:
+            return
+        await self._send(_SEL_FORWARD_SOCKET_SETUP, {
+            "WIRApplicationIdentifierKey": application_id,
+            "WIRConnectionIdentifierKey": self._connection_id,
+            "WIRPageIdentifierKey": page_id,
+            "WIRSenderKey": self._sender_id,
+        })
+        self._sessions.add(session)
+
+    async def _send_to_page(
+        self, application_id: str, page_id: int, message: dict,
+    ) -> None:
+        await self._send(_SEL_FORWARD_SOCKET_DATA, {
+            "WIRApplicationIdentifierKey": application_id,
+            "WIRConnectionIdentifierKey": self._connection_id,
+            "WIRPageIdentifierKey": page_id,
+            "WIRSenderKey": self._sender_id,
+            "WIRSocketDataKey": json.dumps(message).encode(),
+        })
+
+    async def _forward(
+        self, application_id: str, page_id: int, method: str, params: dict | None = None,
+    ) -> dict | None:
+        """Send one WebKit protocol message to a page and wait for its reply.
+
+        Messages are wrapped in `Target.sendMessageToTarget` and replies arrive
+        inside `Target.dispatchMessageFromTarget`. Sending a bare
+        `Runtime.evaluate` is answered with
+
+            {"error": {"code": -32601, "message": "'Runtime' domain was not
+             found"}}
+
+        which reads as "this WebKit has no JavaScript" rather than "you skipped
+        a layer". The target id comes from the `Target.targetCreated` event the
+        page emits when the session opens, so the session has to be established
+        and drained before anything can be sent.
+
+        Replies are matched on the inner message id. WebKit messages carry
+        their own ids, unlike the sim-bridge wire protocol, so pairing by
+        arrival order is unnecessary here — and would be wrong, since the
+        daemon interleaves unrelated events.
+        """
+        session = (application_id, page_id)
+        await self._open_session(application_id, page_id)
+
+        if session not in self._targets:
+            target_id = await self._await_target(application_id, page_id)
+            if target_id is None:
+                logger.debug("webinspector: no target for page %s", page_id)
+                return None
+            self._targets[session] = target_id
+
+        self._message_id += 1
+        inner_id = self._message_id
+        inner = {"id": inner_id, "method": method, "params": params or {}}
+
+        self._message_id += 1
+        await self._send_to_page(application_id, page_id, {
+            "id": self._message_id,
+            "method": "Target.sendMessageToTarget",
+            "params": {"targetId": self._targets[session], "message": json.dumps(inner)},
+        })
+
+        deadline = asyncio.get_running_loop().time() + self._timeout
+        while asyncio.get_running_loop().time() < deadline:
+            decoded = await self._next_page_message(deadline)
+            if decoded is None:
+                return None
+            if decoded.get("method") == "Target.dispatchMessageFromTarget":
+                raw_inner = (decoded.get("params") or {}).get("message")
+                try:
+                    unwrapped = json.loads(raw_inner) if raw_inner else None
+                except ValueError:
+                    continue
+                if unwrapped and unwrapped.get("id") == inner_id:
+                    return unwrapped
+        return None
+
+    async def _next_page_message(self, deadline: float) -> dict | None:
+        """The next decoded protocol message, absorbing daemon chatter."""
+        while asyncio.get_running_loop().time() < deadline:
+            remaining = deadline - asyncio.get_running_loop().time()
+            try:
+                message = await asyncio.wait_for(
+                    self._service.recv_plist(), timeout=remaining)
+            except TimeoutError:
+                return None
+            if message is None:
+                return None
+            if message.get("__selector") != _SEL_APPLICATION_SENT_DATA:
+                self._absorb(message)
+                continue
+            raw = (message.get("__argument") or {}).get("WIRMessageDataKey")
+            if not raw:
+                continue
+            try:
+                return json.loads(bytes(raw).decode())
+            except (ValueError, UnicodeDecodeError):
+                continue
+        return None
+
+    async def _await_target(self, application_id: str, page_id: int) -> str | None:
+        """Read the target id the page announces after its session opens."""
+        deadline = asyncio.get_running_loop().time() + self._timeout
+        while asyncio.get_running_loop().time() < deadline:
+            decoded = await self._next_page_message(deadline)
+            if decoded is None:
+                return None
+            if decoded.get("method") == "Target.targetCreated":
+                info = (decoded.get("params") or {}).get("targetInfo") or {}
+                target = info.get("targetId")
+                if target:
+                    return str(target)
+        return None
+
+    async def evaluate(self, application_id: str, page_id: int, expression: str) -> object:
+        """Run JavaScript in a page and return the decoded result."""
+        reply = await self._forward(application_id, page_id, "Runtime.evaluate", {
+            "expression": expression,
+            "returnByValue": True,
+        })
+        if not reply:
+            return None
+        result = ((reply.get("result") or {}).get("result") or {})
+        return result.get("value")
+
+    async def page_contents(self, application_id: str, page_id: int) -> dict | None:
+        """Every addressable element in a page, with page-space geometry.
+
+        Coordinates are relative to the page viewport, not the screen. A caller
+        wanting to touch them has to anchor the two, which one accessibility
+        hit-test is enough to do.
+        """
+        raw = await self.evaluate(application_id, page_id, _COLLECT_JS)
+        if not raw:
+            return None
+        try:
+            return json.loads(raw) if isinstance(raw, str) else raw
+        except ValueError:
+            return None
 
     async def pages(self, application_id: str) -> list[dict]:
         """Inspectable pages within one application.

--- a/server/device/webinspector.py
+++ b/server/device/webinspector.py
@@ -317,6 +317,11 @@ class SimulatorWebInspector:
         if session not in self._targets:
             target_id = await self._await_target(application_id, page_id)
             if target_id is None:
+                # Drop the session too. Setup is skipped when the session is
+                # cached, and Target.targetCreated is only announced when it is
+                # established — so keeping a session whose target never arrived
+                # means every later call waits for an event that cannot come.
+                self._sessions.discard(session)
                 logger.debug("webinspector: no target for page %s", page_id)
                 return None
             self._targets[session] = target_id
@@ -334,7 +339,7 @@ class SimulatorWebInspector:
 
         deadline = asyncio.get_running_loop().time() + self._timeout
         while asyncio.get_running_loop().time() < deadline:
-            decoded = await self._next_page_message(deadline)
+            decoded = await self._next_page_message(page_id, deadline)
             if decoded is None:
                 return None
             if decoded.get("method") == "Target.dispatchMessageFromTarget":
@@ -347,8 +352,16 @@ class SimulatorWebInspector:
                     return unwrapped
         return None
 
-    async def _next_page_message(self, deadline: float) -> dict | None:
-        """The next decoded protocol message, absorbing daemon chatter."""
+    async def _next_page_message(self, page_id: int, deadline: float) -> dict | None:
+        """The next decoded protocol message from one page, ignoring the rest.
+
+        The page id filter is not decoration. An app can have several
+        inspectable pages — Metatext has two, a YouTube embed and the instance
+        picker — and every one of them announces its own Target.targetCreated
+        on the shared connection. Without this, opening a session on one page
+        can cache another page's target id and then send every message to the
+        wrong document.
+        """
         while asyncio.get_running_loop().time() < deadline:
             remaining = deadline - asyncio.get_running_loop().time()
             try:
@@ -361,7 +374,10 @@ class SimulatorWebInspector:
             if message.get("__selector") != _SEL_APPLICATION_SENT_DATA:
                 self._absorb(message)
                 continue
-            raw = (message.get("__argument") or {}).get("WIRMessageDataKey")
+            argument = message.get("__argument") or {}
+            if argument.get("WIRPageIdentifierKey") not in (None, page_id):
+                continue  # another page's traffic on the shared connection
+            raw = argument.get("WIRMessageDataKey")
             if not raw:
                 continue
             try:
@@ -374,7 +390,7 @@ class SimulatorWebInspector:
         """Read the target id the page announces after its session opens."""
         deadline = asyncio.get_running_loop().time() + self._timeout
         while asyncio.get_running_loop().time() < deadline:
-            decoded = await self._next_page_message(deadline)
+            decoded = await self._next_page_message(page_id, deadline)
             if decoded is None:
                 return None
             if decoded.get("method") == "Target.targetCreated":

--- a/templates/app-knowledge/screens/_template.md
+++ b/templates/app-knowledge/screens/_template.md
@@ -32,6 +32,42 @@ landmarks:
 identify_by:
   - { element: "", label: "" }
 
+# Web-backed content on this screen. Omit the key entirely when there is none.
+#
+# The accessibility tree does not descend into a WKWebView on iOS, so a screen
+# built on web content looks almost empty to get_ui_tree — which reads as "the
+# screen failed to load" rather than "the content is behind another door".
+# Recording it here stops that misdiagnosis and names the route that works.
+#
+# Which route applies is decided by facts only the source knows, so this is
+# exactly the kind of thing worth writing down once:
+#
+#   host          WKWebView | SFSafariViewController | ASWebAuthenticationSession
+#                 | WebView (Android)
+#   in_process    true when the app constructs the view itself. The system-hosted
+#                 ones (SFSafariViewController, ASWebAuthenticationSession) run in
+#                 another process and are not in the app's hierarchy at all.
+#   inspectable   true | false | "debug". Since iOS 16.4 a WKWebView is only
+#                 inspectable if the app sets isInspectable on it. That is a
+#                 property of the view the app creates, NOT of the content it
+#                 loads — so this can be true even for a third-party page, and is
+#                 always false for the out-of-process hosts.
+#   url           what it loads. Note when it is third-party: it can change
+#                 without an app release, so prefer structural selectors over
+#                 text the site can reword.
+#   page_offset   [x, y] of page (0,0) in screen points, when known. DOM
+#                 geometry is viewport-relative; this is what makes it tappable.
+#                 One accessibility hit-test on any element recovers it.
+#
+# On Android none of this applies: the accessibility tree does descend into a
+# WebView, so web content appears as ordinary elements.
+web_content:
+  # - host: "WKWebView"
+  #   in_process: true
+  #   inspectable: "debug"
+  #   url: "https://example.com/page"
+  #   page_offset: [0, 100]
+
 # Where this screen can be reached from.
 reachable_from:
   - screen: "[[screens/...]]"

--- a/tests/test_web_probing.py
+++ b/tests/test_web_probing.py
@@ -239,3 +239,48 @@ def test_bands_are_returned_in_device_points(bands):
     for (want_top, want_bottom), (got_top, got_bottom) in zip(bands, found, strict=False):
         assert abs(got_top - want_top) < 12, f"{got_top} vs {want_top}"
         assert abs(got_bottom - want_bottom) < 12
+
+
+# --------------------------------------------------------------------------
+# Vision-guided targeting
+# --------------------------------------------------------------------------
+
+def test_vision_absence_degrades_rather_than_raises(monkeypatch):
+    """Vision is macOS-only and an optional install. Losing it should cost
+    speed, not the feature — the pixel path still works, just slower."""
+    import builtins
+
+    from server.device import vision_ocr
+
+    real_import = builtins.__import__
+
+    def no_vision(name, *args, **kwargs):
+        if name in ("Vision", "Quartz"):
+            raise ImportError("no Vision here")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", no_vision)
+    assert vision_ocr.text_regions(b"not-a-png", SCREEN) == []
+    assert vision_ocr.available() is False
+
+
+async def test_vision_targets_are_probed_at_their_centres(monkeypatch):
+    """One probe per located text run, at the middle of its box.
+
+    This is the whole point of the Vision pass: the pixel heuristic could only
+    say "ink somewhere on this row" and then had to hunt along it — 75 probes
+    against 4 on the same page.
+    """
+    from server.device import vision_ocr
+    from server.device import web_probing as wp
+
+    monkeypatch.setattr(vision_ocr, "text_regions", lambda png, screen: [
+        {"text": "Servers", "confidence": 1.0, "x": 20, "y": 290, "width": 140, "height": 30},
+    ])
+    target = el("Heading", "Servers", 20, 290, 140, 30)
+    screen = FakeScreen([target])
+    result = await wp.sweep_web_content(
+        SIM, screen.describe_point, shot_of([]), [el("Application", "", 0, 0, 400, 800)],
+    )
+    assert screen.calls == [(90.0, 305.0)], f"probed {screen.calls}"
+    assert [e["AXLabel"] for e in result.elements] == ["Servers"]

--- a/tests/test_web_probing.py
+++ b/tests/test_web_probing.py
@@ -1,0 +1,241 @@
+"""Finding web content the accessibility tree cannot see.
+
+Every behaviour asserted here was measured on a simulator first; the fixture
+exists to reproduce it without one. The two that matter most are easy to get
+wrong from first principles:
+
+* A hit-test in whitespace returns the *nearest* element, not None. Treating
+  that as a find records elements that are not where they are said to be.
+* Probes cost ~93ms, so where you aim decides whether this is a second or a
+  minute. A blind lattice took 57 probes to find 2 of 4 elements; aiming with a
+  screenshot took 9 to find 4 on a harder page.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from server.device import web_probing
+
+SIM = "F5AF3736-C05F-493F-AA52-CA883B13B18C"
+SCREEN = {"x": 0.0, "y": 0.0, "width": 400.0, "height": 800.0}
+
+
+def el(type_, label, x, y, w, h, **extra):
+    return {"type": type_, "AXLabel": label, "AXUniqueId": None,
+            "frame": {"x": x, "y": y, "width": w, "height": h}, **extra}
+
+
+class FakeScreen:
+    """A screen of rects that answers hit-tests the way a simulator does.
+
+    Crucially it never returns None for a miss: it returns the nearest rect,
+    which is what makes the containment check load bearing rather than
+    decorative.
+    """
+
+    def __init__(self, rects, *, strict_misses=False):
+        self.rects = rects
+        self.strict_misses = strict_misses
+        self.calls: list[tuple[float, float]] = []
+
+    async def describe_point(self, _udid, x, y):
+        self.calls.append((x, y))
+        for r in self.rects:
+            f = r["frame"]
+            if f["x"] <= x <= f["x"] + f["width"] and f["y"] <= y <= f["y"] + f["height"]:
+                return r
+        if self.strict_misses or not self.rects:
+            return None
+        return min(self.rects, key=lambda r: abs(
+            (r["frame"]["y"] + r["frame"]["height"] / 2) - y))
+
+
+def png_with_bands(bands, size=(400, 800)):
+    """A PNG whose only content is dark stripes at the given DEVICE-POINT ranges.
+
+    Screenshots come back at a device scale factor, so the fixture draws in
+    pixels from point coordinates exactly as a real capture would.
+    """
+    from PIL import Image, ImageDraw
+    image = Image.new("L", size, 255)
+    draw = ImageDraw.Draw(image)
+    scale = size[1] / SCREEN["height"]
+    for top, bottom in bands:
+        draw.rectangle([40, top * scale, size[0] - 40, bottom * scale], fill=0)
+    buf = io.BytesIO()
+    image.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def shot_of(bands):
+    async def _shot():
+        return png_with_bands(bands)
+    return _shot
+
+
+# --------------------------------------------------------------------------
+# The validity test
+# --------------------------------------------------------------------------
+
+def test_a_frame_that_does_not_contain_the_point_is_not_a_hit():
+    frame = {"x": 0, "y": 100, "width": 100, "height": 20}
+    assert web_probing.hit_contains(frame, 50, 110)
+    assert not web_probing.hit_contains(frame, 50, 300)
+    assert not web_probing.hit_contains(None, 50, 110)
+    assert not web_probing.hit_contains({"x": 0, "y": 0, "width": 0, "height": 0}, 0, 0)
+
+
+async def test_whitespace_answers_are_rejected():
+    """The failure this guards against is silent and plausible-looking.
+
+    A probe into blank space comes back with a real element that is simply
+    somewhere else. Recording it produces an element list that looks right and
+    places things where they are not, which is worse than finding nothing.
+    """
+    content = el("StaticText", "far away", 0, 700, 400, 20)
+    screen = FakeScreen([content])
+    # Aim at a band nowhere near the only element.
+    result = await web_probing.sweep_web_content(
+        SIM, screen.describe_point, shot_of([(100, 130)]), [el("Application", "", 0, 0, 400, 800)],
+    )
+    assert screen.calls, "it should have probed"
+    assert result.elements == [], "a nearest-element answer must not be recorded"
+
+
+# --------------------------------------------------------------------------
+# Finding content
+# --------------------------------------------------------------------------
+
+async def test_finds_content_the_native_tree_omits():
+    web = [
+        el("Heading", "Probe Web Heading", 20, 124, 360, 40),
+        el("StaticText", "Deterministic paragraph", 20, 184, 360, 22),
+        el("StaticText", "unclicked", 20, 240, 100, 22),
+        el("StaticText", "nested-span-target", 24, 260, 143, 22),
+    ]
+    screen = FakeScreen(web)
+    native = [el("Application", "", 0, 0, 400, 800)]
+    result = await web_probing.sweep_web_content(
+        SIM, screen.describe_point,
+        shot_of([(130, 155), (188, 202), (245, 258), (265, 278)]), native,
+    )
+    labels = {e["AXLabel"] for e in result.elements}
+    assert labels == {r["AXLabel"] for r in web}, f"found {labels}"
+
+
+async def test_native_elements_are_not_reported_as_web_content():
+    """The tree already reports these; repeating them would inflate every
+    screen summary with duplicates."""
+    chrome = el("Button", "Done", 20, 60, 60, 30)
+    screen = FakeScreen([chrome])
+    result = await web_probing.sweep_web_content(
+        SIM, screen.describe_point, shot_of([(60, 90)]),
+        [el("Application", "", 0, 0, 400, 800), chrome],
+    )
+    assert result.elements == []
+
+
+async def test_found_elements_are_tagged_with_their_source():
+    """tap_element needs to know which elements came from a probe so it can
+    re-verify one before acting on it."""
+    web = el("Link", "Mastodon", 20, 150, 200, 24)
+    screen = FakeScreen([web])
+    result = await web_probing.sweep_web_content(
+        SIM, screen.describe_point, shot_of([(150, 172)]),
+        [el("Application", "", 0, 0, 400, 800)],
+    )
+    assert result.elements[0]["extra_attrs"]["source"] == "web-probe"
+
+
+# --------------------------------------------------------------------------
+# Cost
+# --------------------------------------------------------------------------
+
+async def test_a_wide_element_is_probed_once_not_once_per_column():
+    """Coverage grows with each hit, so crossing bands and columns are free.
+    Without this the probe count multiplies by the column count."""
+    wide = el("StaticText", "spans the screen", 0, 300, 400, 60)
+    screen = FakeScreen([wide])
+    await web_probing.sweep_web_content(
+        SIM, screen.describe_point, shot_of([(305, 355)]),
+        [el("Application", "", 0, 0, 400, 800)],
+    )
+    assert len(screen.calls) == 1, f"probed {len(screen.calls)} times for one element"
+
+
+async def test_the_probe_budget_is_honoured():
+    rects = [el("StaticText", f"row {i}", 0, 100 + i * 30, 60, 20) for i in range(20)]
+    screen = FakeScreen(rects)
+    bands = [(100 + i * 30, 118 + i * 30) for i in range(20)]
+    result = await web_probing.sweep_web_content(
+        SIM, screen.describe_point, shot_of(bands),
+        [el("Application", "", 0, 0, 400, 800)], max_probes=5,
+    )
+    assert result.truncated
+    assert result.probes <= 5
+
+
+# --------------------------------------------------------------------------
+# Degrading honestly
+# --------------------------------------------------------------------------
+
+async def test_no_screenshot_reports_why_rather_than_sweeping_blindly():
+    async def no_shot():
+        return None
+    screen = FakeScreen([el("StaticText", "x", 0, 100, 50, 20)])
+    result = await web_probing.sweep_web_content(
+        SIM, screen.describe_point, no_shot, [el("Application", "", 0, 0, 400, 800)],
+    )
+    assert result.elements == []
+    assert result.reason and "screenshot" in result.reason
+    assert not screen.calls, "it must not fall back to probing at random"
+
+
+async def test_a_failing_probe_does_not_abort_the_sweep():
+    calls = {"n": 0}
+
+    async def flaky(_udid, x, y):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("sim-bridge: transient")
+        return el("StaticText", "second band", 0, 300, 400, 30)
+
+    result = await web_probing.sweep_web_content(
+        SIM, flaky, shot_of([(100, 130), (305, 325)]),
+        [el("Application", "", 0, 0, 400, 800)],
+    )
+    assert [e["AXLabel"] for e in result.elements] == ["second band"]
+
+
+def test_a_full_screen_container_does_not_mask_the_page():
+    """The cap that makes region detection work.
+
+    A labelled scroll view covering the screen would otherwise mark everything
+    as already-known and the sweep would probe nothing at all.
+    """
+    screen_rect = {"x": 0, "y": 0, "width": 400, "height": 800}
+    covered = web_probing.coverage_rects([
+        el("ScrollView", "Content", 0, 0, 400, 800),
+        el("Button", "Done", 20, 60, 60, 30),
+    ], screen_rect)
+    assert covered == [(20.0, 60.0, 60.0, 30.0)]
+
+
+def test_unlabelled_containers_contribute_no_coverage():
+    """The web view's host view is an unlabelled Group. If containers counted,
+    it would hide the very region this exists to search."""
+    screen_rect = {"x": 0, "y": 0, "width": 400, "height": 800}
+    assert web_probing.coverage_rects([el("Group", "", 0, 100, 400, 500)], screen_rect) == []
+
+
+@pytest.mark.parametrize("bands", [[(100, 140)], [(100, 140), (300, 340)]])
+def test_bands_are_returned_in_device_points(bands):
+    png = png_with_bands(bands, size=(800, 1600))     # 2x the point size
+    found = web_probing.content_bands(png, SCREEN)
+    assert found, "the detector found nothing in an image with obvious content"
+    for (want_top, want_bottom), (got_top, got_bottom) in zip(bands, found, strict=False):
+        assert abs(got_top - want_top) < 12, f"{got_top} vs {want_top}"
+        assert abs(got_bottom - want_bottom) < 12

--- a/tests/test_web_probing.py
+++ b/tests/test_web_probing.py
@@ -13,6 +13,7 @@ wrong from first principles:
 
 from __future__ import annotations
 
+import asyncio
 import io
 
 import pytest
@@ -284,3 +285,59 @@ async def test_vision_targets_are_probed_at_their_centres(monkeypatch):
     )
     assert screen.calls == [(90.0, 305.0)], f"probed {screen.calls}"
     assert [e["AXLabel"] for e in result.elements] == ["Servers"]
+
+
+# --------------------------------------------------------------------------
+# Web Inspector session handling
+# --------------------------------------------------------------------------
+
+async def test_a_failed_target_lookup_does_not_poison_the_session():
+    """Otherwise one timeout disables the page permanently.
+
+    Setup is skipped when a session is cached, and Target.targetCreated is only
+    announced when a session is established. Keeping a session whose target
+    never arrived means every later call waits for an event that cannot come.
+    """
+    from unittest.mock import AsyncMock
+
+    from server.device.webinspector import SimulatorWebInspector
+
+    insp = SimulatorWebInspector()
+    insp._send = AsyncMock()
+    insp._await_target = AsyncMock(return_value=None)
+
+    assert await insp._forward("PID:1", 1, "Runtime.evaluate", {}) is None
+    assert ("PID:1", 1) not in insp._sessions, "the dead session was kept"
+
+
+async def test_another_pages_traffic_is_ignored():
+    """An app can have several inspectable pages on one connection.
+
+    Metatext has two — a YouTube embed and the instance picker — and each
+    announces its own Target.targetCreated. Without filtering, opening a session
+    on one page can cache the other page's target and send every subsequent
+    message to the wrong document.
+    """
+    import json as _json
+
+    from server.device.webinspector import SimulatorWebInspector
+
+    insp = SimulatorWebInspector()
+    wanted = _json.dumps({"id": 7, "result": {"mine": True}}).encode()
+    other = _json.dumps({"id": 7, "result": {"mine": False}}).encode()
+
+    messages = [
+        {"__selector": "_rpc_applicationSentData:",
+         "__argument": {"WIRPageIdentifierKey": 2, "WIRMessageDataKey": other}},
+        {"__selector": "_rpc_applicationSentData:",
+         "__argument": {"WIRPageIdentifierKey": 1, "WIRMessageDataKey": wanted}},
+    ]
+
+    class Service:
+        async def recv_plist(self):
+            return messages.pop(0) if messages else None
+
+    insp._service = Service()
+    deadline = asyncio.get_running_loop().time() + 5
+    got = await insp._next_page_message(1, deadline)
+    assert got == {"id": 7, "result": {"mine": True}}, f"took another page's reply: {got}"


### PR DESCRIPTION
Quern could not see inside a `WKWebView` on iOS simulators. The tree walk stops at the web view — which is not merely empty in the tree, it is **absent entirely** — so a screen built on web content looked like native chrome and nothing else. That shaped real decisions: the earlier investigation concluded WDA was the only route, `workflow-app-knowledge.md` told readers to fall back to coordinate tapping, and a `tap_element` against a web page burned 55 seconds sweeping for something structurally invisible.

Two routes now work. Which applies is decided by the app, not by us.

## Route 1 — the Web Inspector (preferred)

`webinspector.py` merged unwired; this is the half that returns something. Against the probe app:

```
<h1>     id=web_heading    (24, 24 354x39)
<button> id=web_button     (24,120  85x20)  INTERACTIVE
<span>   id=web_nested     (24,160 142x20)
```

Real DOM ids, complete enumeration, an interactivity flag, and JS evaluation. **15ms.**

The protocol detail that cost the most: messages must be wrapped in `Target.sendMessageToTarget`, with replies inside `Target.dispatchMessageFromTarget`. A bare `Runtime.evaluate` is answered with *"'Runtime' domain was not found"*, which reads as "this WebKit has no JavaScript" rather than "you skipped a layer".

Verified on a **third-party page in a third-party app** — Metatext's instance picker, `joinmastodon.org/servers` — after a one-line debug-build change. It found the icon-only `Toggle menu` button, which has no text and is therefore invisible to every screenshot- or accessibility-based approach.

## Route 2 — accessibility hit-testing (fallback)

`describe_point` reaches web content even though the tree walk does not. Works on release builds and on apps that never opted in. Three targeting strategies were measured; two were discarded:

| | probes | time | found |
|---|---|---|---|
| blind lattice | 57 | 5.3s | 2 of 4, on a *simpler* page |
| nearest-hint following | — | **never terminated** in 300s | — |
| Vision-guided (`VNRecognizeTextRequest`) | **4** | **829ms** | 4 of 4 |

Vision runs in-process through pyobjc — no compile step, nothing to sign or ship. Language correction is off: it rewrites UI strings into dictionary words, and the text is matched against accessibility labels.

## The two routes compose

DOM geometry is viewport-relative and so not directly tappable. One hit-test anchors it: the heading reads `(24,24)` in the page and `(24,124)` on screen, and predicting the button's centre from the DOM then hit-testing there returns `Button "Web Button"`. The probe work is the calibration for the Inspector, not a competitor to it.

## Knowledge base

Screens gain a `web_content:` block — host, `in_process`, `inspectable`, `url`, `page_offset`. These are facts only the source can answer. `in_process` decides everything else: an app that constructs the view can opt it into inspection; one handed an `SFSafariViewController` cannot.

Also corrects `workflow-app-knowledge.md`, which still told readers to fall back to coordinates on iOS.

## Things worth knowing

- **A hit-test in whitespace returns the nearest element, not `None`.** `hit_contains` is the validity test; without it a sweep records elements that are not where it says they are. The fixture reproduces this deliberately.
- **Edge detection was the wrong primitive** for the pixel fallback: an edge filter marks a shape's *border*, so a solid-filled button arrives as two hairlines as far apart as the button is tall. Text hid it until a synthetic image exposed it. It uses difference-from-background now.
- **`probing.py` is untouched** beyond promoting `_frame_key` to a public `frame_key`, with the private name kept as an alias, so tab-bar probing on the hot `describe_all` path is byte-identical.
- OCR is lossy (`'fMastodon'`) — but it only *aims*; identity comes from the hit-test, so an error costs a mis-aimed probe rather than a wrong label.

## Not included

The route and MCP tool. This is the capability; the surface is a separate change, and worth deciding after review given the Inspector turned out to dominate the probe for the primary use case.

Suite: 1516.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for inspecting and extracting visible content from web-based screens.
  - Improved discovery of web content that is not exposed through standard accessibility data.
  - Added macOS Vision-based text recognition with fallback image analysis.
  - Added optional web-content configuration for documenting screen behavior.

- **Documentation**
  - Expanded guidance for iOS and Android web views, inspectability, URLs, accessibility, and page offsets.
  - Added examples and recommendations for documenting web-backed screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->