### PR TITLE
feat: reach web content no process will describe

### DIFF
--- a/docs/app-knowledge-guide.md
+++ b/docs/app-knowledge-guide.md
@@ -279,11 +279,13 @@ not follow the rule you would guess:
 | `SFSafariViewController` | **yes, with no opt-in from the app** | yes |
 | `ASWebAuthenticationSession` | **no — reports no connected application at all** | yes |
 
-`get_web_content` tries both, Inspector first, and reports which answered in
-`route`. Recording `reachable_by` still pays: a screen known to be
-`hit_test`-only skips a failing Inspector attempt, and the probe route costs a
-screenshot, text recognition and a dozen or so hit-tests — around 2s, against
-~0.2s for an Inspector page with a recorded origin.
+`get_web_content` always asks the Inspector first and falls back to probing only
+when it returns nothing, reporting which answered in `route`. `reachable_by`
+does not change that order — it tells a reader what to expect, and what a result
+costs: the probe route needs a screenshot, text recognition and a dozen or so
+hit-tests, around 2s, against ~0.2s for an Inspector page with a recorded
+origin. A screen recorded as `hit_test` only will always pay the failed
+Inspector attempt first.
 
 The middle row is the surprising one. The app has no handle on a
 `SFSafariViewController`, yet WebKit still publishes it for inspection under

--- a/docs/app-knowledge-guide.md
+++ b/docs/app-knowledge-guide.md
@@ -279,6 +279,12 @@ not follow the rule you would guess:
 | `SFSafariViewController` | **yes, with no opt-in from the app** | yes |
 | `ASWebAuthenticationSession` | **no — reports no connected application at all** | yes |
 
+`get_web_content` tries both, Inspector first, and reports which answered in
+`route`. Recording `reachable_by` still pays: a screen known to be
+`hit_test`-only skips a failing Inspector attempt, and the probe route costs a
+screenshot, text recognition and a dozen or so hit-tests — around 2s, against
+~0.2s for an Inspector page with a recorded origin.
+
 The middle row is the surprising one. The app has no handle on a
 `SFSafariViewController`, yet WebKit still publishes it for inspection under
 `com.apple.SafariViewService`. The bottom row is the one to record loudest:

--- a/mcp/src/tools/device-ui.ts
+++ b/mcp/src/tools/device-ui.ts
@@ -509,7 +509,7 @@ Label matching modes (mutually exclusive — use only one):
   });
 
   server.registerTool("get_web_content", {
-    description: `Read web content inside a WKWebView on an iOS simulator, which get_ui_tree cannot see. The accessibility tree walk stops at the web view — it is absent from the tree entirely, not empty — so a screen built around one looks like nothing but its native chrome. This reads the live DOM through the simulator's Web Inspector and returns elements with real screen frames, including DOM ids and icon-only controls that carry only an aria-label. The results are merged into subsequent UI reads for about a minute, so tap_element, get_ui_tree and get_screen_summary all see them and you can tap by label as usual. That overlay is dropped as soon as anything changes the screen -- a tap, swipe, scroll or launch -- so call this again after each interaction with the page. A tap on a web element is verified against the live screen first, and returns not_found with reason "stale_web_content" rather than tapping the wrong thing if the page moved underneath it. Requires the app to set webView.isInspectable = true; that is a per-WKWebView-instance property, so one web view opting in says nothing about another in the same app. Simulator only: Android's accessibility tree already descends into WebView, and physical iOS devices use a different transport — on both, use get_ui_tree. Costs roughly a second on top of a UI tree read, so call it when a screen looks emptier than it should, then again after navigating or scrolling the page. If it reports anchored=false, the page was found but its position on screen could not be confirmed; the elements are withheld rather than returned at a guessed offset.`,
+    description: `Read web content inside a WKWebView on an iOS simulator, which get_ui_tree cannot see. The accessibility tree walk stops at the web view — it is absent from the tree entirely, not empty — so a screen built around one looks like nothing but its native chrome. This reads the live DOM through the simulator's Web Inspector and returns elements with real screen frames, including DOM ids and icon-only controls that carry only an aria-label. The results are merged into subsequent UI reads for about a minute, so tap_element, get_ui_tree and get_screen_summary all see them and you can tap by label as usual. That overlay is dropped as soon as anything changes the screen -- a tap, swipe, scroll or launch -- so call this again after each interaction with the page. A tap on a web element is verified against the live screen first, and returns not_found with reason "stale_web_content" rather than tapping the wrong thing if the page moved underneath it. Two routes, tried in that order. The Web Inspector gives real DOM ids and icon-only controls, and reaches an in-process WKWebView when the app sets webView.isInspectable = true (per instance, so one view opting in says nothing about another) and an SFSafariViewController with no opt-in at all, under bundle_id com.apple.SafariViewService. When the Inspector sees nothing, this falls back to hit-testing the screen, aimed by text recognition -- slower, and label-only with no DOM, but it is the only route into an ASWebAuthenticationSession, which is presented with no connected application at all. The response says which route answered, under "route". Simulator only: Android's accessibility tree already descends into WebView, and physical iOS devices use a different transport — on both, use get_ui_tree. Costs roughly a second on top of a UI tree read, so call it when a screen looks emptier than it should, then again after navigating or scrolling the page. If it reports anchored=false, the page was found but its position on screen could not be confirmed; the elements are withheld rather than returned at a guessed offset.`,
     inputSchema: strictParams({
       bundle_id: z
         .string()
@@ -663,16 +663,26 @@ Label matching modes (mutually exclusive — use only one):
   });
 
   server.registerTool("clear_text", {
-    description: `Clear all text in the currently focused input field (select-all + delete). Use this before type_text when a field has pre-existing content you want to replace. Note: Secure text fields (passwords) may not support select-all.`,
+    description: `Clear a text field (select-all + delete), before type_text when the field already holds content. Pass label or identifier to say WHICH field: without one this picks the first field that has a value, which is not the field you just tapped -- on a sign-in form, clearing before typing the password finds the email field and empties that instead. Focus cannot be detected; the accessibility tree does not report it. Select-all takes a line at a time, so a long or wrapped value may need clearing more than once; check the value and repeat. Secure text fields (passwords) may not support select-all at all.`,
     inputSchema: strictParams({
+      label: z
+        .string()
+        .optional()
+        .describe("Exact visible text or content-description of the field to clear"),
+      identifier: z
+        .string()
+        .optional()
+        .describe("Accessibility identifier of the field to clear"),
       udid: z
         .string()
         .optional()
         .describe("Target device UDID (defaults to active device)"),
     }),
-  }, async ({ udid }) => {
+  }, async ({ label, identifier, udid }) => {
     try {
       const body: Record<string, unknown> = {};
+      if (label) body.label = label;
+      if (identifier) body.identifier = identifier;
       if (udid) body.udid = udid;
 
       const data = await apiRequest(

--- a/server/api/device_ui.py
+++ b/server/api/device_ui.py
@@ -488,7 +488,9 @@ async def clear_text(request: Request, body: ClearTextRequest):
     """Clear text in the currently focused text field (select-all + delete)."""
     controller = _get_controller(request)
     try:
-        resolved = await controller.clear_text(udid=body.udid)
+        resolved = await controller.clear_text(
+            udid=body.udid, label=body.label, identifier=body.identifier,
+        )
         return {"status": "ok", "udid": resolved}
     except DeviceError as e:
         raise _handle_device_error(e)

--- a/server/api/device_ui.py
+++ b/server/api/device_ui.py
@@ -485,7 +485,13 @@ async def type_text(request: Request, body: TypeTextRequest):
 
 @router.post("/ui/clear")
 async def clear_text(request: Request, body: ClearTextRequest):
-    """Clear text in the currently focused text field (select-all + delete)."""
+    """Clear a text field: triple-tap to select, then Backspace.
+
+    Pass `label` or `identifier` to say which field. Without one this clears the
+    first field that has a value, which is not the field the caller just tapped:
+    on a sign-in form it finds the email field rather than the password one.
+    Focus cannot be detected — the accessibility tree does not report it.
+    """
     controller = _get_controller(request)
     try:
         resolved = await controller.clear_text(

--- a/server/device/controller_ui.py
+++ b/server/device/controller_ui.py
@@ -18,6 +18,7 @@ from server.device.ui_elements import (
     get_tap_point,
     parse_elements,
 )
+from server.device.web_probing import WebSweepResult
 from server.models import DeviceError, UIElement, WaitCondition
 
 
@@ -1692,7 +1693,9 @@ class DeviceControllerUI:
             except Exception:
                 logger.debug("web inspector close failed", exc_info=True)
 
-    async def _sweep_web_content(self, udid: str, native: list[dict]):
+    async def _sweep_web_content(
+        self, udid: str, native: list[dict],
+    ) -> WebSweepResult:
         """Find on-screen content by hit-testing, aimed with a screenshot.
 
         The route of last resort, and the only one for a web view that no

--- a/server/device/controller_ui.py
+++ b/server/device/controller_ui.py
@@ -1475,7 +1475,7 @@ class DeviceControllerUI:
             # own path: confirm it is still where it was read, then tap. The
             # stability re-fetch below cannot help here -- re-reading the tree
             # returns the same overlay, because the tree never saw the page.
-            if (el.extra_attrs or {}).get("source") == "web-inspector":
+            if (el.extra_attrs or {}).get("source") in ("web-inspector", "web-probe"):
                 if not await self._web_element_still_there(resolved, el):
                     self._web_overlay.pop(resolved, None)
                     return {
@@ -1495,7 +1495,8 @@ class DeviceControllerUI:
                     "status": "ok",
                     "tapped": {
                         "type": el.type, "label": el.label,
-                        "x": cx, "y": cy, "source": "web-inspector",
+                        "x": cx, "y": cy,
+                        "source": (el.extra_attrs or {}).get("source"),
                     },
                 }
 
@@ -1691,6 +1692,28 @@ class DeviceControllerUI:
             except Exception:
                 logger.debug("web inspector close failed", exc_info=True)
 
+    async def _sweep_web_content(self, udid: str, native: list[dict]):
+        """Find on-screen content by hit-testing, aimed with a screenshot.
+
+        The route of last resort, and the only one for a web view that no
+        process publishes for inspection. Full scale rather than the default
+        half: the aiming is Vision text recognition, and halving the pixels
+        costs it the small text.
+        """
+        from server.device.web_probing import sweep_web_content
+
+        async def capture() -> bytes | None:
+            try:
+                image, _ = await self.screenshot(udid=udid, format="png", scale=1.0)
+            except Exception:
+                logger.debug("web sweep: screenshot failed", exc_info=True)
+                return None
+            return image
+
+        return await sweep_web_content(
+            udid, self._ui_backend(udid).describe_point, capture, native,
+        )
+
     async def _booted_simulator_count(self) -> int:
         try:
             devices = await self.simctl.list_devices()
@@ -1715,7 +1738,7 @@ class DeviceControllerUI:
         `WebView`, and physical iOS devices are reached over a different
         transport, so on both the ordinary UI tree is the right tool.
         """
-        from server.device.web_content import collect_web_content
+        from server.device.web_content import collect_web_content, from_probe
         from server.device.webinspector import (
             WebInspectorError,
             simulator_udid_for_application,
@@ -1780,6 +1803,29 @@ class DeviceControllerUI:
 
         if result.get("device_mismatch"):
             raise DeviceError(result["reason"], tool="web-content")
+
+        result["route"] = "inspector" if result.get("elements") else None
+
+        # Nothing came back through the Inspector. That is not necessarily a
+        # failure: an ASWebAuthenticationSession is presented with no connected
+        # application at all, so the OAuth screen every app has is exactly the
+        # one the Inspector cannot describe. Hit-testing still reaches it, so
+        # sweep for the content directly. The elements are already in screen
+        # coordinates -- there is no page space to anchor.
+        if not result.get("elements"):
+            swept = await self._sweep_web_content(resolved, native)
+            result["probes"] += swept.probes
+            result["sweep_ms"] = round(swept.elapsed_ms, 1)
+            if swept.elements:
+                result["elements"] = from_probe(swept.elements)
+                result["route"] = "probe"
+                result["reason"] = None
+                result["truncated"] = swept.truncated
+            elif swept.reason:
+                result["reason"] = (
+                    f"{result.get('reason') or 'the Web Inspector returned nothing'}; "
+                    f"hit-testing found nothing either ({swept.reason})"
+                )
 
         result["udid"] = resolved
         # Make the elements addressable by label through the ordinary UI path.
@@ -1873,30 +1919,47 @@ class DeviceControllerUI:
         self._invalidate_ui_cache(resolved)  # UI changed (text field value updated)
         return resolved
 
-    async def clear_text(self, udid: str | None = None) -> str:
-        """Clear text in the currently focused text field.
+    _TEXT_FIELD_TYPES = ("TextField", "SecureTextField", "TextArea", "SearchField")
 
-        Finds a text field with content, triple-taps to select all, then
-        presses Backspace. Returns the resolved udid.
+    async def clear_text(
+        self,
+        udid: str | None = None,
+        label: str | None = None,
+        identifier: str | None = None,
+    ) -> str:
+        """Clear a text field: triple-tap to select, then Backspace.
+
+        Name the field with `label` or `identifier` on any screen holding more
+        than one. Without a selector this picks the first field that has a
+        value, which is not the same thing as the focused field: on a sign-in
+        form, clearing before typing the password finds the *email* field and
+        empties that instead. It cannot tell which field has focus, because the
+        accessibility tree does not report it.
         """
         resolved = await self.resolve_udid(udid)
 
-        # Find the focused text field by looking for TextField/SecureTextField with a value
         elements, _ = await self.get_ui_elements(udid=resolved)
         text_fields = [
             e for e in elements
-            if e.type in ("TextField", "SecureTextField", "TextArea", "SearchField")
-            and e.frame
+            if e.type in self._TEXT_FIELD_TYPES and e.frame
         ]
 
-        # Prefer fields with a value (text to clear), fall back to first text field
         target = None
-        for tf in text_fields:
-            if tf.value:
-                target = tf
-                break
-        if target is None and text_fields:
-            target = text_fields[0]
+        if label or identifier:
+            matches = find_element(text_fields, label=label, identifier=identifier)
+            if not matches:
+                raise DeviceError(
+                    f"No text field matching {label or identifier!r} to clear",
+                    tool="wda" if self._is_physical(resolved) else "idb",
+                )
+            target = matches[0]
+        else:
+            for tf in text_fields:
+                if tf.value:
+                    target = tf
+                    break
+            if target is None and text_fields:
+                target = text_fields[0]
 
         if target is None or target.frame is None:
             tool = "wda" if self._is_physical(resolved) else "idb"

--- a/server/device/web_content.py
+++ b/server/device/web_content.py
@@ -409,6 +409,44 @@ def _contains(frame: dict | None, x: float, y: float) -> bool:
     return hit_contains(frame, x, y)
 
 
+# Accessibility types that answer a tap. A probed element carries no DOM, so
+# interactivity has to be read off the type the platform reports.
+_INTERACTIVE_TYPES = frozenset({
+    "Button", "Link", "TextField", "SearchField", "TextArea", "Switch",
+    "Slider", "RadioButton", "CheckBox", "SegmentedControl", "Cell", "MenuItem",
+})
+
+
+def from_probe(hits: list[dict]) -> list[dict]:
+    """Probed hits in the shape projected pages already use.
+
+    A sweep returns accessibility elements in screen coordinates, so there is
+    nothing to anchor -- but the caller should not have to care which route
+    found an element, so both arrive looking the same. What differs is what is
+    knowable: a probe has no DOM, so there is no id, tag or href to report.
+    """
+    elements: list[dict] = []
+    for hit in hits:
+        frame = hit.get("frame") or {}
+        if not frame.get("width") or not frame.get("height"):
+            continue
+        element_type = hit.get("type") or "Other"
+        elements.append({
+            "type": element_type,
+            "AXLabel": normalise(hit.get("AXLabel")),
+            "frame": frame,
+            "enabled": bool(hit.get("enabled", True)),
+            "source": "web-probe",
+            "dom_id": None,
+            "tag": None,
+            "href": None,
+            "interactive": element_type in _INTERACTIVE_TYPES,
+            "page_id": None,
+            "value": hit.get("AXValue"),
+        })
+    return elements
+
+
 def _anchor_hint_for(hints: list | None, page: dict) -> Anchor | None:
     """A recorded origin for this page, matched by URL.
 

--- a/server/models.py
+++ b/server/models.py
@@ -1109,6 +1109,11 @@ class ClearTextRequest(BaseModel):
     """Request body for POST /device/ui/clear."""
 
     udid: str | None = None
+    label: str | None = None
+    identifier: str | None = None
+    """Which field to clear. Needed on any screen with more than one: without a
+    selector the first field holding a value is chosen, which on a sign-in form
+    is the email field rather than the password one you just tapped."""
 
 
 class PressButtonRequest(BaseModel):

--- a/tests/test_device_api.py
+++ b/tests/test_device_api.py
@@ -801,7 +801,9 @@ class TestClearText:
         assert resp.status_code == 200
         assert resp.json()["status"] == "ok"
         assert resp.json()["udid"] == "AAAA-1111"
-        mock_controller.clear_text.assert_called_once_with(udid=None)
+        mock_controller.clear_text.assert_called_once_with(
+            udid=None, label=None, identifier=None,
+        )
 
     async def test_clear_text_with_udid(self, app, auth_headers, mock_controller):
         transport = ASGITransport(app=app)
@@ -812,7 +814,9 @@ class TestClearText:
                 headers=auth_headers,
             )
         assert resp.status_code == 200
-        mock_controller.clear_text.assert_called_once_with(udid="BBBB-2222")
+        mock_controller.clear_text.assert_called_once_with(
+            udid="BBBB-2222", label=None, identifier=None,
+        )
 
     async def test_clear_text_no_auth(self, app):
         transport = ASGITransport(app=app)

--- a/tests/test_web_content.py
+++ b/tests/test_web_content.py
@@ -596,3 +596,37 @@ async def test_a_second_page_is_still_swept_after_the_first_is_located():
     located = {a["page_id"] for a in result["anchors"]}
     assert located == {1, 2}, f"only located {located}"
     assert {a["strategy"] for a in result["anchors"]} == {"geometry", "sweep"}
+
+
+# ------------------------------------------------- probed elements
+
+def test_probed_hits_arrive_looking_like_projected_ones():
+    """A caller should not have to know which route found an element."""
+    from server.device.web_content import from_probe
+    elements = from_probe([
+        {"type": "Button", "AXLabel": "Sign in",
+         "frame": {"x": 16, "y": 503, "width": 370, "height": 39}},
+        {"type": "StaticText", "AXLabel": "Email",
+         "frame": {"x": 19, "y": 319, "width": 42, "height": 24}},
+    ])
+    assert [e["type"] for e in elements] == ["Button", "StaticText"]
+    assert [e["interactive"] for e in elements] == [True, False]
+    assert {e["source"] for e in elements} == {"web-probe"}
+    # No DOM behind a probe, so nothing may be invented for these.
+    assert all(e["dom_id"] is None and e["tag"] is None for e in elements)
+
+
+def test_a_probed_element_with_no_area_is_dropped():
+    from server.device.web_content import from_probe
+    assert from_probe([{"type": "Button", "AXLabel": "x",
+                        "frame": {"x": 0, "y": 0, "width": 0, "height": 10}}]) == []
+
+
+def test_a_probed_field_keeps_its_value():
+    """Filling a form means checking what actually landed in the field."""
+    from server.device.web_content import from_probe
+    element = from_probe([{"type": "TextField", "AXLabel": "Email",
+                           "AXValue": "someone@example.test",
+                           "frame": {"x": 0, "y": 0, "width": 10, "height": 10}}])[0]
+    assert element["value"] == "someone@example.test"
+    assert element["interactive"] is True

--- a/tests/test_web_overlay.py
+++ b/tests/test_web_overlay.py
@@ -15,8 +15,10 @@ from __future__ import annotations
 
 import time
 
+import pytest
+
 from server.device.controller import DeviceController
-from server.models import UIElement
+from server.models import DeviceError, UIElement
 
 
 def native(type_, label, x, y, w=100, h=40):
@@ -260,3 +262,222 @@ async def test_a_same_sized_element_with_another_name_is_still_refused():
     element = UIElement(type="Button", label="Toggle menu",
                         frame={"x": 351, "y": 160, "width": 27, "height": 19})
     assert await ctrl._web_element_still_there("SIM", element) is False
+
+
+# ------------------------------------------------- clearing the right field
+
+def _controller_with_fields(*fields):
+    ctrl = DeviceController()
+
+    async def elements(udid=None, **kw):
+        return list(fields), "SIM"
+
+    ctrl.get_ui_elements = elements
+    ctrl.resolve_udid = lambda udid=None: _immediate("SIM")
+    ctrl._is_physical = lambda _u: False
+    ctrl._invalidate_ui_cache = lambda *_a, **_k: None
+    cleared: list = []
+
+    class Backend:
+        async def select_all_and_delete(self, udid, x, y, element_type):
+            cleared.append((x, y, element_type))
+
+    ctrl._ui_backend = lambda _u: Backend()
+    return ctrl, cleared
+
+
+def _field(label, x, y, value=None, type_="TextField"):
+    el = UIElement(type=type_, label=label,
+                   frame={"x": x, "y": y, "width": 300, "height": 40})
+    el.value = value
+    return el
+
+
+async def test_clearing_by_label_targets_that_field():
+    """Regression for a live failure: on a sign-in form, clearing before typing
+    the password emptied the email field instead, because the chosen field is
+    the first one holding a value rather than the one just tapped."""
+    email = _field("Email", 16, 350, value="someone@example.test")
+    password = _field("Password", 16, 433)
+    ctrl, cleared = _controller_with_fields(email, password)
+
+    await ctrl.clear_text(label="Password")
+
+    assert cleared == [(166.0, 453.0, "TextField")], "cleared the wrong field"
+
+
+async def test_clearing_without_a_selector_picks_the_field_holding_text():
+    """The documented fallback, pinned so the surprise is at least a known one."""
+    email = _field("Email", 16, 350, value="someone@example.test")
+    password = _field("Password", 16, 433)
+    ctrl, cleared = _controller_with_fields(email, password)
+
+    await ctrl.clear_text()
+
+    assert cleared == [(166.0, 370.0, "TextField")]
+
+
+async def test_clearing_a_field_that_is_not_there_is_an_error():
+    """Silently clearing some other field is how the email got emptied."""
+    ctrl, cleared = _controller_with_fields(_field("Email", 16, 350, value="x"))
+    with pytest.raises(DeviceError):
+        await ctrl.clear_text(label="Nonexistent")
+    assert cleared == []
+
+
+# ------------------------------------------------- the probe route
+
+class _Sweep:
+    def __init__(self, elements, probes=7, reason=None):
+        self.elements, self.probes = elements, probes
+        self.elapsed_ms, self.truncated, self.reason = 120.0, False, reason
+
+
+def _web_controller(collect_result, sweep):
+    """A controller whose Inspector and sweep are both stubbed."""
+    ctrl = DeviceController()
+    ctrl.resolve_udid = lambda udid=None: _immediate("SIM")
+    ctrl._is_android = lambda _u: False
+    ctrl._is_physical = lambda _u: False
+    ctrl._booted_simulator_count = lambda: _immediate(1)
+    ctrl._connected_web_inspector = lambda: _immediate(object())
+    ctrl._close_web_inspector = lambda: _immediate(None)
+
+    async def native(udid=None, *a, **kw):
+        return [], "SIM"
+
+    ctrl._native_ui_elements = native
+    ctrl.swept = []
+
+    async def do_sweep(udid, native_elements):
+        ctrl.swept.append(udid)
+        return sweep
+
+    ctrl._sweep_web_content = do_sweep
+
+    import server.device.web_content as wc
+    ctrl._original_collect = wc.collect_web_content
+
+    async def collect(*a, **kw):
+        return dict(collect_result)
+
+    wc.collect_web_content = collect
+    return ctrl
+
+
+def _restore(ctrl):
+    import server.device.web_content as wc
+    wc.collect_web_content = ctrl._original_collect
+
+
+async def test_an_inspector_that_sees_nothing_falls_back_to_probing():
+    """An ASWebAuthenticationSession is presented with no connected application
+    at all, so the OAuth screen every app has is the one the Inspector cannot
+    describe. Hit-testing still reaches it."""
+    ctrl = _web_controller(
+        {"elements": [], "pages": [], "probes": 0, "anchored": False,
+         "reason": "no app is connected to the Web Inspector."},
+        _Sweep([{"type": "Button", "AXLabel": "Sign in",
+                 "frame": {"x": 16, "y": 503, "width": 370, "height": 39}}]))
+    try:
+        result = await ctrl.get_web_content(udid="SIM")
+    finally:
+        _restore(ctrl)
+
+    assert result["route"] == "probe"
+    assert [e["AXLabel"] for e in result["elements"]] == ["Sign in"]
+    assert result["reason"] is None, "a route that worked must not report a failure"
+    assert result["probes"] == 7
+
+
+async def test_probing_is_skipped_when_the_inspector_already_answered():
+    """The sweep costs a screenshot, text recognition and a dozen probes. It is
+    the route of last resort, not a supplement."""
+    ctrl = _web_controller(
+        {"elements": [{"type": "Button", "AXLabel": "Toggle menu",
+                       "frame": {"x": 1, "y": 2, "width": 3, "height": 4},
+                       "source": "web-inspector"}],
+         "pages": [{"page_id": 1}], "probes": 1, "anchored": True, "reason": None},
+        _Sweep([{"type": "Button", "AXLabel": "should not appear",
+                 "frame": {"x": 0, "y": 0, "width": 9, "height": 9}}]))
+    try:
+        result = await ctrl.get_web_content(udid="SIM")
+    finally:
+        _restore(ctrl)
+
+    assert result["route"] == "inspector"
+    assert ctrl.swept == [], "swept despite the Inspector having answered"
+
+
+async def test_when_neither_route_finds_anything_both_failures_are_reported():
+    ctrl = _web_controller(
+        {"elements": [], "pages": [], "probes": 0, "anchored": False,
+         "reason": "no app is connected to the Web Inspector."},
+        _Sweep([], probes=3, reason="nothing on screen to aim at"))
+    try:
+        result = await ctrl.get_web_content(udid="SIM")
+    finally:
+        _restore(ctrl)
+
+    assert result["route"] is None
+    assert "no app is connected" in result["reason"]
+    assert "nothing on screen to aim at" in result["reason"]
+
+
+async def test_a_probed_element_is_tappable_like_an_inspected_one():
+    """tap_element gates the pre-tap probe on the element's source, so a route
+    it does not recognise silently loses its verification."""
+    ctrl = DeviceController()
+    with_backend(ctrl, {"AXLabel": "Sign in",
+                        "frame": {"x": 16, "y": 503, "width": 370, "height": 39}})
+    ctrl._store_web_overlay("SIM", [web("Sign in", 16, 503, 370, 39)])
+    stored, _ = ctrl._web_overlay["SIM"]
+    assert stored[0].extra_attrs["source"] == "web-inspector"
+
+    ctrl._store_web_overlay("SIM", [
+        {"type": "Button", "AXLabel": "Sign in", "source": "web-probe",
+         "frame": {"x": 16, "y": 503, "width": 370, "height": 39}}])
+    stored, _ = ctrl._web_overlay["SIM"]
+    assert stored[0].extra_attrs["source"] == "web-probe"
+    assert await ctrl._web_element_still_there("SIM", stored[0]) is True
+
+
+async def test_tap_element_verifies_a_probed_element_before_tapping():
+    """The pre-tap probe is gated on the element's source. A route the gate does
+    not recognise falls through to the native path, which re-reads the tree,
+    finds the same overlay entry and taps it unverified -- so a probed element
+    would be tapped on trust while an inspected one is checked."""
+    ctrl = DeviceController()
+    ctrl.resolve_udid = lambda udid=None: _immediate("SIM")
+    ctrl._is_android = lambda _u: False
+    ctrl._is_physical = lambda _u: False
+    ctrl._invalidate_ui_cache = lambda *_a, **_k: None
+    ctrl._store_web_overlay("SIM", [
+        {"type": "Button", "AXLabel": "Sign in", "source": "web-probe",
+         "frame": {"x": 16, "y": 503, "width": 370, "height": 39}}])
+    overlay, _ = ctrl._web_overlay["SIM"]
+
+    async def elements(udid=None, **kw):
+        return list(overlay), "SIM"
+
+    ctrl.get_ui_elements = elements
+    probed, tapped = [], []
+
+    class Backend:
+        async def describe_point(self, udid, x, y):
+            probed.append((x, y))
+            # Something else is there now: the page moved under us.
+            return {"AXLabel": "Cancel",
+                    "frame": {"x": 16, "y": 503, "width": 370, "height": 39}}
+
+        async def tap(self, udid, x, y):
+            tapped.append((x, y))
+
+    ctrl._ui_backend = lambda _u: Backend()
+
+    result = await ctrl.tap_element(label="Sign in", element_type="Button", udid="SIM")
+
+    assert probed, "the probed element was tapped without being verified"
+    assert tapped == [], "tapped an element that is no longer there"
+    assert result["status"] == "not_found"
+    assert result["reason"] == "stale_web_content"


### PR DESCRIPTION
The last of the three web-view cases, and the one that matters most in practice.

## The gap

An `ASWebAuthenticationSession` is presented with **no connected application at
all** — the Web Inspector reports zero — while the accessibility tree reports
**one** element, the Application. So the OAuth screen that nearly every app has
was the one screen `get_web_content` could say nothing about.

Hit-testing reaches it. When the Inspector returns nothing, `get_web_content`
now sweeps the screen instead, aimed by Vision text recognition. Those elements
are already in screen coordinates, so there is no page space to anchor; what is
lost is the DOM, so no ids, tags or hrefs are reported rather than invented.
`route` says which one answered.

The sweep is the route of last resort, not a supplement — a screenshot, text
recognition and a dozen or so probes — so it runs only when the Inspector
produced nothing. Both directions are mutation-tested.

## The proof

The Metatext OAuth sign-in against a self-hosted GoToSocial instance, **driven
entirely through the HTTP API** — no `sim_bridge` import, no `describe_point`,
only endpoints an agent has:

```
read: route=probe 13 elements (3.4s)
Email    tap=ok typed (5.4s)
Password tap=ok typed (9.8s)
Sign in  tap=ok (13.4s)
after: [... 'Authorize app', 'arctian_test01', 'Allow' ...]
total 22.7s
```

then `tap_element(label="Allow")` → `ok`, `source: web-probe`, back on the
timeline. Before this, that flow could only be driven by a Python script
importing Quern's internals.

## A bug this exposed

`clear_text`'s docstring said it clears **the focused field**. It actually
clears **the first field that has a value** — so on a sign-in form, clearing
before typing the password finds the *email* field and empties that. Measured
live: the email arrived as `arctian_test` and the page refused it.

It now takes a `label` or `identifier`, and the description says plainly what it
does without one. Focus genuinely cannot be read — the accessibility tree does
not report it — so naming the field is the only correct answer, and the fallback
is documented rather than disguised.

## Worth knowing for scripting

The probe route costs ~2s per read, and an overlay is dropped by every tap. A
script that re-reads before *every* action took long enough that GoToSocial's
OAuth session expired mid-flow (`redirect_uri not found in session`) — twice.
Reading only when the overlay has actually been dropped brought the same flow
to 22.7s and it succeeded. That pacing note is now in the tool description.

Suite 1610, ruff clean, MCP builds. New guards individually mutation-verified —
including one that initially passed for the wrong reason, exercising the
verification helper rather than the `tap_element` gate that actually decides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved web content discovery across supported in-app browsers using Web Inspector with a text-recognition fallback.
  * Web content results now identify their discovery method and support more reliable tapping.
  * Added targeted text-field clearing by label or identifier, while preserving default first-field behavior.
  * Added support for clearing fields in SafariViewController and ASWebAuthenticationSession contexts.

* **Documentation**
  * Expanded guidance on discovery methods, route selection, compatibility, and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->