### PR TITLE
feat: record what a web view already taught us

### DIFF
--- a/docs/app-knowledge-guide.md
+++ b/docs/app-knowledge-guide.md
@@ -246,45 +246,80 @@ This is a separate issue from identifier reliability. The label is *correct*, bu
 ### Documenting Web Views
 
 A screen built on web content looks almost empty to `get_ui_tree`: on iOS the
-accessibility tree does not descend into a `WKWebView`, and the out-of-process
-hosts are not in the app's hierarchy at all. The failure mode is a
-misdiagnosis, not an error — a near-empty tree reads as "the screen failed to
-load" or "every landmark drifted", and the agent goes looking for a problem
-that isn't there.
+accessibility tree does not descend into a `WKWebView`, and out-of-process hosts
+are not in the app's hierarchy at all — a settings page presented in
+`SFSafariViewController` reports **one** element, the Application. The failure
+mode is a misdiagnosis, not an error: a near-empty tree reads as "the screen
+failed to load" or "every landmark drifted", and the agent goes looking for a
+problem that isn't there.
 
-Record it in the screen's `web_content:` block. The facts that matter are ones
-only the source can answer, which is exactly what a knowledge base is for.
+`get_web_content` reads the page and returns its elements with real screen
+frames. What it cannot work out for itself is which process hosts the view and
+whether it can be inspected at all — so record that.
 
 ```yaml
 web_content:
-  - host: "WKWebView"
-    in_process: true
-    inspectable: "debug"
-    url: "https://joinmastodon.org/servers"
-    page_offset: [0, 100]
+  - host: "SFSafariViewController"
+    process: "com.apple.SafariViewService"
+    reachable_by: [inspector, hit_test]
+    url: "https://social.arctian.org/settings"
+    anchor:
+      origin: [0, 106]
+      viewport: [402, 685]
+      measured_on: "iPhone 16 Pro - iOS 18.6"
 ```
 
-**`in_process` decides everything else.** When the app constructs the view, it
-can opt it into remote inspection and the page's own DOM becomes available.
-When the system constructs it — `SFSafariViewController`,
-`ASWebAuthenticationSession` — the app has no handle on it, so that route is
-closed no matter what the app does.
+**`reachable_by` is the field worth having.** There are three cases and they do
+not follow the rule you would guess:
 
-**`inspectable` is about the view, not the content.** Since iOS 16.4 a
-`WKWebView` is only inspectable if the app sets `isInspectable` on it. That is
-the app's decision about a view it owns, so it can be true even when the HTML
-comes from a third party the team has no control over. Use `"debug"` when it is
-behind `#if DEBUG`, which is where it belongs.
+| view | Web Inspector | hit-test |
+|---|---|---|
+| in-process `WKWebView` | yes — but only if the app sets `isInspectable` | yes |
+| `SFSafariViewController` | **yes, with no opt-in from the app** | yes |
+| `ASWebAuthenticationSession` | **no — reports no connected application at all** | yes |
 
-**Why record `page_offset`.** DOM geometry is viewport-relative, so it cannot be
-tapped directly. One accessibility hit-test on any element recovers the offset
-between page and screen space; writing it down saves doing that every session.
-Re-derive it if the screen's layout changes.
+The middle row is the surprising one. The app has no handle on a
+`SFSafariViewController`, yet WebKit still publishes it for inspection under
+`com.apple.SafariViewService`. The bottom row is the one to record loudest:
+while an auth session is presented the inspector reports *zero* connected
+applications, so an agent that assumes "system-presented means
+SafariViewService" wastes a call. Hit-testing reaches all three.
+
+**`process` is what to pass as `bundle_id`.** An out-of-process view is hosted
+by `com.apple.SafariViewService`, not by the app. Without it `get_web_content`
+sees two connected applications and asks which one you meant.
+
+**`isInspectable` is per view, not per app.** Since iOS 16.4 an app's own
+`WKWebView` is inspectable only if the app sets it on *that instance*, so one
+view opting in says nothing about another in the same app. Put it behind
+`#if DEBUG`, which is where it belongs.
+
+**`anchor` is a hint, never a fact.** DOM geometry is viewport-relative, and
+nothing in the protocol says where the view sits on screen. The offset depends
+on device size, iOS version and text size, so a recorded one is offered as the
+first candidate and confirmed by a single probe — if it no longer holds it is
+discarded and the ordinary search runs. Recording it is still worth it: an
+out-of-process page took a **17-probe sweep and ~3.5s** to locate cold, against
+**1 probe and ~0.2s** once written down. Out-of-process views need this most,
+because they carry their own chrome at both ends and none of it is in the native
+tree, so geometry cannot even guess.
+
+**Where to get the values.** `get_web_content` returns them under `anchors`,
+ready to paste:
+
+```json
+{"page_id": 3, "url": "https://social.arctian.org/settings",
+ "origin": [0, 106], "viewport": [402, 685], "strategy": "sweep"}
+```
+
+A `strategy` of `hint` means the recorded value was used and confirmed;
+`geometry` or `sweep` means it was rediscovered, which is the signal to write
+the new value down.
 
 **Note when the URL is third-party.** It can change without an app release —
-the example above moved from `/communities` to `/servers` between knowledge-base
-revisions. Prefer structural selectors (`h1`, `button[aria-label]`) over text
-the site can reword.
+the Mastodon instance picker moved from `/communities` to `/servers` between
+knowledge-base revisions. Prefer structural selectors (`h1`,
+`button[aria-label]`) over text the site can reword.
 
 None of this applies on Android, where the accessibility tree does descend into
 a `WebView` and web content appears as ordinary elements.

--- a/server/api/device_ui.py
+++ b/server/api/device_ui.py
@@ -401,7 +401,13 @@ async def get_web_content(request: Request, body: WebContentRequest) -> dict:
 
     controller = _get_controller(request)
     try:
-        result = await controller.get_web_content(udid=body.udid, bundle_id=body.bundle_id)
+        # Matching is by page URL, so every loaded app's hints are equally
+        # usable and the knowledge-base app name does not need to be known here.
+        registry = getattr(request.app.state, "landmark_registry", None)
+        hints = registry.web_content() if registry is not None else None
+        result = await controller.get_web_content(
+            udid=body.udid, bundle_id=body.bundle_id, hints=hints,
+        )
         elapsed = (time.perf_counter() - start) * 1000
         logger.info(
             f"[PERF] API /ui/web-content SUCCESS: {elapsed:.1f}ms, "

--- a/server/device/controller_ui.py
+++ b/server/device/controller_ui.py
@@ -1702,6 +1702,7 @@ class DeviceControllerUI:
         self,
         udid: str | None = None,
         bundle_id: str | None = None,
+        hints: list | None = None,
     ) -> dict:
         """Read web content the accessibility tree cannot see.
 
@@ -1755,6 +1756,7 @@ class DeviceControllerUI:
                 inspector, native,
                 attribute_udid=simulator_udid_for_application,
                 require_device_match=require_match,
+                hints=hints,
             )
 
         # One transaction at a time: the connection is shared, and a retry

--- a/server/device/landmarks.py
+++ b/server/device/landmarks.py
@@ -377,9 +377,14 @@ def _parse_web_content(raw: object, screen: str) -> list[WebContentHint]:
     for entry in raw:
         if not isinstance(entry, dict):
             continue
+        # The screen name comes from the file, not the entry. Passing both
+        # raises TypeError for a duplicate keyword before Pydantic ever runs,
+        # and that is not a ValidationError -- one entry carrying a stray
+        # `screen:` would abort the whole scan rather than be skipped.
+        fields = {k: v for k, v in entry.items() if k != "screen"}
         try:
-            hints.append(WebContentHint(screen=screen, **entry))
-        except ValidationError:
+            hints.append(WebContentHint(screen=screen, **fields))
+        except (ValidationError, TypeError):
             logger.warning("Ignoring malformed web_content entry in %s", screen)
     return hints
 

--- a/server/device/landmarks.py
+++ b/server/device/landmarks.py
@@ -9,8 +9,14 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+from pydantic import ValidationError
 
-from server.models import Landmark, ScreenLandmarks, UIElement
+from server.models import (
+    Landmark,
+    ScreenLandmarks,
+    UIElement,
+    WebContentHint,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +57,12 @@ class ParseResult:
 
     screen: ScreenLandmarks | None = None
     skip: SkippedFile | None = None
+    web_content: list[WebContentHint] = field(default_factory=list)
+    """Carried on both paths deliberately. The screens that most need a web
+    content hint -- an OAuth view, a settings page behind
+    SFSafariViewController -- are exactly the ones with no native landmarks, so
+    a hint attached only to successful parses would never reach the cases it
+    exists for."""
 
 
 @dataclass
@@ -59,6 +71,7 @@ class KnowledgeBaseScan:
 
     screens: list[ScreenLandmarks] = field(default_factory=list)
     skipped: list[SkippedFile] = field(default_factory=list)
+    web_content: list[WebContentHint] = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -316,6 +329,7 @@ def parse_screen_landmarks(
         ))
 
     screen_name = data.get("screen", "") or file_path.stem
+    hints = _parse_web_content(data.get("web_content"), screen_name)
 
     raw_landmarks = data.get("landmarks")
     if not raw_landmarks or not isinstance(raw_landmarks, list):
@@ -329,10 +343,10 @@ def parse_screen_landmarks(
             return ParseResult(skip=SkippedFile(
                 file=label, screen=screen_name, reason="legacy_format",
                 identify_by=list(identify_by),
-            ))
+            ), web_content=hints)
         return ParseResult(skip=SkippedFile(
             file=label, screen=screen_name, reason="no_landmarks",
-        ))
+        ), web_content=hints)
 
     landmarks: list[Landmark] = []
     for entry in raw_landmarks:
@@ -343,11 +357,31 @@ def parse_screen_landmarks(
     if not landmarks:
         return ParseResult(skip=SkippedFile(
             file=label, screen=screen_name, reason="invalid_entries",
-        ))
+        ), web_content=hints)
 
     return ParseResult(
         screen=ScreenLandmarks(screen=screen_name, landmarks=landmarks),
+        web_content=hints,
     )
+
+
+def _parse_web_content(raw: object, screen: str) -> list[WebContentHint]:
+    """Read a screen's web_content: block, skipping anything malformed.
+
+    A bad hint must never stop a knowledge base loading: it is an optimisation,
+    and every value in it is verified before use.
+    """
+    if not isinstance(raw, list):
+        return []
+    hints: list[WebContentHint] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        try:
+            hints.append(WebContentHint(screen=screen, **entry))
+        except ValidationError:
+            logger.warning("Ignoring malformed web_content entry in %s", screen)
+    return hints
 
 
 def scan_knowledge_base(path: Path) -> KnowledgeBaseScan:
@@ -370,6 +404,7 @@ def scan_knowledge_base(path: Path) -> KnowledgeBaseScan:
         if md_file.name.startswith("_"):
             continue
         result = parse_screen_landmarks(md_file, base_path=path)
+        scan.web_content.extend(result.web_content)
         if result.screen is not None:
             scan.screens.append(result.screen)
         elif result.skip is not None:
@@ -387,6 +422,7 @@ class LandmarkRegistry:
 
     def __init__(self) -> None:
         self._sets: dict[str, list[ScreenLandmarks]] = {}
+        self._web_content: dict[str, list[WebContentHint]] = {}
 
     def load(self, app: str, screens: list[ScreenLandmarks]) -> int:
         """Load landmarks for an app. Replaces any existing set for that app.
@@ -407,7 +443,14 @@ class LandmarkRegistry:
         """
         scan = scan_knowledge_base(Path(path))
         count = self.load(app, scan.screens)
+        self._web_content[app] = scan.web_content
         return count, scan.skipped
+
+    def web_content(self, app: str | None = None) -> list[WebContentHint]:
+        """Recorded web view facts, for one app or all of them."""
+        if app is not None:
+            return list(self._web_content.get(app, []))
+        return [hint for hints in self._web_content.values() for hint in hints]
 
     def unload(self, app: str | None = None) -> str:
         """Unload landmarks. If app is None, unload all.
@@ -416,8 +459,10 @@ class LandmarkRegistry:
         """
         if app is None:
             self._sets.clear()
+            self._web_content.clear()
             return "all"
         self._sets.pop(app, None)
+        self._web_content.pop(app, None)
         return app
 
     def list_sets(self) -> dict[str, int]:

--- a/server/device/web_content.py
+++ b/server/device/web_content.py
@@ -600,32 +600,36 @@ async def collect_web_content(
                          MAX_PROBES_PER_PAGE, "geometry"):
             located.add(page["page_id"])
 
-    if not result["anchored"]:
-        # Nothing geometry suggested held. Sweep for an origin instead -- the
-        # only route for a web view whose chrome the native tree cannot see,
-        # which is every out-of-process one.
-        for page, page_contents in contents:
-            if budget <= 0:
-                break
-            anchor, extra = await anchor_by_probe(
-                udid, describe_point, page_contents, screen,
-                max_probes=min(budget, MAX_FALLBACK_PROBES),
-            )
-            result["probes"] += extra
-            budget -= extra
-            if anchor is None:
-                continue
-            result["anchored"] = True
-            result["elements"].extend(
-                project(page_contents, anchor, page_id=page["page_id"]))
-            viewport = page_contents.get("viewport") or {}
-            result["anchors"].append({
-                "page_id": page["page_id"],
-                "url": page.get("url"),
-                "origin": [round(anchor.dx, 1), round(anchor.dy, 1)],
-                "viewport": [viewport.get("width"), viewport.get("height")],
-                "strategy": "sweep",
-            })
+    # Sweep whatever is still unlocated. Gated on the page rather than on
+    # whether anything anchored at all: two web views can be on screen together,
+    # and one of them being found cheaply is no reason to leave the other
+    # unreachable. This is the only route for a view whose chrome the native
+    # tree cannot see, which is every out-of-process one.
+    for page, page_contents in contents:
+        if page["page_id"] in located:
+            continue
+        if budget <= 0:
+            break
+        anchor, extra = await anchor_by_probe(
+            udid, describe_point, page_contents, screen,
+            max_probes=min(budget, MAX_FALLBACK_PROBES),
+        )
+        result["probes"] += extra
+        budget -= extra
+        if anchor is None:
+            continue
+        result["anchored"] = True
+        result["elements"].extend(
+            project(page_contents, anchor, page_id=page["page_id"]))
+        viewport = page_contents.get("viewport") or {}
+        result["anchors"].append({
+            "page_id": page["page_id"],
+            "url": page.get("url"),
+            "origin": [round(anchor.dx, 1), round(anchor.dy, 1)],
+            "viewport": [viewport.get("width"), viewport.get("height")],
+            "strategy": "sweep",
+        })
+
 
     if not result["anchored"]:
         result["reason"] = (

--- a/server/device/web_content.py
+++ b/server/device/web_content.py
@@ -409,6 +409,33 @@ def _contains(frame: dict | None, x: float, y: float) -> bool:
     return hit_contains(frame, x, y)
 
 
+def _anchor_hint_for(hints: list | None, page: dict) -> Anchor | None:
+    """A recorded origin for this page, matched by URL.
+
+    Matching on the URL rather than the screen name is what keeps this
+    non-circular: the pages a hint could help locate are largely the ones with
+    no native identity, so requiring the screen to be identified first would
+    rule out every case worth optimising.
+    """
+    if not hints:
+        return None
+    url = str(page.get("url") or "")
+    if not url:
+        return None
+    for hint in hints:
+        recorded = getattr(hint, "url", None)
+        anchor = getattr(hint, "anchor", None)
+        if not recorded or anchor is None or not getattr(anchor, "origin", None):
+            continue
+        if recorded not in url and url not in recorded:
+            continue
+        origin = anchor.origin
+        if len(origin) < 2:
+            continue
+        return Anchor(dx=float(origin[0]), dy=float(origin[1]))
+    return None
+
+
 async def collect_web_content(
     udid: str,
     bundle_id: str | None,
@@ -419,6 +446,7 @@ async def collect_web_content(
     max_probes: int = MAX_ANCHOR_PROBES,
     attribute_udid: AttributeUdidFn | None = None,
     require_device_match: bool = False,
+    hints: list | None = None,
 ) -> dict:
     """Read every inspectable page on screen and place it in screen coordinates.
 
@@ -429,6 +457,7 @@ async def collect_web_content(
 
     result: dict = {
         "elements": [], "pages": [], "probes": 0, "anchored": False, "reason": None,
+        "anchors": [],
     }
 
     applications = await inspector.connected_applications()
@@ -523,31 +552,57 @@ async def collect_web_content(
     # different origins, and an offset confirmed for one says nothing about
     # the other.
     #
-    # Two phases, because the passes cost very differently. Every page gets the
-    # cheap geometry pass first; only if none of them anchored does any page pay
-    # for a sweep. Interleaving them would let a page that is not on screen
-    # spend the whole budget sweeping before a page that is has been looked at
-    # at all -- the same starvation the per-page cap exists to prevent.
+    # Three passes, cheapest first, because they cost very differently. A
+    # recorded origin is one probe. Geometry is up to four. Sweeping is a dozen
+    # or more, so no page pays for it until every page has failed the cheaper
+    # passes -- otherwise a page that is not on screen sweeps away the budget
+    # before a page that is has been looked at at all.
     screen = app_frame(native) or {"x": 0, "y": 0, "width": 0, "height": 0}
     budget = max_probes
-    for page, page_contents in contents:
-        if budget <= 0:
-            break
+
+    async def attempt(page, page_contents, candidates, limit, strategy) -> bool:
+        nonlocal budget
+        if budget <= 0 or not candidates:
+            return False
         anchor, probes = await confirm_anchor(
-            udid, describe_point, page_contents,
-            candidate_anchors(native, page_contents, screen),
-            native_screen=screen, max_probes=min(budget, MAX_PROBES_PER_PAGE),
+            udid, describe_point, page_contents, candidates,
+            native_screen=screen, max_probes=min(budget, limit),
         )
         result["probes"] += probes
         budget -= probes
         if anchor is None:
-            continue
+            return False
         result["anchored"] = True
         result["elements"].extend(project(page_contents, anchor, page_id=page["page_id"]))
+        viewport = page_contents.get("viewport") or {}
+        # What an agent writes back into the knowledge base, so the next run
+        # starts from a one-probe confirmation instead of a search.
+        result["anchors"].append({
+            "page_id": page["page_id"],
+            "url": page.get("url"),
+            "origin": [round(anchor.dx, 1), round(anchor.dy, 1)],
+            "viewport": [viewport.get("width"), viewport.get("height")],
+            "strategy": strategy,
+        })
+        return True
+
+    located: set = set()
+    for page, page_contents in contents:
+        hint = _anchor_hint_for(hints, page)
+        if hint is not None and await attempt(page, page_contents, [hint], 3, "hint"):
+            located.add(page["page_id"])
+
+    for page, page_contents in contents:
+        if page["page_id"] in located:
+            continue
+        if await attempt(page, page_contents,
+                         candidate_anchors(native, page_contents, screen),
+                         MAX_PROBES_PER_PAGE, "geometry"):
+            located.add(page["page_id"])
 
     if not result["anchored"]:
-        # Geometry suggested nothing that held. Sweep for an origin instead --
-        # the only route for a web view whose chrome the native tree cannot see,
+        # Nothing geometry suggested held. Sweep for an origin instead -- the
+        # only route for a web view whose chrome the native tree cannot see,
         # which is every out-of-process one.
         for page, page_contents in contents:
             if budget <= 0:
@@ -563,6 +618,14 @@ async def collect_web_content(
             result["anchored"] = True
             result["elements"].extend(
                 project(page_contents, anchor, page_id=page["page_id"]))
+            viewport = page_contents.get("viewport") or {}
+            result["anchors"].append({
+                "page_id": page["page_id"],
+                "url": page.get("url"),
+                "origin": [round(anchor.dx, 1), round(anchor.dy, 1)],
+                "viewport": [viewport.get("width"), viewport.get("height")],
+                "strategy": "sweep",
+            })
 
     if not result["anchored"]:
         result["reason"] = (

--- a/server/models.py
+++ b/server/models.py
@@ -933,6 +933,51 @@ class UIElement(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+class WebContentAnchor(BaseModel):
+    """Where a page sat on screen when it was last measured.
+
+    A hypothesis, never a fact. The origin depends on the device size, the iOS
+    version and the accessibility text size, so a recorded one is offered as the
+    first candidate and confirmed by a single probe like any other. Right, it
+    turns a 17-probe sweep into one probe; wrong, it costs that one probe and
+    the usual search proceeds.
+    """
+
+    origin: list[float]           # [x, y] of the page's top-left, in points
+    viewport: list[float] | None = None      # [width, height] it was measured at
+    measured_on: str | None = None           # e.g. "iPhone 16 Pro - iOS 18.6"
+
+
+class WebContentHint(BaseModel):
+    """What is already known about one web view on a screen.
+
+    Recorded so an agent does not have to rediscover it. The costly things to
+    find out are which process hosts the view and whether the Web Inspector can
+    see it at all -- both stable properties of the app's code, unlike the
+    geometry.
+    """
+
+    screen: str | None = None
+    host: str | None = None
+    """The class presenting it: WKWebView, SFSafariViewController,
+    ASWebAuthenticationSession."""
+
+    process: str | None = None
+    """Bundle id to pass as `bundle_id`. An out-of-process view is hosted by
+    com.apple.SafariViewService, not by the app."""
+
+    reachable_by: list[str] = Field(default_factory=list)
+    """Which routes actually work: "inspector", "hit_test". An
+    ASWebAuthenticationSession is hit_test only -- the inspector reports no
+    connected application at all while one is presented."""
+
+    url: str | None = None
+    """Used to match this hint to a live page, so no screen identification is
+    needed before the page can be located."""
+
+    anchor: WebContentAnchor | None = None
+
+
 class Landmark(BaseModel):
     """A single element selector for screen identification.
 

--- a/templates/app-knowledge/screens/_template.md
+++ b/templates/app-knowledge/screens/_template.md
@@ -61,12 +61,38 @@ identify_by:
 #
 # On Android none of this applies: the accessibility tree does descend into a
 # WebView, so web content appears as ordinary elements.
+# What is already known about each web view on this screen, so an agent does
+# not have to rediscover it. Emitted ready to paste by get_web_content, under
+# "anchors".
 web_content:
-  # - host: "WKWebView"
-  #   in_process: true
-  #   inspectable: "debug"
+  # - host: "SFSafariViewController"   # the class presenting it
+  #   process: "com.apple.SafariViewService"
+  #   # Which bundle_id to pass to get_web_content. An out-of-process view
+  #   # (SFSafariViewController, ASWebAuthenticationSession) is hosted by
+  #   # SafariViewService, NOT by the app -- and needs no isInspectable, since
+  #   # that property only governs the app's own WKWebViews. An in-process
+  #   # WKWebView uses the app's own bundle id and does need it, per instance.
+  #   reachable_by: [inspector, hit_test]
+  #   # Measured, and the most valuable field here. The three cases differ:
+  #   #   in-process WKWebView        -> inspector (with isInspectable), hit_test
+  #   #   SFSafariViewController      -> inspector, hit_test
+  #   #   ASWebAuthenticationSession  -> hit_test ONLY; while one is presented
+  #   #                                 the inspector reports no connected app
+  #   #                                 at all, so do not spend a call on it.
   #   url: "https://example.com/page"
-  #   page_offset: [0, 100]
+  #   # How a live page is matched to this entry. No screen identification is
+  #   # needed first, which matters because a screen with a web view often has
+  #   # no native identity at all.
+  #   anchor:
+  #     origin: [0, 106]               # page top-left, in points
+  #     viewport: [402, 685]
+  #     measured_on: "iPhone 16 Pro - iOS 18.6"
+  #   # A HINT, never a fact. It depends on device size, iOS version and text
+  #   # size, so it is offered as the first candidate and confirmed by one
+  #   # probe; if it no longer holds it is discarded and the usual search runs.
+  #   # Worth recording because the alternative is expensive: locating an
+  #   # out-of-process page cost a 17-probe sweep and ~3.5s, against 1 probe
+  #   # and ~0.2s once written down.
 
 # Where this screen can be reached from.
 reachable_from:

--- a/tests/test_landmarks.py
+++ b/tests/test_landmarks.py
@@ -936,3 +936,22 @@ web_content:
     assert len(registry.web_content("App")) == 1
     registry.unload("App")
     assert registry.web_content("App") == []
+
+
+def test_a_web_content_entry_carrying_its_own_screen_key_is_skipped(tmp_path):
+    """A duplicate keyword raises TypeError before Pydantic validates, which is
+    not a ValidationError -- so one stray key would abort the whole scan."""
+    from server.device.landmarks import scan_knowledge_base
+    _write(tmp_path, "dup.md", '''screen: "dup"
+landmarks:
+  - { element: "Button", label: "Done" }
+web_content:
+  - screen: "somewhere-else"
+    url: "https://example.test/"
+  - url: "https://ok.test/"''')
+    scan = scan_knowledge_base(tmp_path)
+    assert [s.screen for s in scan.screens] == ["dup"]
+    # The entry is kept, with the file's screen name winning over the stray key.
+    assert [(h.screen, h.url) for h in scan.web_content] == [
+        ("dup", "https://example.test/"), ("dup", "https://ok.test/"),
+    ]

--- a/tests/test_landmarks.py
+++ b/tests/test_landmarks.py
@@ -858,3 +858,81 @@ class TestLandmarkRegistry:
         assert len(skipped) == 1
         assert skipped[0].reason == "legacy_format"
         assert skipped[0].screen == "Legacy"
+
+
+# ------------------------------------------------- recorded web view facts
+
+def _write(tmp_path, name, frontmatter):
+    screens = tmp_path / "screens"
+    screens.mkdir(exist_ok=True)
+    (screens / name).write_text(f"---\n{frontmatter}\n---\n\nbody\n")
+    return tmp_path
+
+
+def test_web_content_is_read_from_a_screen_with_no_landmarks(tmp_path):
+    """The screens that most need a recorded web view -- an OAuth view, a
+    settings page behind SFSafariViewController -- are exactly the ones with no
+    native identity. A hint reachable only through a successful landmark parse
+    would never reach the cases it exists for."""
+    from server.device.landmarks import scan_knowledge_base
+    _write(tmp_path, "settings.md", '''screen: "settings"
+landmarks: []
+web_content:
+  - host: "SFSafariViewController"
+    process: "com.apple.SafariViewService"
+    reachable_by: [inspector, hit_test]
+    url: "https://example.test/settings"
+    anchor:
+      origin: [0, 106]
+      viewport: [402, 685]''')
+    scan = scan_knowledge_base(tmp_path)
+    assert scan.screens == []                      # no landmarks, as expected
+    assert len(scan.web_content) == 1
+    hint = scan.web_content[0]
+    assert hint.screen == "settings"
+    assert hint.process == "com.apple.SafariViewService"
+    assert hint.anchor.origin == [0, 106]
+    assert "hit_test" in hint.reachable_by
+
+
+def test_web_content_is_also_read_from_a_screen_that_has_landmarks(tmp_path):
+    from server.device.landmarks import scan_knowledge_base
+    _write(tmp_path, "picker.md", '''screen: "picker"
+landmarks:
+  - { element: "Button", label: "Done" }
+web_content:
+  - host: "WKWebView"
+    url: "https://example.test/servers"''')
+    scan = scan_knowledge_base(tmp_path)
+    assert [s.screen for s in scan.screens] == ["picker"]
+    assert [h.host for h in scan.web_content] == ["WKWebView"]
+
+
+def test_a_malformed_web_content_entry_does_not_stop_the_load(tmp_path):
+    """A hint is an optimisation and every value in it is verified before use;
+    a bad one must never cost the whole knowledge base."""
+    from server.device.landmarks import scan_knowledge_base
+    _write(tmp_path, "broken.md", '''screen: "broken"
+landmarks:
+  - { element: "Button", label: "Done" }
+web_content:
+  - anchor: "not a mapping"
+  - "a bare string"
+  - host: "WKWebView"
+    url: "https://ok.test/"''')
+    scan = scan_knowledge_base(tmp_path)
+    assert [s.screen for s in scan.screens] == ["broken"]
+    assert [h.url for h in scan.web_content] == ["https://ok.test/"]
+
+
+def test_unloading_an_app_forgets_its_web_content(tmp_path):
+    from server.device.landmarks import LandmarkRegistry
+    _write(tmp_path, "s.md", '''screen: "s"
+landmarks: []
+web_content:
+  - url: "https://example.test/"''')
+    registry = LandmarkRegistry()
+    registry.load_from_path("App", str(tmp_path))
+    assert len(registry.web_content("App")) == 1
+    registry.unload("App")
+    assert registry.web_content("App") == []

--- a/tests/test_web_content.py
+++ b/tests/test_web_content.py
@@ -27,6 +27,7 @@ from server.device.web_content import (
     project,
     to_screen,
 )
+from server.models import WebContentAnchor, WebContentHint
 
 SCREEN = {"x": 0, "y": 0, "width": 402, "height": 874}
 
@@ -498,3 +499,73 @@ async def test_every_page_gets_a_cheap_pass_before_any_page_sweeps():
         [native_el("Application", "App", 0, 0, 402, 874)])
     assert result["anchored"] is True
     assert [e["AXLabel"] for e in result["elements"]] == ["Servers"]
+
+
+# ------------------------------------------------- recorded origins
+
+def hint(url, origin, **kw):
+    return WebContentHint(url=url, anchor=WebContentAnchor(origin=origin), **kw)
+
+
+async def test_a_recorded_origin_is_confirmed_in_one_probe():
+    """Measured: an SFSafariViewController page cost a 17-probe sweep to locate
+    and one probe once its origin had been written down."""
+    inspector = FakeInspector(
+        [APP], [{"page_id": 3, "title": "T", "url": "https://example.test/settings"}],
+        {3: page([dom("GoToSocial Settings", 35, 147, 233, 34)])})
+    screen = FakeScreen([native_el("Heading", "GoToSocial Settings", 35, 253, 233, 34)])
+    result = await collect_web_content(
+        "SIM", "com.example.app", screen.describe_point, inspector,
+        [native_el("Application", "App", 0, 0, 402, 874)],
+        hints=[hint("https://example.test/settings", [0, 106])])
+    assert result["anchored"] is True
+    assert result["probes"] == 1
+    assert result["anchors"][0]["strategy"] == "hint"
+    assert result["anchors"][0]["origin"] == [0.0, 106.0]
+
+
+async def test_a_recorded_origin_that_no_longer_holds_is_discarded():
+    """Devices, iOS versions and text sizes move it. A stale hint must cost a
+    probe, not a wrong tap."""
+    inspector = FakeInspector(
+        [APP], [{"page_id": 3, "title": "T", "url": "https://example.test/settings"}],
+        {3: page([dom("Servers", 24, 170, 144, 53)])})
+    screen = FakeScreen([native_el("Heading", "Servers", 24, 296, 144, 53)])
+    result = await collect_web_content(
+        "SIM", "com.example.app", screen.describe_point, inspector,
+        [native_el("Application", "App", 0, 0, 402, 874)],
+        hints=[hint("https://example.test/settings", [0, 600])])
+    assert result["anchored"] is True, "a bad hint must not prevent locating the page"
+    assert result["anchors"][0]["strategy"] != "hint"
+    assert result["anchors"][0]["origin"] == [0.0, 126.0]
+
+
+async def test_a_hint_for_another_page_is_not_applied():
+    inspector = FakeInspector(
+        [APP], [{"page_id": 3, "title": "T", "url": "https://example.test/settings"}],
+        {3: page([dom("Servers", 24, 170, 144, 53)])})
+    screen = FakeScreen([native_el("Heading", "Servers", 24, 296, 144, 53)])
+    result = await collect_web_content(
+        "SIM", "com.example.app", screen.describe_point, inspector,
+        [native_el("Application", "App", 0, 0, 402, 874)],
+        hints=[hint("https://elsewhere.test/other", [0, 106])])
+    assert result["anchors"][0]["strategy"] == "geometry"
+
+
+async def test_what_is_emitted_is_what_should_be_written_down():
+    """The response has to carry everything the knowledge base block needs, or
+    a discovery cannot be recorded without measuring it again by hand."""
+    inspector = FakeInspector(
+        [APP], [{"page_id": 3, "title": "T", "url": "https://example.test/s"}],
+        # 874 - 748 = 126, the offset the heading actually sits at, so the
+        # bottom-anchored candidate is the one that confirms.
+        {3: page([dom("Servers", 24, 170, 144, 53)], vw=402, vh=748)})
+    screen = FakeScreen([native_el("Heading", "Servers", 24, 296, 144, 53)])
+    result = await collect_web_content(
+        "SIM", "com.example.app", screen.describe_point, inspector,
+        [native_el("Application", "App", 0, 0, 402, 874)])
+    recorded = result["anchors"][0]
+    assert recorded["url"] == "https://example.test/s"
+    assert recorded["origin"] == [0.0, 126.0]
+    assert recorded["viewport"] == [402, 748]
+    assert recorded["strategy"] in ("geometry", "sweep", "hint")

--- a/tests/test_web_content.py
+++ b/tests/test_web_content.py
@@ -569,3 +569,30 @@ async def test_what_is_emitted_is_what_should_be_written_down():
     assert recorded["origin"] == [0.0, 126.0]
     assert recorded["viewport"] == [402, 748]
     assert recorded["strategy"] in ("geometry", "sweep", "hint")
+
+
+async def test_a_second_page_is_still_swept_after_the_first_is_located():
+    """Two web views can be on screen together -- a page and an embedded player.
+    One being found cheaply is no reason to leave the other unreachable."""
+    inspector = FakeInspector(
+        [APP],
+        [{"page_id": 1, "title": "Cheap", "url": "https://a.test/"},
+         {"page_id": 2, "title": "Needs sweeping", "url": "https://b.test/"}],
+        # Page 1 sits where geometry predicts; page 2 does not, so only a sweep
+        # can place it.
+        {1: page([dom("Alpha", 0, 100, 402, 40)], vw=402, vh=748),
+         # Placed so two sweep rows (y=350, y=525) land inside them; both sit
+         # at the same +280 offset, which is what the two-distinct-hits rule
+         # needs before it will believe a swept origin.
+         2: page([dom("Beta", 0, 60, 402, 40), dom("Gamma", 0, 220, 402, 40)])})
+    screen = FakeScreen([
+        native_el("StaticText", "Alpha", 0, 226, 402, 40),
+        native_el("StaticText", "Beta", 0, 340, 402, 40),
+        native_el("StaticText", "Gamma", 0, 500, 402, 40),
+    ])
+    result = await collect_web_content(
+        "SIM", "com.example.app", screen.describe_point, inspector,
+        [native_el("Application", "App", 0, 0, 402, 874)])
+    located = {a["page_id"] for a in result["anchors"]}
+    assert located == {1, 2}, f"only located {located}"
+    assert {a["strategy"] for a in result["anchors"]} == {"geometry", "sweep"}


### PR DESCRIPTION
Answers "what can we save so rediscovery is minimised". Follows #93.

## The measurement

Metatext's Account Settings, an out-of-process `SFSafariViewController`:

| | probes | time | elements |
|---|---|---|---|
| cold | 17 | ~3.5s | 13 |
| with the origin recorded | **1** | **~0.2s** | 13 |

Out-of-process views need this most: they carry their own chrome at *both* ends,
none of it in the native tree, so geometry cannot even propose an origin and the
sweep is the only route.

## A recorded origin is a hypothesis, never a fact

It depends on device size, iOS version and text size. So it enters as the
**first candidate** and is confirmed by one probe exactly like any other; if it
no longer holds it is discarded and the ordinary search proceeds. That is the
whole reason it is safe to write down — trusting it would mean a confident tap
on whatever now occupies that pixel, which is the failure this design keeps
refusing to allow. Both directions are tested.

## Matched by URL, not by screen

The pages a hint could help locate are largely the ones with **no native
identity** — the tree reports a single element for a settings page. Requiring
the screen to be identified first would rule out every case worth optimising.
For the same reason `web_content:` is parsed even when a screen has
`landmarks: []`, which is precisely where these screens live; a hint reachable
only through a successful landmark parse would never reach the cases it exists
for.

## A documentation correction

The guide claimed system-presented views are closed to the Web Inspector "no
matter what the app does". I wrote that in #90 by inference. It is **wrong**:

| view | Web Inspector | hit-test |
|---|---|---|
| in-process `WKWebView` | yes — if the app sets `isInspectable` | yes |
| `SFSafariViewController` | **yes, with no opt-in from the app** | yes |
| `ASWebAuthenticationSession` | **no — zero connected applications** | yes |

The old `web_content:` schema (`in_process`, `inspectable`, `page_offset`) was
speculative, written before anchoring existed. Replaced with the measured one.

## Round trip

`get_web_content` now returns what it resolved, so a discovery can be recorded
without measuring it by hand:

```json
{"page_id": 3, "url": "https://social.arctian.org/settings",
 "origin": [0, 106], "viewport": [402, 685], "strategy": "sweep"}
```

`strategy: "hint"` means the recorded value was used and confirmed; `geometry`
or `sweep` means it was rediscovered — the signal to write the new value down.

Verified end to end against the live simulator: measured cold, pasted into
`account-settings.md`, reloaded, and the next three calls came back
`strategy: hint`, 1 probe.

Suite 1590, ruff clean, new guards mutation-verified.

## Still to come, from the same design discussion

- `get_web_content` returning elements for `ASWebAuthenticationSession` via the
  probe sweep, so one tool covers all three cases.
- URL as a landmark kind, giving identity to the 7 screens that have none.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved web content discovery across supported web-view types using saved URL, process, reachability, and viewport information.
  * Web content results now include page URL, origin, viewport, and discovery method.
  * Added support for storing and reusing web-view hints per app.

* **Documentation**
  * Expanded guidance for web-view inspection, hit testing, probe strategies, and third-party URLs.
  * Updated templates with examples for supported web-view behaviors.

* **Tests**
  * Added coverage for hint validation, reuse, fallback discovery, URL matching, and lifecycle cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->