### PR TITLE
fix: actually clear a web text field

### DIFF
--- a/mcp/src/tools/device-ui.ts
+++ b/mcp/src/tools/device-ui.ts
@@ -705,7 +705,7 @@ Label matching modes (mutually exclusive — use only one):
   });
 
   server.registerTool("clear_text", {
-    description: `Clear a text field (select-all + delete), before type_text when the field already holds content. Pass label or identifier to say WHICH field: without one this picks the first field that has a value, which is not the field you just tapped -- on a sign-in form, clearing before typing the password finds the email field and empties that instead. Focus cannot be detected; the accessibility tree does not report it. Select-all takes a line at a time, so a long or wrapped value may need clearing more than once; check the value and repeat. Secure text fields (passwords) may not support select-all at all.`,
+    description: `Clear a text field (select-all + delete), before type_text when the field already holds content. Pass label or identifier to say WHICH field: without one this picks the first field that has a value, which is not the field you just tapped -- on a sign-in form, clearing before typing the password finds the email field and empties that instead. Focus cannot be detected; the accessibility tree does not report it. A web field is cleared through the Web Inspector when the page is visible to it (a few milliseconds), and by keystroke otherwise -- about 63ms per character, so a long value takes seconds. Either way the field ends empty. Secure text fields (passwords) may not support select-all at all.`,
     inputSchema: strictParams({
       label: z
         .string()

--- a/server/device/controller_ui.py
+++ b/server/device/controller_ui.py
@@ -2174,25 +2174,24 @@ class DeviceControllerUI:
 
         cx = target.frame["x"] + target.frame["width"] / 2
         cy = target.frame["y"] + target.frame["height"] / 2
-
         backend = self._ui_backend(resolved)
-        await backend.select_all_and_delete(
-            resolved, x=cx, y=cy, element_type=target.type,
-        )
 
-        # Native fields are done: the triple-tap selects the whole value and the
-        # backspace clears it, measured at 60 characters to 0 in one call.
-        #
-        # A web input usually does not honour the triple-tap, and the backspace
-        # then removes a single character -- measured on a form inside an
-        # SFSafariViewController, one call took 26 characters to 25, so the
-        # field looks cleared without being cleared. Only those need more work,
-        # and the source says which is which. Deciding by re-reading the field
-        # instead would cost a full tree walk on every clear, native ones
-        # included, to learn something already known.
+        # The triple-tap selects the whole value in a native text view --
+        # measured at 60 characters to 0 in one call -- and is all that is
+        # needed there.
         if (target.extra_attrs or {}).get("source") not in ("web-inspector", "web-probe"):
+            await backend.select_all_and_delete(
+                resolved, x=cx, y=cy, element_type=target.type,
+            )
             self._invalidate_ui_cache(resolved)
             return resolved
+
+        # A web input does not honour it: measured inside an
+        # SFSafariViewController, one call took 26 characters to 25. Running it
+        # here would achieve nothing except quietly editing a field this may be
+        # about to refuse to clear. One tap, to put the caret in it.
+        await backend.tap(resolved, cx, cy)
+        await asyncio.sleep(0.2)
 
         # Attempted regardless of the cached length: `value` is an overlay
         # snapshot and can be stale, and this route verifies itself -- it
@@ -2203,8 +2202,8 @@ class DeviceControllerUI:
 
         remaining = len(target.value or "")
         if remaining > self._MAX_DELETE:
-            # Better to say so than to send 500 backspaces at a longer field and
-            # report ok over a value that is still partly there.
+            # Refused before touching it. Sending the cap and reporting ok over
+            # a value still partly there is the failure being fixed here.
             raise DeviceError(
                 f"'{target.label or target.identifier}' holds {remaining} "
                 f"characters, more than the {self._MAX_DELETE} this can clear by "
@@ -2215,10 +2214,9 @@ class DeviceControllerUI:
             )
 
         if remaining and hasattr(backend, "delete_backwards"):
-            # Tap near the trailing edge first: backspace only deletes behind
-            # the caret, and a tap in the middle of the text would leave
-            # everything after it. Then overshoot -- backspace on an empty field
-            # does nothing, and the length may be a moment stale.
+            # Backspace only deletes behind the caret, so put it past the last
+            # character first, then overshoot -- an extra keystroke on an empty
+            # field does nothing, and the length may be a moment stale.
             edge_x = target.frame["x"] + target.frame["width"] - self._CARET_EDGE_INSET
             await backend.tap(resolved, min(edge_x, cx + target.frame["width"] / 2), cy)
             await asyncio.sleep(0.2)

--- a/server/device/controller_ui.py
+++ b/server/device/controller_ui.py
@@ -734,6 +734,9 @@ class DeviceControllerUI:
             parsed.append(UIElement(
                 type=element.get("type") or "Other",
                 label=element.get("AXLabel") or "",
+                # Carried, not dropped: clear_text sizes its work from the
+                # value, and a web field reporting None reads as already empty.
+                value=element.get("value"),
                 # A DOM id is not an accessibility identifier and must not
                 # masquerade as one: it never appears in the native tree, so
                 # letting it match `identifier=` would make a web-only lookup
@@ -1725,6 +1728,50 @@ class DeviceControllerUI:
             except Exception:
                 logger.debug("web inspector close failed", exc_info=True)
 
+    async def _clear_web_input(self, udid: str) -> bool:
+        """Empty the focused web input through the Web Inspector, if it can.
+
+        Measured against a 55-character field: 6ms, where the same clear by
+        keystroke costs ~3.5s. Not a replacement for the keystroke path, which
+        is the only one that works where the Inspector sees nothing -- an
+        ASWebAuthenticationSession reports no connected application at all, and
+        that is the OAuth form every app has.
+        """
+        if self._is_android(udid) or self._is_physical(udid):
+            return False
+        from server.device.web_content import _is_app
+
+        async def attempt() -> bool:
+            async with self._web_inspector_op_lock:
+                inspector = await self._connected_web_inspector()
+                for application in await inspector.connected_applications():
+                    app_id = application.get("application_id")
+                    if not app_id or not _is_app(application):
+                        continue
+                    for page in await inspector.pages(app_id):
+                        # Every page is asked; only the one with an input
+                        # focused acts, so this cannot empty a field on a page
+                        # the caller was not typing into.
+                        if await inspector.clear_focused_input(app_id, page["page_id"]):
+                            return True
+            return False
+
+        for retry in (False, True):
+            try:
+                if await attempt():
+                    return True
+            except Exception:
+                logger.debug("web input clear via the inspector failed",
+                             exc_info=True)
+            if retry:
+                break
+            # The connection is long-lived and can be dead by the time it is
+            # used -- the symptom is an incomplete read, not an error on
+            # connect. Reconnect once before falling back to keystrokes, which
+            # cost ~63ms per character against this path's 6ms.
+            await self._close_web_inspector()
+        return False
+
     async def wait_for_settle(
         self,
         udid: str | None = None,
@@ -2055,6 +2102,19 @@ class DeviceControllerUI:
 
     _TEXT_FIELD_TYPES = ("TextField", "SecureTextField", "TextArea", "SearchField")
 
+    # Points in from the field's trailing edge for the caret-placing tap. Inside
+    # the field, past the end of any text that fits.
+    _CARET_EDGE_INSET = 8.0
+
+    # Extra backspaces beyond the value's known length. The length can be a
+    # moment stale, and an extra keystroke on an empty field does nothing.
+    _DELETE_OVERSHOOT = 8
+
+    # A ceiling on the work. At the bridge's ~63ms per keystroke, this is about
+    # thirty seconds; a field longer than this wants a different approach, not a
+    # longer wait.
+    _MAX_DELETE = 500
+
     async def clear_text(
         self,
         udid: str | None = None,
@@ -2104,9 +2164,42 @@ class DeviceControllerUI:
         cx = target.frame["x"] + target.frame["width"] / 2
         cy = target.frame["y"] + target.frame["height"] / 2
 
-        await self._ui_backend(resolved).select_all_and_delete(
+        backend = self._ui_backend(resolved)
+        await backend.select_all_and_delete(
             resolved, x=cx, y=cy, element_type=target.type,
         )
+
+        # Native fields are done: the triple-tap selects the whole value and the
+        # backspace clears it, measured at 60 characters to 0 in one call.
+        #
+        # A web input usually does not honour the triple-tap, and the backspace
+        # then removes a single character -- measured on a form inside an
+        # SFSafariViewController, one call took 26 characters to 25, so the
+        # field looks cleared without being cleared. Only those need more work,
+        # and the source says which is which. Deciding by re-reading the field
+        # instead would cost a full tree walk on every clear, native ones
+        # included, to learn something already known.
+        if (target.extra_attrs or {}).get("source") not in ("web-inspector", "web-probe"):
+            self._invalidate_ui_cache(resolved)
+            return resolved
+
+        remaining = len(target.value or "")
+        if remaining and await self._clear_web_input(resolved):
+            self._invalidate_ui_cache(resolved)
+            return resolved
+
+        if remaining and hasattr(backend, "delete_backwards"):
+            # Tap near the trailing edge first: backspace only deletes behind
+            # the caret, and a tap in the middle of the text would leave
+            # everything after it. Then overshoot -- backspace on an empty field
+            # does nothing, and the length may be a moment stale.
+            edge_x = target.frame["x"] + target.frame["width"] - self._CARET_EDGE_INSET
+            await backend.tap(resolved, min(edge_x, cx + target.frame["width"] / 2), cy)
+            await asyncio.sleep(0.2)
+            await backend.delete_backwards(
+                resolved, min(remaining + self._DELETE_OVERSHOOT, self._MAX_DELETE),
+            )
+
         self._invalidate_ui_cache(resolved)
         return resolved
 

--- a/server/device/controller_ui.py
+++ b/server/device/controller_ui.py
@@ -1740,6 +1740,10 @@ class DeviceControllerUI:
         if self._is_android(udid) or self._is_physical(udid):
             return False
         from server.device.web_content import _is_app
+        from server.device.webinspector import simulator_udid_for_application
+
+        booted = await self._booted_simulator_count()
+        require_match = booted is None or booted > 1
 
         async def attempt() -> bool:
             async with self._web_inspector_op_lock:
@@ -1747,6 +1751,13 @@ class DeviceControllerUI:
                 for application in await inspector.connected_applications():
                     app_id = application.get("application_id")
                     if not app_id or not _is_app(application):
+                        continue
+                    # The socket carries no UDID. Without this, a focused input
+                    # on another booted simulator would be cleared instead --
+                    # and reported as success, so the field actually asked about
+                    # would be left alone.
+                    owner = await simulator_udid_for_application(app_id)
+                    if owner != udid and (owner is not None or require_match):
                         continue
                     for page in await inspector.pages(app_id):
                         # Every page is asked; only the one with an input
@@ -2183,10 +2194,25 @@ class DeviceControllerUI:
             self._invalidate_ui_cache(resolved)
             return resolved
 
-        remaining = len(target.value or "")
-        if remaining and await self._clear_web_input(resolved):
+        # Attempted regardless of the cached length: `value` is an overlay
+        # snapshot and can be stale, and this route verifies itself -- it
+        # reports success only when the element's value is actually empty.
+        if await self._clear_web_input(resolved):
             self._invalidate_ui_cache(resolved)
             return resolved
+
+        remaining = len(target.value or "")
+        if remaining > self._MAX_DELETE:
+            # Better to say so than to send 500 backspaces at a longer field and
+            # report ok over a value that is still partly there.
+            raise DeviceError(
+                f"'{target.label or target.identifier}' holds {remaining} "
+                f"characters, more than the {self._MAX_DELETE} this can clear by "
+                "keystroke, and the Web Inspector could not reach the page to "
+                "clear it directly. Reload the page, or make the web view "
+                "inspectable.",
+                tool="idb",
+            )
 
         if remaining and hasattr(backend, "delete_backwards"):
             # Tap near the trailing edge first: backspace only deletes behind
@@ -2196,9 +2222,7 @@ class DeviceControllerUI:
             edge_x = target.frame["x"] + target.frame["width"] - self._CARET_EDGE_INSET
             await backend.tap(resolved, min(edge_x, cx + target.frame["width"] / 2), cy)
             await asyncio.sleep(0.2)
-            await backend.delete_backwards(
-                resolved, min(remaining + self._DELETE_OVERSHOOT, self._MAX_DELETE),
-            )
+            await backend.delete_backwards(resolved, remaining + self._DELETE_OVERSHOOT)
 
         self._invalidate_ui_cache(resolved)
         return resolved

--- a/server/device/sim_bridge.py
+++ b/server/device/sim_bridge.py
@@ -551,7 +551,14 @@ class SimBridgeBackend:
         self, udid: str, x: float, y: float,
         element_type: str | None = None,
     ) -> None:
-        """Select all text and delete it. Triple-tap to select, then backspace."""
+        """Select all text and delete it. Triple-tap to select, then backspace.
+
+        Reliable in a native text view. A web input frequently does not honour
+        the triple-tap as a select-all, and the single backspace then removes
+        exactly one character -- measured on a form inside an
+        SFSafariViewController, at every tap spacing tried. Callers that need
+        the field actually empty should follow with `delete_backwards`.
+        """
         # Triple-tap to select all
         for _ in range(3):
             await self._send({"cmd": "tap", "udid": udid, "x": x, "y": y})
@@ -559,6 +566,17 @@ class SimBridgeBackend:
         await asyncio.sleep(0.1)
         # Send backspace (HID usage 0x2A on page 7)
         await self._send({"cmd": "type", "udid": udid, "text": "\x08"})
+
+    async def delete_backwards(self, udid: str, count: int) -> None:
+        """Delete `count` characters behind the caret.
+
+        Depends on nothing but the backspace key, so it works where a
+        selection-based clear does not. Measured at ~63ms per character, which
+        is the bridge's own keystroke cadence; sending more than the field holds
+        is harmless, since backspace on an empty field does nothing.
+        """
+        if count > 0:
+            await self._send({"cmd": "type", "udid": udid, "text": "\x08" * count})
 
     async def screenshot(
         self, udid: str, quality: float = 0.8, scale: int = 1,

--- a/server/device/webinspector.py
+++ b/server/device/webinspector.py
@@ -160,6 +160,39 @@ _COLLECT_JS = """
 """
 
 
+# How long to listen for application-connected notices before answering. Long
+# enough for a report already in flight, short enough not to be felt: the daemon
+# has usually sent it well before anyone asks.
+_REFRESH_SETTLE = 0.3
+
+
+# Clearing the focused input, for pages the Inspector can see. Measured against
+# a 55-character field: 6ms, where the same clear by keystroke costs ~3.5s.
+#
+# Two things this deliberately does not do. It does not fall back to the first
+# input on the page -- a page that is not the one being typed into would then
+# have an unrelated field wiped, and every inspectable page gets asked. And it
+# does not assign through `el.value`: React and other frameworks override that
+# setter on the element instance, so the DOM would empty while their own state
+# kept the old value, leaving a field that looks cleared and is not. Going
+# through the prototype's setter and firing the events a framework listens for
+# is what makes the clear real.
+_CLEAR_FOCUSED_JS = """
+(function () {
+  var el = document.activeElement;
+  if (!el) return 'not focused';
+  var proto = el instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype
+            : el instanceof HTMLInputElement ? HTMLInputElement.prototype : null;
+  if (!proto) return 'not an input';
+  var setter = Object.getOwnPropertyDescriptor(proto, 'value').set;
+  setter.call(el, '');
+  el.dispatchEvent(new Event('input', {bubbles: true}));
+  el.dispatchEvent(new Event('change', {bubbles: true}));
+  return el.value === '' ? 'cleared' : 'not cleared';
+})()
+"""
+
+
 class WebInspectorError(RuntimeError):
     """Raised when the inspector channel is unavailable or misbehaves."""
 
@@ -331,8 +364,28 @@ class SimulatorWebInspector:
         else:
             logger.debug("webinspector: unhandled selector %s", selector)
 
-    async def connected_applications(self) -> list[dict]:
-        """Applications the inspector can see, newest state first."""
+    async def connected_applications(self, refresh: bool = True) -> list[dict]:
+        """Applications the inspector can see, newest state first.
+
+        The list is built from what the daemon has told us, and it tells us
+        proactively -- an app that launches after this connection was made
+        arrives as an `_rpc_applicationConnected:` that nobody has read yet. On
+        a long-lived connection that means the cache silently describes the
+        world as it was at connect time: measured, an SFSafariViewController
+        opened later was absent entirely, so a caller concluded there was no
+        inspectable page and fell back to a route costing a thousand times more.
+
+        So the channel is drained first, briefly. Cheap next to being wrong.
+        """
+        if refresh and self._service is not None:
+            try:
+                await self._drain_handshake(settle=_REFRESH_SETTLE)
+            except Exception:
+                # Best effort. This method never touched the socket before, so
+                # a dead connection surfaced later, where callers already
+                # reconnect; letting it raise here turned that into a 500.
+                logger.debug("webinspector: could not refresh the application "
+                             "list; answering from cache", exc_info=True)
         return [
             {
                 "application_id": app_id,
@@ -502,6 +555,15 @@ class SimulatorWebInspector:
             return json.loads(raw) if isinstance(raw, str) else raw
         except ValueError:
             return None
+
+    async def clear_focused_input(self, application_id: str, page_id: int) -> bool:
+        """Empty the focused input on a page. True only if it actually emptied.
+
+        Scoped to whatever has focus, so asking every page is safe: only the one
+        being typed into has an input focused, and the rest decline.
+        """
+        result = await self.evaluate(application_id, page_id, _CLEAR_FOCUSED_JS)
+        return result == "cleared"
 
     async def pages(self, application_id: str) -> list[dict]:
         """Inspectable pages within one application.

--- a/tests/test_web_overlay.py
+++ b/tests/test_web_overlay.py
@@ -633,3 +633,105 @@ async def test_a_failed_listing_reports_no_listing_rather_than_no_pages():
 
     ctrl._connected_web_inspector = boom
     assert await ctrl.web_page_urls("SIM") is None
+
+
+def test_a_web_fields_value_survives_into_the_overlay():
+    """clear_text sizes its work from the value. A field that reports None
+    reads as already empty, and the clear silently does nothing."""
+    ctrl = controller_with_overlay([
+        {"type": "TextField", "AXLabel": "Instance", "source": "web-inspector",
+         "value": "https://social.example",
+         "frame": {"x": 35, "y": 325, "width": 332, "height": 39}}])
+    stored, _ = ctrl._web_overlay["SIM"]
+    assert stored[0].value == "https://social.example"
+
+
+# ------------------------------------------------- clearing a web field
+
+class _ClearBackend:
+    def __init__(self):
+        self.select_calls, self.taps, self.deleted = [], [], []
+
+    async def select_all_and_delete(self, udid, x, y, element_type):
+        self.select_calls.append((x, y, element_type))
+
+    async def tap(self, udid, x, y):
+        self.taps.append((x, y))
+
+    async def delete_backwards(self, udid, count):
+        self.deleted.append(count)
+
+
+def _clear_controller(field, *, web_clear=False):
+    ctrl = DeviceController()
+    ctrl.resolve_udid = lambda udid=None: _immediate("SIM")
+    ctrl._is_physical = lambda _u: False
+    ctrl._is_android = lambda _u: False
+    ctrl._invalidate_ui_cache = lambda *_a, **_k: None
+    backend = _ClearBackend()
+    ctrl._ui_backend = lambda _u: backend
+
+    async def elements(udid=None, **kw):
+        return [field], "SIM"
+
+    ctrl.get_ui_elements = elements
+    ctrl._clear_web_input = lambda _u: _immediate(web_clear)
+    return ctrl, backend
+
+
+def _web_field(value: str):
+    el = UIElement(type="TextField", label="Instance",
+                   frame={"x": 35, "y": 325, "width": 332, "height": 39})
+    el.value = value
+    el.extra_attrs = {"source": "web-inspector"}
+    return el
+
+
+def _native_field(value: str):
+    el = UIElement(type="TextArea", label="",
+                   identifier="composition.text",
+                   frame={"x": 0, "y": 100, "width": 300, "height": 80})
+    el.value = value
+    return el
+
+
+async def test_a_native_field_is_done_after_the_triple_tap():
+    """It selects the whole value there -- measured at 60 characters to 0 in one
+    call -- so deleting again would spend seconds re-clearing an empty field."""
+    ctrl, backend = _clear_controller(_native_field("x" * 61))
+    await ctrl.clear_text(identifier="composition.text")
+    assert backend.select_calls, "the fast path did not run"
+    assert backend.deleted == [], "spent keystrokes on an already-cleared field"
+
+
+async def test_a_web_field_is_finished_off_by_keystrokes():
+    """The triple-tap removes one character there, so the field looks cleared
+    without being cleared."""
+    ctrl, backend = _clear_controller(_web_field("y" * 60), web_clear=False)
+    await ctrl.clear_text(label="Instance")
+    assert backend.deleted, "left the web field partly filled"
+    assert backend.deleted[0] >= 60, "deleted fewer characters than the field held"
+
+
+async def test_the_caret_is_moved_to_the_end_before_deleting():
+    """Backspace only removes what is behind the caret, so a tap in the middle
+    of the text would leave everything after it."""
+    ctrl, backend = _clear_controller(_web_field("z" * 20), web_clear=False)
+    await ctrl.clear_text(label="Instance")
+    assert backend.taps, "no caret-placing tap"
+    x, _ = backend.taps[-1]
+    centre = 35 + 332 / 2
+    assert x > centre, "tapped at or before the centre, leaving a suffix behind"
+
+
+async def test_the_inspector_clear_short_circuits_the_keystrokes():
+    """6ms against ~63ms per character; the keystroke path is the fallback."""
+    ctrl, backend = _clear_controller(_web_field("w" * 100), web_clear=True)
+    await ctrl.clear_text(label="Instance")
+    assert backend.deleted == [], "typed backspaces despite the page being cleared"
+
+
+async def test_an_empty_web_field_costs_nothing_extra():
+    ctrl, backend = _clear_controller(_web_field(""), web_clear=False)
+    await ctrl.clear_text(label="Instance")
+    assert backend.deleted == []

--- a/tests/test_web_overlay.py
+++ b/tests/test_web_overlay.py
@@ -745,6 +745,9 @@ async def test_a_field_too_long_to_clear_is_refused_not_half_cleared():
         await ctrl.clear_text(label="Instance")
     assert "900" in str(exc.value)
     assert backend.deleted == [], "typed backspaces it knew could not finish"
+    # And it did not edit the field on the way to refusing: the triple-tap
+    # removes a character from a web input, so running it first would leave 899.
+    assert backend.select_calls == [], "modified a field it then refused to clear"
 
 
 async def test_the_inspector_is_tried_even_when_the_cached_value_looks_empty():

--- a/tests/test_web_overlay.py
+++ b/tests/test_web_overlay.py
@@ -735,3 +735,59 @@ async def test_an_empty_web_field_costs_nothing_extra():
     ctrl, backend = _clear_controller(_web_field(""), web_clear=False)
     await ctrl.clear_text(label="Instance")
     assert backend.deleted == []
+
+
+async def test_a_field_too_long_to_clear_is_refused_not_half_cleared():
+    """Sending the cap and reporting ok would leave a value partly there while
+    saying it was cleared -- the failure this whole change is about."""
+    ctrl, backend = _clear_controller(_web_field("q" * 900), web_clear=False)
+    with pytest.raises(DeviceError) as exc:
+        await ctrl.clear_text(label="Instance")
+    assert "900" in str(exc.value)
+    assert backend.deleted == [], "typed backspaces it knew could not finish"
+
+
+async def test_the_inspector_is_tried_even_when_the_cached_value_looks_empty():
+    """`value` is an overlay snapshot. If it is stale and empty, gating on it
+    would skip both routes and report a clear that never happened."""
+    ctrl, backend = _clear_controller(_web_field(""), web_clear=True)
+    cleared: list = []
+    ctrl._clear_web_input = lambda _u: (cleared.append(True), _immediate(True))[1]
+    await ctrl.clear_text(label="Instance")
+    assert cleared, "never asked the inspector because the snapshot looked empty"
+
+
+async def test_a_web_clear_on_another_simulator_does_not_count():
+    """Clearing a focused input on a different booted simulator and reporting
+    success would leave the field actually asked about untouched."""
+    ctrl = DeviceController()
+    ctrl._is_android = lambda _u: False
+    ctrl._is_physical = lambda _u: False
+    ctrl._booted_simulator_count = lambda: _immediate(2)
+    cleared: list = []
+
+    class Inspector:
+        async def connected_applications(self):
+            return [{"application_id": "PID:9", "bundle_id": "com.example.app"}]
+
+        async def pages(self, app_id):
+            return [{"page_id": 1}]
+
+        async def clear_focused_input(self, app_id, page_id):
+            cleared.append((app_id, page_id))
+            return True
+
+    ctrl._connected_web_inspector = lambda: _immediate(Inspector())
+    ctrl._close_web_inspector = lambda: _immediate(None)
+    import server.device.webinspector as wi
+    original = wi.simulator_udid_for_application
+
+    async def elsewhere(_app_id):
+        return "SOME-OTHER-SIM"
+
+    wi.simulator_udid_for_application = elsewhere
+    try:
+        assert await ctrl._clear_web_input("SIM") is False
+        assert cleared == [], "cleared an input on another simulator"
+    finally:
+        wi.simulator_udid_for_application = original


### PR DESCRIPTION
Closes #98.

## The bug

`clear_text` selected by **triple-tapping**. A native text view honours that; a
web input generally does not, and the single backspace that followed then
removed **one character** — while the call reported `ok`.

Measured inside an `SFSafariViewController`:

| field | before → after, one call |
|---|---|
| native `TextArea` | 60 → **0** ✓ |
| web `<input>` | 26 → **25** (at every tap spacing tried: 0.05s … 0.25s) |
| web `<input>`, longer value | 168 → **31** (a partial selection happened to take) |

The consequence during an OAuth sign-in was an email arriving as
`arctian_test` and the page refusing it — several steps away from the call that
actually went wrong.

## The fix, in tiers

**Native fields are untouched.** The triple-tap works there. Re-reading to
confirm would cost a full tree walk on *every* clear to learn something already
known, so the element's source decides which kind of field this is.

**Web fields, first choice — the Web Inspector.** `6ms`, against ~3.5s of
keystrokes for a 55-character value.

It deliberately does **not** assign through `el.value`. React and friends
override that setter on the element instance, so the DOM would empty while the
framework's own state kept the old value — a field that looks cleared and is
not, which is the same bug in a new costume. It goes through the prototype's
setter and fires `input` and `change`. Only the *focused* element is touched, so
asking every page cannot wipe a field on a page the caller was not typing into.

**Web fields, fallback — backspaces.** One per character (~63ms each). Depends
on nothing but the backspace key, so it works where the Inspector sees nothing
at all: an `ASWebAuthenticationSession` reports **no connected application**,
and that is the OAuth form every app has. The caret is moved to the trailing
edge first, since backspace only removes what is behind it.

Measured end to end: web field 60 → 0 in **1.23s** (was 7.65s via keystrokes
alone), native 61 → 0 in **0.77s**.

## A bug this exposed

`connected_applications` answered from a cache built during the connect
handshake. On a long-lived connection an app that launched **later was
invisible** — the server's own connection could not see the `SafariViewService`
hosting the page directly in front of it, so `get_web_content` fell back to
probing while reporting nothing wrong. That is why the fast path kept losing to
keystrokes here, and it was silently degrading web-content reads generally.

The channel is now drained briefly before answering. Note the first version of
that fix made things worse: `connected_applications` had never touched the
socket, so a dead connection began raising where callers expected a list, and
that surfaced as a 500. It answers from cache on a failed drain instead.

## Verification

5 new tests, each mutation-verified — native-skips-the-extra-work,
keystroke-fallback, caret-placement, and inspector-preference all fail when
their guard is removed. Suite 1656, ruff clean, MCP builds.

## Note

`clear_text` on a web field still requires a prior `get_web_content`, since the
field is only addressable through the overlay. Without one it correctly returns
"No text field found to clear" rather than clearing something else.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved clearing of text in web-based input fields using Web Inspector support when available.
  * Added fallback keystroke deletion when Inspector clearing is unavailable or incomplete.
  * Added refreshed application information to improve clearing reliability.

* **Bug Fixes**
  * Web overlay fields now retain their displayed values.
  * Clearing is prevented from partially deleting oversized web fields.
  * Clearing results from unrelated simulator applications are no longer accepted.
  * Native fields avoid unnecessary deletion steps after clearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->