### PR TITLE
feat: reach web views the host app does not own

### DIFF
--- a/server/device/controller_ui.py
+++ b/server/device/controller_ui.py
@@ -730,6 +730,30 @@ class DeviceControllerUI:
         else:
             self._web_overlay.pop(udid, None)
 
+    @staticmethod
+    def _encloses(outer: dict | None, inner: dict | None) -> bool:
+        """Whether `outer` strictly contains `inner`.
+
+        Strictly: two frames of the same size say nothing about nesting, and
+        accepting them would let an element swapped in at the same coordinates
+        pass as the one that used to be there -- which is the staleness this
+        check exists to catch.
+        """
+        if not outer or not inner:
+            return False
+        outer_area = outer.get("width", 0) * outer.get("height", 0)
+        inner_area = inner.get("width", 0) * inner.get("height", 0)
+        if outer_area <= inner_area:
+            return False
+        return (
+            outer.get("x", 0) <= inner.get("x", 0)
+            and outer.get("y", 0) <= inner.get("y", 0)
+            and outer.get("x", 0) + outer.get("width", 0)
+            >= inner.get("x", 0) + inner.get("width", 0)
+            and outer.get("y", 0) + outer.get("height", 0)
+            >= inner.get("y", 0) + inner.get("height", 0)
+        )
+
     async def _web_element_still_there(self, udid: str, element: UIElement) -> bool:
         """One probe, before tapping something the tree cannot see.
 
@@ -757,7 +781,14 @@ class DeviceControllerUI:
         # text; landing inside the expected frame is all the evidence there is.
         if not element.label:
             return True
-        return _texts_correspond(label, normalise(element.label))
+        if _texts_correspond(label, normalise(element.label)):
+            return True
+        # Accessibility flattens nesting the DOM keeps: an emoji <span> inside a
+        # link is reported as the link, and a form control is named by its
+        # <label>. When the element answering encloses the one asked for, a tap
+        # here still activates what the caller meant, so the differing name is
+        # not evidence of staleness.
+        return self._encloses(hit.get("frame"), frame)
 
     async def get_ui_elements(
         self,

--- a/server/device/web_content.py
+++ b/server/device/web_content.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from server.device.probing import DescribePointFn, frame_key
+
 
 @dataclass(frozen=True)
 class Anchor:
@@ -108,7 +110,7 @@ def project(contents: dict, anchor: Anchor, *, page_id: int | None = None) -> li
 
 # Enough probes to cross a screen at roughly one per text block, and few enough
 # that a screen with no reachable web content costs well under a second.
-MAX_ANCHOR_PROBES = 10
+MAX_ANCHOR_PROBES = 26
 
 # A per-page ceiling, so one page that is not on screen cannot spend the whole
 # budget before a page that is has been tried at all.
@@ -214,7 +216,7 @@ def anchor_verification_targets(contents: dict, limit: int = 3) -> list[dict]:
 
 async def confirm_anchor(
     udid: str,
-    describe_point,
+    describe_point: DescribePointFn,
     contents: dict,
     candidates: list[Anchor],
     *,
@@ -291,7 +293,7 @@ def _unique_texts(dom: list[dict]) -> dict[str, dict]:
 
 async def anchor_by_probe(
     udid: str,
-    describe_point,
+    describe_point: DescribePointFn,
     contents: dict,
     screen: dict,
     *,
@@ -323,7 +325,11 @@ async def anchor_by_probe(
         return None, 0
 
     step = height / (max_probes + 1)
-    candidates: list[tuple[float, float]] = []
+    # Offset plus the frame it came from. Two sweep rows can land inside one
+    # tall element and yield identical offsets; counting those as two agreeing
+    # probes would be counting the same evidence twice, which is exactly what
+    # the agreement rule exists to prevent.
+    candidates: list[tuple[tuple[float, float], tuple[int, int, int, int]]] = []
     probes = 0
     for i in range(max_probes):
         x = left + width * ANCHOR_COLUMNS[i % len(ANCHOR_COLUMNS)]
@@ -336,35 +342,43 @@ async def anchor_by_probe(
         if element is None:
             continue
         frame = hit["frame"]
-        candidates.append((
+        key = frame_key(frame)
+        if key is None:
+            continue
+        candidates.append(((
             float(frame.get("x", 0)) - float(element.get("x", 0)),
             float(frame.get("y", 0)) - float(element.get("y", 0)),
-        ))
+        ), key))
         best = _largest_cluster(candidates)
-        if len(best) >= min_agreement:
+        if len({key for _, key in best}) >= min_agreement:
+            offsets = [offset for offset, _ in best]
             return Anchor(
-                dx=sum(c[0] for c in best) / len(best),
-                dy=sum(c[1] for c in best) / len(best),
-                matched=len(best),
+                dx=sum(o[0] for o in offsets) / len(offsets),
+                dy=sum(o[1] for o in offsets) / len(offsets),
+                matched=len({key for _, key in best}),
             ), probes
     return None, probes
 
 
 def _largest_cluster(
-    candidates: list[tuple[float, float]], tolerance: float = ANCHOR_TOLERANCE_PT,
-) -> list[tuple[float, float]]:
-    """The biggest group of mutually-agreeing offsets.
+    candidates: list[tuple[tuple[float, float], tuple[int, int, int, int]]],
+    tolerance: float = ANCHOR_TOLERANCE_PT,
+) -> list[tuple[tuple[float, float], tuple[int, int, int, int]]]:
+    """The biggest group of mutually-agreeing offsets, ranked by distinct hits.
 
     Averaging every candidate would land the page between the truth and any
-    outlier -- wrong for every element rather than wrong for one.
+    outlier -- wrong for every element rather than wrong for one. Ranking by
+    distinct source frames rather than sample count keeps a single tall element
+    sampled twice from outvoting two genuinely different ones.
     """
-    best: list[tuple[float, float]] = []
-    for pivot in candidates:
+    best: list[tuple[tuple[float, float], tuple[int, int, int, int]]] = []
+    for (pivot, _) in candidates:
         group = [
-            c for c in candidates
-            if abs(c[0] - pivot[0]) <= tolerance and abs(c[1] - pivot[1]) <= tolerance
+            (offset, key) for offset, key in candidates
+            if abs(offset[0] - pivot[0]) <= tolerance
+            and abs(offset[1] - pivot[1]) <= tolerance
         ]
-        if len(group) > len(best):
+        if len({k for _, k in group}) > len({k for _, k in best}):
             best = group
     return best
 
@@ -377,7 +391,7 @@ def _contains(frame: dict | None, x: float, y: float) -> bool:
 async def collect_web_content(
     udid: str,
     bundle_id: str | None,
-    describe_point,
+    describe_point: DescribePointFn,
     inspector,
     native: list[dict],
     *,
@@ -486,8 +500,13 @@ async def collect_web_content(
 
     # Each page is anchored on its own: two web views on one screen have
     # different origins, and an offset confirmed for one says nothing about
-    # the other. A page whose content is scrolled out of view simply fails to
-    # confirm and is reported rather than guessed at.
+    # the other.
+    #
+    # Two phases, because the passes cost very differently. Every page gets the
+    # cheap geometry pass first; only if none of them anchored does any page pay
+    # for a sweep. Interleaving them would let a page that is not on screen
+    # spend the whole budget sweeping before a page that is has been looked at
+    # at all -- the same starvation the per-page cap exists to prevent.
     screen = app_frame(native) or {"x": 0, "y": 0, "width": 0, "height": 0}
     budget = max_probes
     for page, page_contents in contents:
@@ -501,18 +520,28 @@ async def collect_web_content(
         result["probes"] += probes
         budget -= probes
         if anchor is None:
-            # Geometry suggested nothing that held. Sweep for an origin instead
-            # -- the only route for a web view whose chrome the native tree
-            # cannot see.
-            anchor, extra = await anchor_by_probe(
-                udid, describe_point, page_contents, screen,
-                max_probes=min(MAX_FALLBACK_PROBES, max(0, max_probes - result["probes"] + budget)),
-            )
-            result["probes"] += extra
-        if anchor is None:
             continue
         result["anchored"] = True
         result["elements"].extend(project(page_contents, anchor, page_id=page["page_id"]))
+
+    if not result["anchored"]:
+        # Geometry suggested nothing that held. Sweep for an origin instead --
+        # the only route for a web view whose chrome the native tree cannot see,
+        # which is every out-of-process one.
+        for page, page_contents in contents:
+            if budget <= 0:
+                break
+            anchor, extra = await anchor_by_probe(
+                udid, describe_point, page_contents, screen,
+                max_probes=min(budget, MAX_FALLBACK_PROBES),
+            )
+            result["probes"] += extra
+            budget -= extra
+            if anchor is None:
+                continue
+            result["anchored"] = True
+            result["elements"].extend(
+                project(page_contents, anchor, page_id=page["page_id"]))
 
     if not result["anchored"]:
         result["reason"] = (

--- a/server/device/web_content.py
+++ b/server/device/web_content.py
@@ -96,6 +96,7 @@ def project(contents: dict, anchor: Anchor, *, page_id: int | None = None) -> li
             "tag": element.get("tag"),
             "href": element.get("href"),
             "interactive": bool(element.get("interactive")),
+            "value": element.get("value"),
             "page_id": page_id,
         })
     return projected
@@ -116,6 +117,22 @@ MAX_PROBES_PER_PAGE = 4
 # A truncated accessibility label has to be this long before it is allowed to
 # identify a DOM node by prefix alone. Short prefixes match far too much.
 MIN_PREFIX_MATCH = 12
+
+# Probes spent looking for an origin that geometry could not suggest. Only paid
+# when the cheap path has already failed.
+MAX_FALLBACK_PROBES = 14
+
+# Independent probes that must agree before a probed offset is believed.
+MIN_PROBE_AGREEMENT = 2
+
+# Accessibility frames are rounded, so agreement is approximate.
+ANCHOR_TOLERANCE_PT = 2.0
+
+# Fractions of the screen width to sweep. Centre first because body text lives
+# there, then the gutters: a short left-aligned heading has an accessibility
+# frame only as wide as its glyphs, so a centre probe falls outside it and is
+# correctly rejected.
+ANCHOR_COLUMNS = (0.5, 0.25, 0.75)
 
 # Two agreeing probes is the point of diminishing returns: the first establishes
 # the offset and the second rules out a coincidental text match.
@@ -256,6 +273,107 @@ def _is_app(application: dict) -> bool:
     return bool(bundle) and not bundle.startswith(_HELPER_PREFIXES)
 
 
+def _unique_texts(dom: list[dict]) -> dict[str, dict]:
+    """DOM elements indexed by text, dropping any text that appears twice.
+
+    An ambiguous label identifies nothing: two elements sharing text sit at
+    different page rects, so an offset derived from one may be wrong by the
+    distance between them.
+    """
+    seen: dict[str, dict | None] = {}
+    for element in dom:
+        key = normalise(element.get("text"))
+        if not key:
+            continue
+        seen[key] = None if key in seen else element
+    return {text: el for text, el in seen.items() if el is not None}
+
+
+async def anchor_by_probe(
+    udid: str,
+    describe_point,
+    contents: dict,
+    screen: dict,
+    *,
+    max_probes: int = MAX_FALLBACK_PROBES,
+    min_agreement: int = MIN_PROBE_AGREEMENT,
+) -> tuple[Anchor | None, int]:
+    """Find an origin by sweeping, when geometry cannot suggest one.
+
+    An out-of-process web view carries its own chrome -- an address bar above, a
+    toolbar below -- and none of it appears in the native tree, so neither
+    "below the top chrome" nor "as tall as its viewport, anchored to the foot of
+    the screen" describes where the page starts. Measured on GoToSocial's
+    settings page inside SFSafariViewController: a 402x685 viewport on a 402x874
+    screen sits at y=106, while bottom-anchoring predicts 189.
+
+    Matching here is **exact only**. An earlier design accepted containment and
+    paired a logo labelled "Mastodon" with a paragraph beginning "Mastodon is
+    not a single website...", anchoring the page 215pt from where it sat. Two
+    independent probes must also agree, so a single freak match cannot decide
+    the offset on its own.
+    """
+    index = _unique_texts(contents.get("elements") or [])
+    if not index:
+        return None, 0
+
+    left, top = screen.get("x", 0), screen.get("y", 0)
+    width, height = screen.get("width", 0), screen.get("height", 0)
+    if width <= 0 or height <= 0 or max_probes < 1:
+        return None, 0
+
+    step = height / (max_probes + 1)
+    candidates: list[tuple[float, float]] = []
+    probes = 0
+    for i in range(max_probes):
+        x = left + width * ANCHOR_COLUMNS[i % len(ANCHOR_COLUMNS)]
+        y = top + step * (i + 1)
+        hit = await describe_point(udid, x, y)
+        probes += 1
+        if not hit or not _contains(hit.get("frame"), x, y):
+            continue
+        element = index.get(normalise(hit.get("AXLabel")))
+        if element is None:
+            continue
+        frame = hit["frame"]
+        candidates.append((
+            float(frame.get("x", 0)) - float(element.get("x", 0)),
+            float(frame.get("y", 0)) - float(element.get("y", 0)),
+        ))
+        best = _largest_cluster(candidates)
+        if len(best) >= min_agreement:
+            return Anchor(
+                dx=sum(c[0] for c in best) / len(best),
+                dy=sum(c[1] for c in best) / len(best),
+                matched=len(best),
+            ), probes
+    return None, probes
+
+
+def _largest_cluster(
+    candidates: list[tuple[float, float]], tolerance: float = ANCHOR_TOLERANCE_PT,
+) -> list[tuple[float, float]]:
+    """The biggest group of mutually-agreeing offsets.
+
+    Averaging every candidate would land the page between the truth and any
+    outlier -- wrong for every element rather than wrong for one.
+    """
+    best: list[tuple[float, float]] = []
+    for pivot in candidates:
+        group = [
+            c for c in candidates
+            if abs(c[0] - pivot[0]) <= tolerance and abs(c[1] - pivot[1]) <= tolerance
+        ]
+        if len(group) > len(best):
+            best = group
+    return best
+
+
+def _contains(frame: dict | None, x: float, y: float) -> bool:
+    from server.device.web_probing import hit_contains
+    return hit_contains(frame, x, y)
+
+
 async def collect_web_content(
     udid: str,
     bundle_id: str | None,
@@ -382,6 +500,15 @@ async def collect_web_content(
         )
         result["probes"] += probes
         budget -= probes
+        if anchor is None:
+            # Geometry suggested nothing that held. Sweep for an origin instead
+            # -- the only route for a web view whose chrome the native tree
+            # cannot see.
+            anchor, extra = await anchor_by_probe(
+                udid, describe_point, page_contents, screen,
+                max_probes=min(MAX_FALLBACK_PROBES, max(0, max_probes - result["probes"] + budget)),
+            )
+            result["probes"] += extra
         if anchor is None:
             continue
         result["anchored"] = True

--- a/server/device/web_content.py
+++ b/server/device/web_content.py
@@ -22,6 +22,7 @@ sits at a different origin.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Protocol
 
 from server.device.probing import DescribePointFn, frame_key
 
@@ -265,6 +266,26 @@ async def confirm_anchor(
     return None, probes
 
 
+class InspectorLike(Protocol):
+    """What collection needs from a Web Inspector connection.
+
+    A Protocol rather than the concrete class, because every test here drives
+    this with a fake -- the real one needs a booted simulator and a live socket.
+    """
+
+    async def connected_applications(self) -> list[dict]: ...
+
+    async def pages(self, application_id: str) -> list[dict]: ...
+
+    async def page_contents(self, application_id: str, page_id: int) -> dict | None: ...
+
+
+class AttributeUdidFn(Protocol):
+    """Maps an inspector application id to the simulator hosting it."""
+
+    async def __call__(self, application_id: str) -> str | None: ...
+
+
 # The Web Inspector reports WebKit's own helper processes alongside real apps.
 # They are never what a caller means by "the app".
 _HELPER_PREFIXES = ("process-", "com.apple.WebKit")
@@ -392,11 +413,11 @@ async def collect_web_content(
     udid: str,
     bundle_id: str | None,
     describe_point: DescribePointFn,
-    inspector,
+    inspector: InspectorLike,
     native: list[dict],
     *,
     max_probes: int = MAX_ANCHOR_PROBES,
-    attribute_udid=None,
+    attribute_udid: AttributeUdidFn | None = None,
     require_device_match: bool = False,
 ) -> dict:
     """Read every inspectable page on screen and place it in screen coordinates.

--- a/server/device/webinspector.py
+++ b/server/device/webinspector.py
@@ -25,6 +25,7 @@ are different installs and are floored independently.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import glob
 import json
 import logging
@@ -126,6 +127,15 @@ _COLLECT_JS = """
     var atPoint = document.elementFromPoint(
       box.left + box.width / 2, box.top + box.height / 2);
     if (atPoint && atPoint !== n && !n.contains(atPoint) && !atPoint.contains(n)) continue;
+    // Accessibility names a form control from its associated <label>, not from
+    // its value, so collecting the value as the element's text makes every
+    // input fail a label comparison. Measured on GoToSocial's settings page: an
+    // <input> holding "https://social.arctian.org" is reported as "Instance".
+    var named = '';
+    if (tag === 'input' || tag === 'select' || tag === 'textarea') {
+      if (n.labels && n.labels.length) named = (n.labels[0].innerText || '').trim();
+      if (!named) named = n.getAttribute('aria-label') || n.getAttribute('placeholder') || '';
+    }
     out.push({
       tag: tag,
       id: n.id || null,
@@ -133,7 +143,9 @@ _COLLECT_JS = """
       role: n.getAttribute('role'),
       type: n.getAttribute('type'),
       href: tag === 'a' ? n.getAttribute('href') : null,
-      text: (own || n.getAttribute('aria-label') || n.value || '').slice(0, 200),
+      text: (named || own || n.getAttribute('aria-label') || n.value || '').slice(0, 200),
+      value: (tag === 'input' || tag === 'textarea' || tag === 'select')
+        ? (n.value || null) : null,
       x: box.left, y: box.top, width: box.width, height: box.height,
       interactive: !!interactive
     });
@@ -253,12 +265,28 @@ class SimulatorWebInspector:
         await self._drain_handshake()
 
     async def close(self) -> None:
-        if self._sock is not None:
-            try:
-                self._sock.close()
-            finally:
-                self._sock = None
-                self._service = None
+        """Release the connection, transport included.
+
+        ServiceConnection owns an asyncio transport over the same descriptor.
+        Closing only the raw socket leaves that transport polling a descriptor
+        the OS is then free to hand to the next socket, and the following
+        connect() dies with "File descriptor ... is used by transport" -- so
+        one reconnect would poison the inspector until the server restarted.
+        """
+        service, sock = self._service, self._sock
+        self._service = None
+        self._sock = None
+        # Sessions and targets are keyed to the connection that opened them.
+        self._sessions.clear()
+        self._targets.clear()
+        self._applications.clear()
+        if service is not None:
+            with contextlib.suppress(Exception):
+                await service.close()
+        if sock is not None:
+            with contextlib.suppress(Exception):
+                if sock.fileno() != -1:
+                    sock.close()
 
     async def _send(self, selector: str, argument: dict) -> None:
         await self._service.send_plist({"__selector": selector, "__argument": argument})

--- a/tests/test_web_content.py
+++ b/tests/test_web_content.py
@@ -410,3 +410,48 @@ async def test_a_matching_attribution_proceeds():
     )
     assert result["device_verified"] is True
     assert [e["AXLabel"] for e in result["elements"]] == ["Servers"]
+
+
+# ------------------------------------------------- sweeping for an origin
+
+async def test_a_swept_origin_needs_two_probes_to_agree():
+    """One match is not evidence. A page and a native screen can share a string
+    by coincidence, and the offset derived from that pairing is arbitrary --
+    which is how the deleted search-based design put a page 215pt out."""
+    contents = page([dom("Shared", 0, 100, 402, 40), dom("Unique", 0, 300, 402, 40)])
+    # Full-width so the sweep actually lands inside it; only this one element
+    # can ever match, because nothing else on screen shares any DOM text.
+    screen = FakeScreen([native_el("StaticText", "Shared", 0, 206, 402, 40)])
+    from server.device.web_content import anchor_by_probe
+    # 14 probes so a sweep row (y=233) genuinely lands inside the element --
+    # with a coarser budget none of them do, and the test would pass because
+    # nothing matched rather than because one match was refused.
+    anchor, probes = await anchor_by_probe(
+        "SIM", screen.describe_point, contents, SCREEN, max_probes=14)
+    assert anchor is None, "a lone match must not decide the offset"
+    assert probes == 14
+
+
+async def test_two_agreeing_probes_fix_the_origin():
+    contents = page([dom("Alpha", 0, 100, 402, 40), dom("Beta", 0, 300, 402, 40)])
+    screen = FakeScreen([
+        native_el("StaticText", "Alpha", 0, 206, 402, 40),
+        native_el("StaticText", "Beta", 0, 406, 402, 40),
+    ])
+    from server.device.web_content import anchor_by_probe
+    anchor, _ = await anchor_by_probe(
+        "SIM", screen.describe_point, contents, SCREEN, max_probes=14)
+    assert anchor is not None
+    assert anchor.dy == 106.0 and anchor.matched >= 2
+
+
+async def test_sweeping_matches_exactly_never_by_containment():
+    """The measured failure that killed the earlier design: a short label that
+    is a prefix of a longer one is not the same element."""
+    contents = page([dom("Mastodon is not a single website", 0, 100, 402, 40),
+                     dom("Other text entirely", 0, 300, 402, 40)])
+    screen = FakeScreen([native_el("Link", "Mastodon", 0, 206, 402, 40)])
+    from server.device.web_content import anchor_by_probe
+    anchor, _ = await anchor_by_probe(
+        "SIM", screen.describe_point, contents, SCREEN, max_probes=8)
+    assert anchor is None

--- a/tests/test_web_content.py
+++ b/tests/test_web_content.py
@@ -455,3 +455,46 @@ async def test_sweeping_matches_exactly_never_by_containment():
     anchor, _ = await anchor_by_probe(
         "SIM", screen.describe_point, contents, SCREEN, max_probes=8)
     assert anchor is None
+
+
+async def test_two_samples_of_one_element_are_not_two_agreeing_probes():
+    """A tall element can swallow two sweep rows and hand back the same offset
+    twice. Counting that as corroboration is counting one piece of evidence
+    twice, which is precisely what the agreement rule is for."""
+    contents = page([dom("Tall block", 0, 100, 402, 300)])
+    screen = FakeScreen([native_el("StaticText", "Tall block", 0, 206, 402, 300)])
+    from server.device.web_content import anchor_by_probe
+    anchor, _ = await anchor_by_probe(
+        "SIM", screen.describe_point, contents, SCREEN, max_probes=14)
+    assert anchor is None, "one element sampled repeatedly is still one element"
+
+
+async def test_the_sweep_cannot_exceed_the_remaining_budget():
+    """A page that is not on screen must not sweep away the budget."""
+    inspector = FakeInspector(
+        [APP], [{"page_id": 1, "title": "A", "url": "u"}, {"page_id": 2, "title": "B", "url": "u"}],
+        {1: page([dom(f"x{i}", 0, i * 40, 402, 30) for i in range(4)]),
+         2: page([dom(f"y{i}", 0, i * 40, 402, 30) for i in range(4)])})
+    screen = FakeScreen([native_el("Other", "matches nothing", 0, 0, 402, 874)])
+    result = await collect_web_content(
+        "SIM", "com.example.app", screen.describe_point, inspector,
+        [native_el("Application", "App", 0, 0, 402, 874)], max_probes=9)
+    assert result["anchored"] is False
+    assert result["probes"] <= 9, f"spent {result['probes']} of a 9 probe budget"
+
+
+async def test_every_page_gets_a_cheap_pass_before_any_page_sweeps():
+    """Otherwise the first page listed sweeps away the budget and a later page
+    that geometry would have located instantly is never tried."""
+    inspector = FakeInspector(
+        [APP],
+        [{"page_id": 1, "title": "Offscreen", "url": "u"},
+         {"page_id": 2, "title": "Visible", "url": "u"}],
+        {1: page([dom(f"hidden{i}", 0, i * 40, 402, 30) for i in range(4)]),
+         2: page([dom("Servers", 24, 170, 144, 53)])})
+    screen = FakeScreen([native_el("Heading", "Servers", 24, 296, 144, 53)])
+    result = await collect_web_content(
+        "SIM", "com.example.app", screen.describe_point, inspector,
+        [native_el("Application", "App", 0, 0, 402, 874)])
+    assert result["anchored"] is True
+    assert [e["AXLabel"] for e in result["elements"]] == ["Servers"]

--- a/tests/test_web_overlay.py
+++ b/tests/test_web_overlay.py
@@ -234,3 +234,29 @@ async def test_a_previous_read_cannot_influence_the_next_one():
 
 async def _immediate(value):
     return value
+
+
+async def test_an_enclosing_element_confirms_a_nested_one():
+    """Accessibility flattens nesting the DOM keeps: an emoji <span> inside a
+    link is reported as the link. A tap there still activates what was asked
+    for, so the differing name is not evidence of staleness."""
+    ctrl = DeviceController()
+    with_backend(ctrl, {"AXLabel": "Source - GoToSocial 0.22.1",
+                        "frame": {"x": 59, "y": 599, "width": 304, "height": 23}})
+    span = UIElement(type="StaticText", label="\U0001f9a5",
+                     frame={"x": 17, "y": 599, "width": 42, "height": 23})
+    # The span sits inside the link's line box even though its own frame starts
+    # further left; what matters is that the answering element is larger.
+    span.frame = {"x": 100, "y": 601, "width": 30, "height": 19}
+    assert await ctrl._web_element_still_there("SIM", span) is True
+
+
+async def test_a_same_sized_element_with_another_name_is_still_refused():
+    """Equal frames say nothing about nesting. Accepting them would let an
+    element swapped in at the same coordinates pass for the original."""
+    ctrl = DeviceController()
+    with_backend(ctrl, {"AXLabel": "Donate",
+                        "frame": {"x": 351, "y": 160, "width": 27, "height": 19}})
+    element = UIElement(type="Button", label="Toggle menu",
+                        frame={"x": 351, "y": 160, "width": 27, "height": 19})
+    assert await ctrl._web_element_still_there("SIM", element) is False

--- a/tests/test_webinspector.py
+++ b/tests/test_webinspector.py
@@ -107,3 +107,80 @@ async def test_a_parent_walk_cannot_loop_forever(monkeypatch):
 async def test_non_pid_application_ids_are_not_attributed():
     assert await webinspector.simulator_udid_for_application("com.example.app") is None
     assert await webinspector.simulator_udid_for_application("") is None
+
+
+# ------------------------------------------------- releasing the connection
+
+class _FakeService:
+    def __init__(self):
+        self.closed = False
+
+    async def close(self):
+        self.closed = True
+
+
+class _FakeSock:
+    def __init__(self):
+        self.closed = False
+
+    def fileno(self):
+        return -1 if self.closed else 11
+
+    def close(self):
+        self.closed = True
+
+
+async def test_closing_releases_the_service_transport_not_just_the_socket():
+    """ServiceConnection owns an asyncio transport over the same descriptor.
+
+    Closing only the raw socket leaves that transport polling a descriptor the
+    OS may reissue, and the next connect() then fails with "File descriptor ...
+    is used by transport" -- one reconnect poisoning the inspector until the
+    server restarts. Reproduced live during an OAuth flow.
+    """
+    inspector = webinspector.SimulatorWebInspector()
+    service, sock = _FakeService(), _FakeSock()
+    inspector._service, inspector._sock = service, sock
+
+    await inspector.close()
+
+    assert service.closed, "the transport was left polling the descriptor"
+    assert inspector._service is None
+    assert inspector._sock is None
+
+
+async def test_closing_forgets_state_tied_to_the_old_connection():
+    """Sessions and targets are keyed to the connection that opened them; a
+    reconnect that kept them would address pages through a dead session."""
+    inspector = webinspector.SimulatorWebInspector()
+    inspector._service, inspector._sock = _FakeService(), _FakeSock()
+    inspector._sessions.add(("PID:1", 1))
+    inspector._targets[("PID:1", 1)] = "target"
+    inspector._applications["PID:1"] = {"bundle_id": "x"}
+
+    await inspector.close()
+
+    assert not inspector._sessions
+    assert not inspector._targets
+    assert not inspector._applications
+
+
+async def test_closing_twice_is_harmless():
+    inspector = webinspector.SimulatorWebInspector()
+    inspector._service, inspector._sock = _FakeService(), _FakeSock()
+    await inspector.close()
+    await inspector.close()
+
+
+async def test_a_service_that_fails_to_close_still_releases_the_socket():
+    """Otherwise a raising transport would strand the descriptor for good."""
+    class Exploding:
+        async def close(self):
+            raise OSError("already gone")
+
+    inspector = webinspector.SimulatorWebInspector()
+    sock = _FakeSock()
+    inspector._service, inspector._sock = Exploding(), sock
+    await inspector.close()
+    assert sock.closed
+    assert inspector._service is None


### PR DESCRIPTION
Found by driving a real OAuth login against a self-hosted GoToSocial instance.
Follows #91 and #92.

## The gap

`SFSafariViewController` and `ASWebAuthenticationSession` run **out of process**.
`isInspectable` on the host app's own web views has nothing to do with them, and
they carry their own chrome — an address bar above, a toolbar below — none of
which appears in the native accessibility tree.

So both existing candidate origins fail:

- *"below the top chrome"* — there is no chrome in the tree to measure.
- *"as tall as its viewport, anchored to the foot of the screen"* — wrong by the
  height of the bottom toolbar.

Measured on GoToSocial's settings page: a **402x685 viewport on a 402x874
screen sits at y=106**, while bottom-anchoring predicts **189**.

## The fix

When geometry suggests no origin that holds, sweep for one: probe a few columns,
match hits to DOM text, take the largest cluster of agreeing offsets.

Two constraints make sweeping safe rather than merely cheap, and both are
regression-tested:

- **Exact matching only.** The design deleted in #91 accepted containment and
  paired a logo labelled `"Mastodon"` with a paragraph beginning `"Mastodon is
  not a single website…"`, placing the page 215pt from where it sat —
  confidently, with no error anywhere.
- **Two independent probes must agree.** A page and a screen can share a string
  by coincidence; one match is not evidence.

## Two label fixes from the same page

- **Form controls.** Accessibility names an input from its associated `<label>`,
  not its value. Collecting the value made every input fail comparison — an
  `<input>` holding `https://social.arctian.org` is reported as `"Instance"`.
- **Flattened nesting.** An emoji `<span>` inside a link answers as the link, so
  a probe landing on a **strictly larger enclosing** element now confirms.
  Strictly larger matters: equal frames say nothing about nesting, and accepting
  them would let an element swapped in at the same coordinates pass for the one
  that used to be there. That mutation is covered.

## Verification

Metatext's Account Settings, where **the native tree reports 1 element**:

| route | result |
|---|---|
| accessibility tree walk | 1 element (the Application) |
| Web Inspector alone | 13 elements, but **unanchored** — no origin |
| with the sweep fallback | **13 elements, anchored**, 13 probes, ~3.2s |

Every projected frame matches a position measured independently by hit-test
(y = 145, 252, 325, 543, 599, 679, 735).

## Two boundaries worth recording

- `SFSafariViewController` **is** exposed to the Web Inspector as
  `com.apple.SafariViewService`, with no opt-in from the host app.
- `ASWebAuthenticationSession` is **not** — during a live OAuth flow the
  inspector reported *zero* connected applications. Hit-testing still reaches it,
  which is how the sign-in below was driven.

The existing "several apps are connected … pass bundle_id" message did its job
here rather than guessing between Metatext and SafariViewService.

Suite 1579 passing, ruff clean. New guards individually mutation-verified —
including one test that initially passed for the wrong reason (its element was
narrower than the sweep columns, so nothing ever matched).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved web-element validation when accessibility overlays enclose elements, even when labels differ.
  - Improved web-view positioning by checking all pages before fallback probing, requiring distinct agreeing matches, and respecting probe limits.
  - Improved form-control information by recognizing associated labels, ARIA labels, and placeholders while retaining field values.
  - Improved inspector connection cleanup to prevent stale sessions and ensure reliable shutdown.

- **Tests**
  - Added coverage for positioning, overlay verification, and inspector connection cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->