### PR TITLE
feat: wait for the screen to settle instead of sleeping

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ quern tunneld <cmd>          # Manage the tunneld LaunchDaemon (install/uninstal
 
 ## MCP Tools
 
-108 tools available via MCP. All tools are lazy-loaded and won't hog your context just by connecting the MCP. They are lightweight API wrappers and are easy for the Agent to use.
+109 tools available via MCP. All tools are lazy-loaded and won't hog your context just by connecting the MCP. They are lightweight API wrappers and are easy for the Agent to use.
 
 | Category | Tools |
 |----------|-------|
@@ -291,7 +291,7 @@ quern tunneld <cmd>          # Manage the tunneld LaunchDaemon (install/uninstal
 | System Proxy | `configure_system_proxy`, `unconfigure_system_proxy` |
 | Intercept & Mock | `set_intercept`, `clear_intercept`, `list_held_flows`, `release_flow`, `replay_flow`, `set_mock`, `list_mocks`, `update_mock`, `clear_mocks` |
 | Device | `list_devices`, `boot_device`, `shutdown_device`, `erase_device`, `install_app`, `launch_app`, `terminate_app`, `uninstall_app`, `list_apps`, `build_and_install` |
-| UI | `get_ui_tree`, `get_element_state`, `wait_for_element`, `get_screen_summary`, `tap`, `tap_element`, `swipe`, `scroll_to_element`, `type_text`, `clear_text`, `press_button`, `get_web_content` |
+| UI | `get_ui_tree`, `get_element_state`, `wait_for_element`, `get_screen_summary`, `tap`, `tap_element`, `swipe`, `scroll_to_element`, `type_text`, `clear_text`, `press_button`, `get_web_content`, `wait_for_settle` |
 | Screenshots | `take_screenshot`, `take_annotated_screenshot`, `start_screenshot_timeline`, `stop_screenshot_timeline`, `get_screenshot_timeline` |
 | Device Config | `set_location`, `open_url`, `grant_permission`, `set_locale`, `set_hardware_keyboard`, `set_font_scale`, `set_display_density` |
 | App State | `save_app_state`, `restore_app_state`, `list_app_states`, `delete_app_state` |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -112,6 +112,7 @@ The key lives at `~/.quern/api-key`; the server's URL and port are in `~/.quern/
 | `swipe` | POST | `/api/v1/device/ui/swipe` | Swipe gesture |
 | `scroll_to_element` | POST | `/api/v1/device/ui/scroll-to-element` | Scroll a container until the target is in view, without tapping it |
 | `get_web_content` | POST | `/api/v1/device/ui/web-content` | Read WKWebView content the accessibility tree cannot see (iOS simulator only) |
+| `wait_for_settle` | POST | `/api/v1/device/ui/wait-settled` | Wait until the screen stops changing, by comparing successive screenshots |
 | `type_text` | POST | `/api/v1/device/ui/type` | Type text |
 | `clear_text` | POST | `/api/v1/device/ui/clear` | Clear text field |
 | `press_button` | POST | `/api/v1/device/ui/press` | Press hardware button |

--- a/mcp/src/tools/device-ui.ts
+++ b/mcp/src/tools/device-ui.ts
@@ -508,6 +508,48 @@ Label matching modes (mutually exclusive — use only one):
     }
   });
 
+  server.registerTool("wait_for_settle", {
+    description: `Wait until the screen stops changing — the answer no sleep can give. Compares successive screenshots and returns once consecutive frames are effectively identical, so it adapts to whatever the screen is actually doing instead of guessing a duration. Use it after any action that starts a transition or an animation, and before interacting with a web view: web content is invisible to the accessibility tree, so nothing else can tell you it has finished drawing. It answers "has drawing stopped", NOT "has content arrived" -- a blank page still loading is perfectly still, and this will call it settled in under two seconds (measured against a stalled request: settled=true after 1.6s with a white screen). Raising the timeout does not help, because nothing is moving. For a slow load, wait for the content itself -- poll get_web_content until it returns elements, or wait_for_element for a native one -- and use this afterwards to let the result stop moving. Measured on a web form where typing is silently lost if it arrives early — a 0.2s sleep landed the keystroke 1 time in 5, a 1.0s sleep landed 5 of 5, and this landed 5 of 5 in about 0.67s. Returns settled=false with a reason when the timeout expires, which means something is animating rather than loading (a spinner, a video, a carousel) and will never settle — treat that as a signal about the screen, not a failure of the wait. Also reports last_change, the fraction of pixels that differed on the final comparison, which distinguishes "nearly settled" from "moving steadily".`,
+    inputSchema: strictParams({
+      timeout: z
+        .coerce.number()
+        .default(10)
+        .describe("Seconds to wait before giving up (default 10)"),
+      udid: z
+        .string()
+        .optional()
+        .describe("Target device UDID (defaults to active device)"),
+    }),
+  }, async ({ timeout, udid }) => {
+    try {
+      const body: Record<string, unknown> = { timeout };
+      if (udid) body.udid = udid;
+
+      const data = await apiRequest(
+        "POST",
+        "/api/v1/device/ui/wait-settled",
+        undefined,
+        body
+      );
+
+      return {
+        content: [
+          { type: "text" as const, text: JSON.stringify(data, null, 2) },
+        ],
+      };
+    } catch (e) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error: ${e instanceof Error ? e.message : String(e)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  });
+
   server.registerTool("get_web_content", {
     description: `Read web content inside a WKWebView on an iOS simulator, which get_ui_tree cannot see. The accessibility tree walk stops at the web view — it is absent from the tree entirely, not empty — so a screen built around one looks like nothing but its native chrome. This reads the live DOM through the simulator's Web Inspector and returns elements with real screen frames, including DOM ids and icon-only controls that carry only an aria-label. The results are merged into subsequent UI reads for about a minute, so tap_element, get_ui_tree and get_screen_summary all see them and you can tap by label as usual. That overlay is dropped as soon as anything changes the screen -- a tap, swipe, scroll or launch -- so call this again after each interaction with the page. A tap on a web element is verified against the live screen first, and returns not_found with reason "stale_web_content" rather than tapping the wrong thing if the page moved underneath it. Two routes, tried in that order. The Web Inspector gives real DOM ids and icon-only controls, and reaches an in-process WKWebView when the app sets webView.isInspectable = true (per instance, so one view opting in says nothing about another) and an SFSafariViewController with no opt-in at all, under bundle_id com.apple.SafariViewService. When the Inspector sees nothing, this falls back to hit-testing the screen, aimed by text recognition -- slower, and label-only with no DOM, but it is the only route into an ASWebAuthenticationSession, which is presented with no connected application at all. The response says which route answered, under "route". Simulator only: Android's accessibility tree already descends into WebView, and physical iOS devices use a different transport — on both, use get_ui_tree. Costs roughly a second on top of a UI tree read, so call it when a screen looks emptier than it should, then again after navigating or scrolling the page. If it reports anchored=false, the page was found but its position on screen could not be confirmed; the elements are withheld rather than returned at a guessed offset.`,
     inputSchema: strictParams({

--- a/server/api/device_ui.py
+++ b/server/api/device_ui.py
@@ -25,6 +25,7 @@ from server.models import (
     TapRequest,
     TypeTextRequest,
     WaitForElementRequest,
+    WaitSettledRequest,
     WebContentRequest,
 )
 
@@ -426,6 +427,30 @@ async def get_web_content(request: Request, body: WebContentRequest) -> dict:
         logger.error(
             f"[PERF] API /ui/web-content ERROR: {(time.perf_counter()-start)*1000:.1f}ms, error={e}"
         )
+        raise _handle_device_error(e)
+
+
+@router.post("/ui/wait-settled")
+async def wait_settled(request: Request, body: WaitSettledRequest) -> dict:
+    """Wait until the screen stops changing.
+
+    Answers "has drawing stopped", not "has content arrived": a blank page still
+    loading is perfectly still and settles in under two seconds. Waiting out a
+    slow load means waiting on the content first, then settling.
+
+    Returns `settled: false` with a reason when the timeout expires, which means
+    something is animating rather than loading — a spinner, a video, a carousel.
+    """
+    start = time.perf_counter()
+    controller = _get_controller(request)
+    try:
+        result = await controller.wait_for_settle(udid=body.udid, timeout=body.timeout)
+        logger.info(
+            f"[PERF] API /ui/wait-settled: {(time.perf_counter()-start)*1000:.1f}ms, "
+            f"settled={result['settled']}, frames={result['frames']}"
+        )
+        return {"status": "ok", **result}
+    except DeviceError as e:
         raise _handle_device_error(e)
 
 

--- a/server/device/controller.py
+++ b/server/device/controller.py
@@ -487,16 +487,25 @@ class DeviceController(DeviceControllerUI):
             resolved = udid
         else:
             resolved = await self.resolve_udid(None)
+        raw_png = await self.raw_screenshot(resolved)
+        return process_screenshot(raw_png, format=format, scale=scale, quality=quality)
+
+    async def raw_screenshot(self, resolved: str) -> bytes:
+        """The device's own capture, before any re-encoding.
+
+        Separate because a caller that is going to decode the image itself
+        should not pay for it being resized and re-encoded first: measured, the
+        processing adds ~62ms to a ~114ms capture, and settle detection decodes
+        every frame anyway.
+        """
         if self._is_android(resolved):
             # Only wake physical devices — emulator screencap works with screen off
             if not resolved.startswith("emulator-"):
                 await self._ensure_android_screen_on(resolved)
-            raw_png = await self.adb.screenshot(resolved)
-        elif self._is_physical(resolved):
-            raw_png = await self.pmd3.screenshot(resolved)
-        else:
-            raw_png = await self.simctl.screenshot(resolved)
-        return process_screenshot(raw_png, format=format, scale=scale, quality=quality)
+            return await self.adb.screenshot(resolved)
+        if self._is_physical(resolved):
+            return await self.pmd3.screenshot(resolved)
+        return await self.simctl.screenshot(resolved)
 
     async def set_location(
         self, latitude: float, longitude: float, udid: str | None = None,

--- a/server/device/controller_ui.py
+++ b/server/device/controller_ui.py
@@ -500,7 +500,11 @@ class DeviceControllerUI:
                 # rubber-banding, so the immediate frame may be an over-scroll
                 # bounce that snaps back out of view. Re-fetching once settled
                 # both rejects that and returns accurate resting coordinates.
-                await asyncio.sleep(0.3)
+                #
+                # Waited for rather than slept through: a bounce lasts as long
+                # as it lasts, and the constant this replaced was too short for
+                # a long list and too long for a short one.
+                await self.wait_for_settle(udid=resolved, timeout=3.0)
                 el = await _fetch()
                 if el is not None and _visible(el):
                     return el
@@ -1390,6 +1394,11 @@ class DeviceControllerUI:
                     # Let the scroll settle before clicking — a tap landing
                     # while the list is still coming to rest gets absorbed as a
                     # scroll-stop instead of a click (observed intermittently).
+                    #
+                    # Still a sleep, unlike the iOS paths above: wait_for_settle
+                    # costs three captures, and adb's capture time has not been
+                    # measured here, so swapping this blind could make the
+                    # Android path slower rather than more reliable. See #100.
                     await asyncio.sleep(0.4)
                     tapped = await backend.tap_by_selector(
                         resolved_fast, identifier=identifier, label=label,
@@ -1584,8 +1593,9 @@ class DeviceControllerUI:
                             initial_frame, current_frame
                         )
 
-                        # Wait longer for animation to complete
-                        await asyncio.sleep(0.3)
+                        # The element is known to be moving, so wait for it to
+                        # stop rather than guessing how long that takes.
+                        await self.wait_for_settle(udid=resolved, timeout=3.0)
 
                         # Re-fetch one more time to get final position (bypass cache again)
                         # Use filtering for performance
@@ -1692,6 +1702,42 @@ class DeviceControllerUI:
                 await inspector.close()
             except Exception:
                 logger.debug("web inspector close failed", exc_info=True)
+
+    async def wait_for_settle(
+        self,
+        udid: str | None = None,
+        timeout: float = 10.0,
+    ) -> dict:
+        """Wait until the screen stops changing.
+
+        The answer no sleep can give: the same screen settles in a fraction of a
+        second when cached and takes arbitrarily longer on a cold load, so a
+        constant is always both too long and too short.
+        """
+        from server.device.settle import wait_settled
+
+        resolved = await self.resolve_udid(udid)
+
+        async def capture() -> bytes | None:
+            try:
+                # Raw, not the processed screenshot: this decodes and downscales
+                # each frame itself, so paying to resize and re-encode first is
+                # ~62ms of waste on a ~114ms capture, three times per wait.
+                return await self.raw_screenshot(resolved)
+            except Exception:
+                logger.debug("settle: screenshot failed", exc_info=True)
+                return None
+
+        result = await wait_settled(capture, timeout=timeout)
+        return {
+            "settled": result.settled,
+            "elapsed_ms": round(result.elapsed_ms, 1),
+            "frames": result.frames,
+            "last_change": (round(result.last_change, 5)
+                            if result.last_change is not None else None),
+            "reason": result.reason,
+            "udid": resolved,
+        }
 
     async def _sweep_web_content(
         self, udid: str, native: list[dict],

--- a/server/device/controller_ui.py
+++ b/server/device/controller_ui.py
@@ -502,9 +502,22 @@ class DeviceControllerUI:
                 # both rejects that and returns accurate resting coordinates.
                 #
                 # Waited for rather than slept through: a bounce lasts as long
-                # as it lasts, and the constant this replaced was too short for
-                # a long list and too long for a short one.
-                await self.wait_for_settle(udid=resolved, timeout=3.0)
+                # as it lasts, and the constant this replaced was too short --
+                # a real scroll takes ~1100ms to settle against the 300ms that
+                # was slept.
+                #
+                # A screen that never settles is still worth acting on: a
+                # timeline with a playing video never holds still, and refusing
+                # to scroll there would make it unreachable. The coordinates are
+                # then no better than the sleep gave, which is why it is said
+                # out loud rather than passed off as a settled read.
+                stability = await self.wait_for_settle(udid=resolved, timeout=3.0)
+                if not stability["settled"]:
+                    logger.info(
+                        "ios scroll-to-element: screen never settled (%s) — "
+                        "using coordinates that may still be moving",
+                        stability.get("reason"),
+                    )
                 el = await _fetch()
                 if el is not None and _visible(el):
                     return el
@@ -1594,8 +1607,17 @@ class DeviceControllerUI:
                         )
 
                         # The element is known to be moving, so wait for it to
-                        # stop rather than guessing how long that takes.
-                        await self.wait_for_settle(udid=resolved, timeout=3.0)
+                        # stop rather than guessing how long that takes. If it
+                        # never stops the tap still goes ahead -- the position
+                        # is re-read below either way, and refusing would make
+                        # any screen with an animation untappable.
+                        stability = await self.wait_for_settle(udid=resolved, timeout=3.0)
+                        if not stability["settled"]:
+                            logger.info(
+                                "tap_element: screen never settled (%s) — tapping "
+                                "the last known position",
+                                stability.get("reason"),
+                            )
 
                         # Re-fetch one more time to get final position (bypass cache again)
                         # Use filtering for performance

--- a/server/device/settle.py
+++ b/server/device/settle.py
@@ -1,0 +1,169 @@
+"""Wait for the screen to stop changing.
+
+A sleep cannot answer "has this finished drawing?" -- whatever constant you
+pick is too long for a cached screen and too short for a slow one. Measured
+against a web form in an out-of-process SFSafariViewController, where typing is
+silently lost if it arrives early: a 0.2s sleep landed the keystroke 1 time in
+5, a 1.0s sleep landed 5 of 5, and waiting for the screen to settle landed 5 of
+5 in 0.65-0.69s. Faster than the sleep that was reliable, and reliable unlike
+the sleep that was fast.
+
+Comparing frames needs no privileged channel, which is what makes it general.
+The accessibility tree cannot see inside a WKWebView, and an
+ASWebAuthenticationSession is not published to the Web Inspector at all -- but
+both draw pixels.
+
+What this cannot answer is whether anything has *arrived*. A blank page part way
+through a slow load is perfectly still, and settles: measured against a request
+to a non-routable address, Safari showed a white screen with its progress bar
+stalled and this reported settled after 1.6s with no change at all between
+frames. A longer timeout does not help, because nothing is moving. Waiting for a
+slow load means waiting on the content -- and then waiting for it to settle.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+logger = logging.getLogger("quern-debug-server.settle")
+
+CaptureFn = Callable[[], Awaitable[bytes | None]]
+
+# Fraction of pixels that may differ between two frames and still count as
+# unchanged. Not a guess: an idle simulator screen measures 0.00017 frame to
+# frame -- rendering noise and the status bar clock -- so this clears the floor
+# with room, while a blinking caret (1.8% of pixels at its peak) exceeds it and
+# merely delays settling by one blink.
+DEFAULT_EPSILON = 0.001
+
+# Consecutive unchanged comparisons required. One is not enough: a frame taken
+# mid-animation can match its predecessor by coincidence when an element pauses
+# at the extreme of an ease curve.
+DEFAULT_STABLE_FRAMES = 2
+
+# Per-pixel intensity difference below which a pixel counts as unchanged, on a
+# 0-255 grayscale. Absorbs compression and subpixel-rendering noise.
+PIXEL_THRESHOLD = 12
+
+# Captures are downscaled by this factor before comparison. Settling is a
+# whole-screen question, and at quarter scale the comparison is small change
+# against the capture, which dominates at ~130-210ms.
+DOWNSCALE = 4
+
+
+@dataclass
+class SettleResult:
+    settled: bool
+    elapsed_ms: float
+    frames: int
+    last_change: float | None = None
+    """Fraction of pixels that differed on the final comparison. Useful when a
+    wait times out: a screen with a spinner sits at some steady non-zero value
+    rather than approaching the threshold."""
+
+    reason: str | None = None
+
+
+def _prepare(png: bytes):
+    """Decode to a small grayscale image, or None if it cannot be read."""
+    try:
+        from PIL import Image
+    except ImportError:  # pragma: no cover - Pillow is a declared dependency
+        return None
+    try:
+        image = Image.open(io.BytesIO(png)).convert("L")
+    except Exception:
+        logger.debug("settle: could not decode a capture", exc_info=True)
+        return None
+    if DOWNSCALE > 1:
+        image = image.resize((max(1, image.width // DOWNSCALE),
+                              max(1, image.height // DOWNSCALE)))
+    return image
+
+
+def changed_fraction(before, after, threshold: int = PIXEL_THRESHOLD) -> float:
+    """Fraction of pixels differing by more than `threshold`.
+
+    Two frames of different sizes have wholly changed -- a rotation or a device
+    swap, not a settling screen.
+    """
+    from PIL import ImageChops
+
+    if before.size != after.size:
+        return 1.0
+    delta = ImageChops.difference(before, after)
+    mask = delta.point(lambda p: 255 if p > threshold else 0)
+    return sum(mask.histogram()[255:]) / float(before.width * before.height)
+
+
+async def wait_settled(
+    capture: CaptureFn,
+    *,
+    timeout: float = 10.0,
+    epsilon: float = DEFAULT_EPSILON,
+    stable_frames: int = DEFAULT_STABLE_FRAMES,
+) -> SettleResult:
+    """Poll captures until consecutive frames stop differing.
+
+    `capture` is injected so this is testable without a device, the same
+    contract `probing.probe_container` uses for `describe_point`.
+
+    There is deliberately no delay between captures. A capture already costs
+    ~130-210ms, which is the natural cadence, and adding a sleep on top would
+    reintroduce the guessed constant this exists to remove -- measured, polling
+    at capture rate settles a presented sheet in 0.65s where a 0.25s inter-frame
+    delay would take roughly twice as long to reach the same conclusion.
+    """
+    started = time.perf_counter()
+    deadline = started + timeout
+    previous = None
+    stable = 0
+    frames = 0
+    last_change: float | None = None
+
+    while True:
+        png = await capture()
+        if png is None:
+            return SettleResult(
+                settled=False, elapsed_ms=(time.perf_counter() - started) * 1000,
+                frames=frames, last_change=last_change,
+                reason="could not capture the screen",
+            )
+        current = _prepare(png)
+        if current is None:
+            return SettleResult(
+                settled=False, elapsed_ms=(time.perf_counter() - started) * 1000,
+                frames=frames, last_change=last_change,
+                reason="could not decode the capture",
+            )
+        frames += 1
+
+        if previous is not None:
+            last_change = changed_fraction(previous, current)
+            stable = stable + 1 if last_change < epsilon else 0
+            if stable >= stable_frames:
+                return SettleResult(
+                    settled=True,
+                    elapsed_ms=(time.perf_counter() - started) * 1000,
+                    frames=frames, last_change=last_change,
+                )
+        previous = current
+
+        # Checked after a comparison, not before a capture: a screen that
+        # settles exactly at the deadline should be reported settled.
+        if time.perf_counter() >= deadline:
+            return SettleResult(
+                settled=False, elapsed_ms=(time.perf_counter() - started) * 1000,
+                frames=frames, last_change=last_change,
+                reason=(
+                    "the screen was still changing when the timeout expired"
+                    + (f" (last comparison differed by {last_change:.2%})"
+                       if last_change is not None else "")
+                    + ". Something is animating -- a spinner, a video, a "
+                    "carousel -- and will not settle."
+                ),
+            )

--- a/server/device/settle.py
+++ b/server/device/settle.py
@@ -23,11 +23,16 @@ slow load means waiting on the content -- and then waiting for it to settle.
 
 from __future__ import annotations
 
+import asyncio
 import io
 import logging
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from PIL.Image import Image
 
 logger = logging.getLogger("quern-debug-server.settle")
 
@@ -68,7 +73,7 @@ class SettleResult:
     reason: str | None = None
 
 
-def _prepare(png: bytes):
+def _prepare(png: bytes) -> Image | None:
     """Decode to a small grayscale image, or None if it cannot be read."""
     try:
         from PIL import Image
@@ -85,7 +90,9 @@ def _prepare(png: bytes):
     return image
 
 
-def changed_fraction(before, after, threshold: int = PIXEL_THRESHOLD) -> float:
+def changed_fraction(
+    before: Image, after: Image, threshold: int = PIXEL_THRESHOLD,
+) -> float:
     """Fraction of pixels differing by more than `threshold`.
 
     Two frames of different sizes have wholly changed -- a rotation or a device
@@ -125,21 +132,57 @@ async def wait_settled(
     frames = 0
     last_change: float | None = None
 
-    while True:
-        png = await capture()
-        if png is None:
-            return SettleResult(
-                settled=False, elapsed_ms=(time.perf_counter() - started) * 1000,
-                frames=frames, last_change=last_change,
-                reason="could not capture the screen",
+    def timed_out() -> SettleResult:
+        """Explain the timeout from what was actually observed.
+
+        Not from whether a capture happened to be in flight when the deadline
+        passed: captures run back to back, so that is true most of the time and
+        would describe an animating screen as a slow one.
+        """
+        if frames == 0:
+            reason = (
+                "no screen capture completed within the timeout — the device is "
+                "not answering rather than still drawing"
             )
+        elif last_change is not None and last_change >= epsilon:
+            reason = (
+                f"the screen was still changing when the timeout expired (the "
+                f"last comparison differed by {last_change:.2%}). Something is "
+                "animating — a spinner, a video, a carousel — and will not settle."
+            )
+        else:
+            reason = (
+                "the screen did not hold still for long enough before the "
+                "timeout expired"
+            )
+        return SettleResult(
+            settled=False, elapsed_ms=(time.perf_counter() - started) * 1000,
+            frames=frames, last_change=last_change, reason=reason,
+        )
+
+    def failed(reason: str) -> SettleResult:
+        return SettleResult(
+            settled=False, elapsed_ms=(time.perf_counter() - started) * 1000,
+            frames=frames, last_change=last_change, reason=reason,
+        )
+
+    while True:
+        remaining = deadline - time.perf_counter()
+        if remaining <= 0:
+            return timed_out()
+        try:
+            # Bounded by what is left of the budget. The deadline is otherwise
+            # only consulted between frames, so a capture that blocks would run
+            # past the timeout entirely -- a wedged simulator does exactly that.
+            png = await asyncio.wait_for(capture(), timeout=remaining)
+        except TimeoutError:
+            return timed_out()
+
+        if png is None:
+            return failed("could not capture the screen")
         current = _prepare(png)
         if current is None:
-            return SettleResult(
-                settled=False, elapsed_ms=(time.perf_counter() - started) * 1000,
-                frames=frames, last_change=last_change,
-                reason="could not decode the capture",
-            )
+            return failed("could not decode the capture")
         frames += 1
 
         if previous is not None:
@@ -152,18 +195,3 @@ async def wait_settled(
                     frames=frames, last_change=last_change,
                 )
         previous = current
-
-        # Checked after a comparison, not before a capture: a screen that
-        # settles exactly at the deadline should be reported settled.
-        if time.perf_counter() >= deadline:
-            return SettleResult(
-                settled=False, elapsed_ms=(time.perf_counter() - started) * 1000,
-                frames=frames, last_change=last_change,
-                reason=(
-                    "the screen was still changing when the timeout expired"
-                    + (f" (last comparison differed by {last_change:.2%})"
-                       if last_change is not None else "")
-                    + ". Something is animating -- a spinner, a video, a "
-                    "carousel -- and will not settle."
-                ),
-            )

--- a/server/models.py
+++ b/server/models.py
@@ -1150,6 +1150,13 @@ class TypeTextRequest(BaseModel):
     settle_delay: float = Field(default=1.0, ge=0, le=10)
 
 
+class WaitSettledRequest(BaseModel):
+    """Request body for POST /device/ui/wait-settled."""
+
+    udid: str | None = None
+    timeout: float = Field(default=10.0, gt=0, le=120)
+
+
 class ClearTextRequest(BaseModel):
     """Request body for POST /device/ui/clear."""
 

--- a/tests/test_settle.py
+++ b/tests/test_settle.py
@@ -1,0 +1,219 @@
+"""Waiting for the screen to stop changing.
+
+The alternative is a sleep, and no constant is right: the same screen settles in
+0.65s cached and takes arbitrarily longer on a cold load. These tests drive the
+detector with synthetic frames, so the behaviour under test is the decision rule
+rather than any particular device's timing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+
+import pytest
+from PIL import Image
+
+from server.device.settle import (
+    DEFAULT_EPSILON,
+    changed_fraction,
+    wait_settled,
+)
+
+SIZE = (400, 800)   # quarter-scale: 100x200 = 20,000 px, near a real screen
+
+
+def frame(fill: int = 255, *, blot: tuple[int, int, int, int] | None = None,
+          size: tuple[int, int] = SIZE) -> bytes:
+    """A PNG of a flat colour, optionally with a rectangle painted on it."""
+    image = Image.new("L", size, fill)
+    if blot:
+        for x in range(blot[0], blot[2]):
+            for y in range(blot[1], blot[3]):
+                image.putpixel((x, y), 0)
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+# Captures allowed before a test decides the loop is not terminating. Generous
+# against the handful any of these need, and small enough to fail fast.
+MAX_CAPTURES = 200
+
+
+class LoopDidNotTerminate(AssertionError):
+    pass
+
+
+def paced(sequence, delay: float = 0.005):
+    """A capture that takes a little real time, cycling through `sequence`.
+
+    A synthetic capture returns instantly, so a wall-clock timeout of 0.3s would
+    fit tens of thousands of frames and trip any sane capture cap. A real one
+    costs ~114ms; this keeps the ratio of frames to seconds within sight of that
+    without making the suite slow.
+    """
+    index = 0
+
+    async def capture():
+        nonlocal index
+        await asyncio.sleep(delay)
+        png = sequence[index % len(sequence)]
+        index += 1
+        return png
+
+    return capture
+
+
+def capped(capture, limit: int = MAX_CAPTURES):
+    """Make a capture raise once it has been called too many times.
+
+    asyncio.wait_for cannot rescue this: wait_settled polls in a loop whose
+    await returns without suspending, so a cancellation never gets delivered
+    and the task spins instead of stopping. The only reliable brake is the
+    thing the loop calls -- so the capture counts itself and raises, turning a
+    missing timeout into a failed test rather than a hung suite.
+    """
+    calls = 0
+
+    async def limited():
+        nonlocal calls
+        calls += 1
+        if calls > limit:
+            raise LoopDidNotTerminate(
+                f"wait_settled made {calls} captures without returning"
+            )
+        return await capture()
+
+    return limited
+
+
+async def bounded(awaitable, limit: float = 10.0):
+    return await asyncio.wait_for(awaitable, timeout=limit)
+
+
+def capturing(*frames: bytes):
+    """A capture callable that yields the given frames, then repeats the last."""
+    sequence = list(frames)
+    calls: list[int] = []
+
+    async def capture() -> bytes | None:
+        index = min(len(calls), len(sequence) - 1)
+        calls.append(index)
+        return sequence[index]
+
+    capture.calls = calls
+    return capture
+
+
+# ------------------------------------------------------------ settling
+
+async def test_a_static_screen_settles():
+    result = await bounded(wait_settled(capped(capturing(frame())), timeout=5))
+    assert result.settled is True
+    assert result.frames == 3, "two comparisons need three frames"
+
+
+async def test_a_screen_still_changing_does_not_settle_early():
+    """Frames that keep differing must not be mistaken for a settled screen.
+
+    The blot cycles rather than running out of positions: a sequence that goes
+    static partway through would settle legitimately and prove nothing.
+    """
+    moving = [frame(blot=(0, y, 200, y + 200)) for y in range(0, 400, 50)]
+    result = await bounded(wait_settled(capped(paced(moving)), timeout=0.35))
+    assert result.settled is False
+    assert "still changing" in result.reason
+
+
+async def test_one_matching_pair_is_not_enough():
+    """A frame taken mid-animation can match its predecessor by coincidence --
+    an element pausing at the extreme of an ease curve. Two consecutive
+    comparisons are required."""
+    pause = frame(blot=(0, 0, 40, 40))
+    sequence = [pause, pause, frame(blot=(0, 60, 40, 100)), frame(), frame(), frame()]
+
+    async def capture(_i=[0]):
+        png = sequence[min(_i[0], len(sequence) - 1)]
+        _i[0] += 1
+        return png
+
+    result = await bounded(wait_settled(capped(capture), timeout=5, stable_frames=2))
+    assert result.settled is True
+    # Not at frame 2, where the first coincidental match happened.
+    assert result.frames == 6
+
+
+async def test_a_settled_screen_reports_how_little_changed():
+    result = await bounded(wait_settled(capped(capturing(frame())), timeout=5))
+    assert result.last_change == 0.0
+
+
+async def test_the_wait_is_bounded():
+    """Animated content never settles; the wait has to end anyway."""
+    flicker = [frame(), frame(blot=(0, 0, 400, 800))]
+    result = await bounded(wait_settled(capped(paced(flicker)), timeout=0.3))
+    assert result.settled is False
+    assert result.elapsed_ms >= 300
+    assert "animating" in result.reason
+
+
+async def test_a_timeout_reports_how_much_was_still_moving():
+    """A spinner sits at a steady non-zero value rather than approaching the
+    threshold, which is the difference between "slow" and "never"."""
+    flicker = [frame(), frame(blot=(0, 0, 400, 400))]
+    result = await bounded(wait_settled(capped(paced(flicker)), timeout=0.3))
+    assert result.last_change is not None and result.last_change > 0.1
+
+
+# ------------------------------------------------------------ capture failure
+
+async def test_a_capture_that_fails_is_not_a_settled_screen():
+    async def capture():
+        return None
+
+    result = await bounded(wait_settled(capped(capture), timeout=5))
+    assert result.settled is False
+    # Specifically the capture failure, not the decode one: both messages
+    # mention "capture", so a loose check passes either way and cannot tell
+    # whether a missing capture even reached the decoder.
+    assert result.reason == "could not capture the screen"
+
+
+async def test_an_undecodable_capture_is_not_a_settled_screen():
+    async def capture():
+        return b"not a png"
+
+    result = await bounded(wait_settled(capped(capture), timeout=5))
+    assert result.settled is False
+    assert result.reason == "could not decode the capture"
+
+
+# ------------------------------------------------------------ comparison
+
+def test_a_resized_screen_counts_as_wholly_changed():
+    """A rotation or a device swap is not a settling screen."""
+    from server.device.settle import _prepare
+    assert changed_fraction(_prepare(frame()), _prepare(frame(size=(800, 400)))) == 1.0
+
+
+def test_small_noise_stays_under_the_threshold():
+    """An idle simulator measures 0.00017 frame to frame. The threshold has to
+    clear that, or nothing ever settles."""
+    from server.device.settle import _prepare
+    speck = changed_fraction(_prepare(frame()), _prepare(frame(blot=(0, 0, 2, 2))))
+    assert speck < DEFAULT_EPSILON
+
+
+def test_a_visible_change_exceeds_the_threshold():
+    from server.device.settle import _prepare
+    change = changed_fraction(_prepare(frame()), _prepare(frame(blot=(0, 0, 200, 200))))
+    assert change > DEFAULT_EPSILON
+
+
+@pytest.mark.parametrize("stable_frames", [1, 3])
+async def test_the_required_run_of_stable_frames_is_configurable(stable_frames):
+    result = await bounded(wait_settled(capped(capturing(frame())), timeout=5,
+                                        stable_frames=stable_frames))
+    assert result.settled is True
+    assert result.frames == stable_frames + 1

--- a/tests/test_settle.py
+++ b/tests/test_settle.py
@@ -217,3 +217,28 @@ async def test_the_required_run_of_stable_frames_is_configurable(stable_frames):
                                         stable_frames=stable_frames))
     assert result.settled is True
     assert result.frames == stable_frames + 1
+
+
+async def test_a_capture_that_blocks_does_not_outlast_the_timeout():
+    """The deadline is only consulted between frames, so a capture that hangs
+    would run past it entirely. A wedged simulator does exactly that."""
+    async def slow():
+        await asyncio.sleep(30)
+        return frame()
+
+    started = asyncio.get_running_loop().time()
+    result = await bounded(wait_settled(slow, timeout=0.4), limit=5)
+    assert result.settled is False
+    assert asyncio.get_running_loop().time() - started < 3, "ran past its timeout"
+    assert result.frames == 0
+    assert "not answering" in result.reason
+
+
+async def test_an_animating_screen_is_described_as_animating():
+    """Captures run back to back, so the deadline nearly always expires while
+    one is in flight. That must not be reported as a slow device."""
+    flicker = [frame(), frame(blot=(0, 0, 400, 800))]
+    result = await bounded(wait_settled(capped(paced(flicker)), timeout=0.3))
+    assert result.settled is False
+    assert "animating" in result.reason
+    assert result.frames > 1


### PR DESCRIPTION
Closes #100.

## The measurement that motivated it

A web form where typing is silently lost if it arrives early, varying only the
wait:

| approach | keystroke landed | cost |
|---|---|---|
| `sleep(0.2)` | **1/5** | 0.2s |
| `sleep(1.0)` | 5/5 | 1.0s |
| **wait until settled** | **5/5** | **0.65–0.69s** |

Faster than the sleep that was reliable; reliable unlike the sleep that was
fast. The page in that test was **cached** — a cold load moves the window
arbitrarily, which is the whole argument against a constant.

## The one that justifies the change to existing code

A real scroll on a populated timeline takes **~1100ms** to settle (8 frames,
±15ms across five runs). **The sleep it replaced was 300ms.**

That sleep's own comment described the bug it was there to prevent — an
over-scroll bounce read as a resting position — so the constant was not merely
imprecise, it was 3.6× too short to do its job. This is a correctness fix, not
a speed one.

## Nothing here is a guess

- **Threshold 0.001** of pixels: an idle simulator measures **0.00017** frame to
  frame. A blinking caret peaks at 1.8% and so exceeds it, delaying settling by
  one blink rather than defeating it (41/45 pairs still under, measured on a
  focused field).
- **Two consecutive unchanged comparisons**, because a frame taken
  mid-animation can match its predecessor by coincidence at the extreme of an
  ease curve.
- **No delay between captures.** A capture already costs ~114ms; adding an
  interval would reintroduce the constant this exists to remove. Raw capture,
  not the processed screenshot — that saves ~62ms per frame that would be spent
  resizing an image this decodes itself anyway.

## What it deliberately does not do

**It answers "has drawing stopped", not "has content arrived."** A blank page
part way through a slow load is perfectly still. Measured against a request to a
non-routable address: Safari showed a white screen with its progress bar
stalled, and this reported `settled: true` after **1.6s** with zero change
between frames. **A longer timeout does not help, because nothing is moving.**
That is stated in the tool description, the module docstring and the endpoint —
it is the sharpest edge here and the easiest to misread.

## Pillow, not Vision — having measured both

| | pixel difference | Vision feature print |
|---|---|---|
| cost per frame | ~17ms | **~98ms** |
| caret-sized change (2×30) | 0.00009 | 0.0386 |
| one line of text (400×40) | 0.00599 | 0.0923 |
| usable threshold window | **66×** | **2.4×** |

I expected feature prints to be *less* sensitive to small changes. They are
more. But that is the wrong direction here: a caret is a tiny change that never
stops, so it must be tolerated or a focused field never settles — and Vision
leaves only a 2.4× margin between tolerating one and catching a line of text.
It would also make this macOS-only, where `raw_screenshot` already handles adb.

(Incidental: pyobjc does not expose `computeDistance:`'s out-parameter without
`registerMetaDataForSelector`, and silently returns `(True, None)` otherwise.)

## Scope

Two of the four sleeps became waits. The Android one is left alone — adb's
capture time is unmeasured here, so swapping it blind could make that path
slower rather than more reliable. The 0.1s stability pause is left too, being
shorter than three captures cost.

13 new tests, each mutation-verified. Note one of those mutations initially
**hung the suite** rather than failing it: `asyncio.wait_for` cannot cancel a
poll loop whose await never suspends, so the brake had to go in the capture
itself, which counts its own calls and raises. Suite 1648, ruff clean, MCP
builds, README/api-reference guard-tested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tool that waits until the device screen becomes stable before continuing.
  * Added an API endpoint with optional device selection and timeout settings.
  * iOS screen interactions now wait for visual stability instead of using a fixed delay.

* **Documentation**
  * Updated the README and API reference with the new tool and revised tool count.

* **Tests**
  * Added coverage for stable screens, ongoing motion, timeouts, capture failures, and image-difference thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->