### PR TITLE
fix: let type_text prove the text arrived

### DIFF
--- a/mcp/src/tools/device-ui.ts
+++ b/mcp/src/tools/device-ui.ts
@@ -653,10 +653,12 @@ Label matching modes (mutually exclusive — use only one):
     inputSchema: strictParams({
       label: z
         .string()
+        .min(1)
         .optional()
         .describe("Field to type into, by visible text. Enables verification."),
       identifier: z
         .string()
+        .min(1)
         .optional()
         .describe("Field to type into, by accessibility identifier. Enables verification."),
       text: z.string().describe("Text to type"),

--- a/mcp/src/tools/device-ui.ts
+++ b/mcp/src/tools/device-ui.ts
@@ -649,8 +649,16 @@ Label matching modes (mutually exclusive — use only one):
   });
 
   server.registerTool("type_text", {
-    description: `Type text into the currently focused input field. On iOS simulators this attaches the simulated hardware keyboard before typing (required for shifted characters to retain their modifier), which hides the software keyboard — use set_hardware_keyboard with enabled=false afterward if a later step expects the software keyboard to be visible.`,
+    description: `Type text into an input field. PASS label OR identifier whenever you can: the field is then located, tapped, typed into and read back, so the call fails loudly if the text did not arrive. Without one the text goes wherever the keyboard happens to be pointed and nothing can check it -- on a screen with no text field at all this still returns ok, having typed into nothing, and a tap that failed to take focus looks identical to one that worked. The response reports verified: true|false so you can tell which you got. Verification costs a fresh UI read (~2s), which is why it is opt-in. On iOS simulators this attaches the simulated hardware keyboard before typing (required for shifted characters to retain their modifier), which hides the software keyboard — use set_hardware_keyboard with enabled=false afterward if a later step expects the software keyboard to be visible.`,
     inputSchema: strictParams({
+      label: z
+        .string()
+        .optional()
+        .describe("Field to type into, by visible text. Enables verification."),
+      identifier: z
+        .string()
+        .optional()
+        .describe("Field to type into, by accessibility identifier. Enables verification."),
       text: z.string().describe("Text to type"),
       udid: z
         .string()
@@ -671,9 +679,11 @@ Label matching modes (mutually exclusive — use only one):
         .optional()
         .describe("Seconds to wait before capturing after screenshot/screen context (default 1.0)."),
     }),
-  }, async ({ text, udid, include_screen_context, capture_screenshots, settle_delay }) => {
+  }, async ({ text, label, identifier, udid, include_screen_context, capture_screenshots, settle_delay }) => {
     try {
       const body: Record<string, unknown> = { text };
+      if (label) body.label = label;
+      if (identifier) body.identifier = identifier;
       if (udid) body.udid = udid;
       if (include_screen_context) body.include_screen_context = true;
       if (capture_screenshots) body.capture_screenshots = true;

--- a/server/api/device_ui.py
+++ b/server/api/device_ui.py
@@ -502,8 +502,12 @@ async def type_text(request: Request, body: TypeTextRequest):
         if body.capture_screenshots:
             resolved = await controller.resolve_udid(body.udid)
             before = await _capture_action_screenshot(controller, resolved, "type_before")
-        udid = await controller.type_text(text=body.text, udid=body.udid)
-        result: dict = {"status": "ok", "udid": udid}
+        typed = await controller.type_text(
+            text=body.text, udid=body.udid,
+            label=body.label, identifier=body.identifier,
+        )
+        udid = typed["udid"]
+        result: dict = {"status": "ok", "udid": udid, "verified": typed["verified"]}
         if body.capture_screenshots:
             await asyncio.sleep(body.settle_delay)
             after = await _capture_action_screenshot(controller, udid, "type_after")

--- a/server/device/controller_ui.py
+++ b/server/device/controller_ui.py
@@ -2168,21 +2168,9 @@ class DeviceControllerUI:
         return text in after and after != before
 
     def _matching_fields(self, elements, label: str | None, identifier: str | None):
-        """Text fields matching every selector given.
-
-        find_element takes label *or* identifier -- its chain is an elif, so a
-        label wins and an identifier beside it is ignored. That is fine when one
-        selector is used to find a thing, and not fine here: the field typed
-        into and the field read back afterwards are looked up separately, so a
-        selector that silently does nothing could have them resolve to different
-        fields and verify the wrong one.
-        """
+        """Text fields matching every selector given."""
         fields = [e for e in elements if e.type in self._TEXT_FIELD_TYPES and e.frame]
-        if label is not None:
-            fields = [e for e in fields if (e.label or "").lower() == label.lower()]
-        if identifier is not None:
-            fields = [e for e in fields if e.identifier == identifier]
-        return fields
+        return find_element(fields, label=label, identifier=identifier)
 
     async def _find_text_field(
         self, udid: str, *, label: str | None, identifier: str | None,

--- a/server/device/controller_ui.py
+++ b/server/device/controller_ui.py
@@ -2104,12 +2104,101 @@ class DeviceControllerUI:
             },
         }
 
-    async def type_text(self, text: str, udid: str | None = None) -> str:
-        """Type text into focused field. Returns the resolved udid."""
+    async def type_text(
+        self,
+        text: str,
+        udid: str | None = None,
+        label: str | None = None,
+        identifier: str | None = None,
+    ) -> dict:
+        """Type text, into a named field if one is given.
+
+        Without a target this types wherever the keyboard is pointed and cannot
+        report whether that was anywhere: keystrokes are fire-and-forget, and
+        nothing in the accessibility tree says which element has focus. On a
+        screen with no text field at all it still succeeds, having typed into
+        nothing.
+
+        Naming the field buys certainty -- it is located, tapped, typed into,
+        and read back, so a mismatch is an error rather than a silence. That
+        costs a fresh tree read, around 1.8s natively and 2s for web content,
+        which is why it is asked for rather than assumed.
+        """
         resolved = await self.resolve_udid(udid)
+        if not (label or identifier):
+            await self._ui_backend(resolved).type_text(resolved, text)
+            self._invalidate_ui_cache(resolved)
+            return {"udid": resolved, "verified": False}
+
+        target = await self._find_text_field(resolved, label=label, identifier=identifier)
+        before = target.value or ""
+        cx, cy = get_tap_point(target)
+        await self._ui_backend(resolved).tap(resolved, cx, cy)
+        # A tap on a freshly presented field does not always take focus, and
+        # anything typed before it does is lost silently. Give it a moment, then
+        # confirm from the value rather than assuming.
+        await asyncio.sleep(0.3)
         await self._ui_backend(resolved).type_text(resolved, text)
-        self._invalidate_ui_cache(resolved)  # UI changed (text field value updated)
-        return resolved
+        self._invalidate_ui_cache(resolved)
+        await asyncio.sleep(0.3)
+
+        after = await self._read_field_value(resolved, target, label, identifier)
+        if not self._text_landed(before, after, text, target.type):
+            raise DeviceError(
+                f"typed {len(text)} characters into "
+                f"'{label or identifier}' but its value did not change "
+                f"({len(before)} characters before, "
+                f"{'unreadable' if after is None else str(len(after)) + ' after'}). "
+                "The tap may not have taken focus, or the field may be "
+                "read-only.",
+                tool="idb",
+            )
+        return {"udid": resolved, "verified": True}
+
+    @staticmethod
+    def _text_landed(before: str, after: str | None, text: str, kind: str) -> bool:
+        """Whether the value moved the way typing `text` would move it."""
+        if after is None:
+            return False
+        if kind == "SecureTextField":
+            # A secure field reports dots, so the text itself is never visible;
+            # the length is the only evidence available.
+            return len(after) >= len(before) + len(text)
+        return text in after and after != before
+
+    async def _find_text_field(
+        self, udid: str, *, label: str | None, identifier: str | None,
+    ):
+        elements, _ = await self.get_ui_elements(udid=udid)
+        fields = [e for e in elements if e.type in self._TEXT_FIELD_TYPES and e.frame]
+        matches = find_element(fields, label=label, identifier=identifier)
+        if not matches:
+            raise DeviceError(
+                f"No text field matching {label or identifier!r} to type into",
+                tool="wda" if self._is_physical(udid) else "idb",
+            )
+        return matches[0]
+
+    async def _read_field_value(
+        self, udid: str, target, label: str | None, identifier: str | None,
+    ) -> str | None:
+        """The field's value now, read fresh.
+
+        Web content needs re-reading through its own route: the overlay still
+        holds the value from before the keystrokes, so consulting it would
+        confirm whatever was already believed.
+        """
+        if (target.extra_attrs or {}).get("source") in ("web-inspector", "web-probe"):
+            try:
+                await self.get_web_content(udid=udid)
+            except DeviceError:
+                return None
+        try:
+            elements, _ = await self.get_ui_elements(udid=udid, use_cache=False)
+        except DeviceError:
+            return None
+        matches = find_element(elements, label=label, identifier=identifier)
+        return (matches[0].value or "") if matches else None
 
     _TEXT_FIELD_TYPES = ("TextField", "SecureTextField", "TextArea", "SearchField")
 

--- a/server/device/controller_ui.py
+++ b/server/device/controller_ui.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import time
 from datetime import UTC, datetime
@@ -2166,15 +2167,41 @@ class DeviceControllerUI:
             return len(after) >= len(before) + len(text)
         return text in after and after != before
 
+    def _matching_fields(self, elements, label: str | None, identifier: str | None):
+        """Text fields matching every selector given.
+
+        find_element takes label *or* identifier -- its chain is an elif, so a
+        label wins and an identifier beside it is ignored. That is fine when one
+        selector is used to find a thing, and not fine here: the field typed
+        into and the field read back afterwards are looked up separately, so a
+        selector that silently does nothing could have them resolve to different
+        fields and verify the wrong one.
+        """
+        fields = [e for e in elements if e.type in self._TEXT_FIELD_TYPES and e.frame]
+        if label is not None:
+            fields = [e for e in fields if (e.label or "").lower() == label.lower()]
+        if identifier is not None:
+            fields = [e for e in fields if e.identifier == identifier]
+        return fields
+
     async def _find_text_field(
         self, udid: str, *, label: str | None, identifier: str | None,
     ):
-        elements, _ = await self.get_ui_elements(udid=udid)
-        fields = [e for e in elements if e.type in self._TEXT_FIELD_TYPES and e.frame]
-        matches = find_element(fields, label=label, identifier=identifier)
+        # Read fresh. A cached tree can describe a screen that has since
+        # changed, and typing at stale coordinates would put the text in
+        # whatever now occupies them -- which the read-back afterwards, looking
+        # up the same selector, would not necessarily notice.
+        if self._web_overlay.get(udid):
+            with contextlib.suppress(DeviceError):
+                await self.get_web_content(udid=udid)
+        elements, _ = await self.get_ui_elements(udid=udid, use_cache=False)
+        matches = self._matching_fields(elements, label, identifier)
         if not matches:
             raise DeviceError(
-                f"No text field matching {label or identifier!r} to type into",
+                # Phrased for the 404 mapping: anything else surfaces as a 500,
+                # which reads as a broken server rather than a missing field.
+                f"No element found: no text field matching "
+                f"{label or identifier!r} to type into",
                 tool="wda" if self._is_physical(udid) else "idb",
             )
         return matches[0]
@@ -2197,7 +2224,7 @@ class DeviceControllerUI:
             elements, _ = await self.get_ui_elements(udid=udid, use_cache=False)
         except DeviceError:
             return None
-        matches = find_element(elements, label=label, identifier=identifier)
+        matches = self._matching_fields(elements, label, identifier)
         return (matches[0].value or "") if matches else None
 
     _TEXT_FIELD_TYPES = ("TextField", "SecureTextField", "TextArea", "SearchField")

--- a/server/device/ui_elements.py
+++ b/server/device/ui_elements.py
@@ -170,9 +170,11 @@ def find_element(
 ) -> list[UIElement]:
     """Find elements matching label/identifier/type filters.
 
-    Combines filters with AND logic. At least one of label, label_contains,
-    label_prefix, identifier, or element_type is required. Only one label
-    matching mode may be used at a time.
+    One selector chooses the candidates, in this order: label, label_contains,
+    label_prefix, identifier, element_type. Only the first one supplied is used
+    -- passing both a label and an identifier does not narrow to elements with
+    both, the identifier is simply ignored. `element_type` is the exception and
+    narrows whatever the chosen selector returned.
 
     Args:
         elements: List of UI elements to search

--- a/server/device/ui_elements.py
+++ b/server/device/ui_elements.py
@@ -170,11 +170,13 @@ def find_element(
 ) -> list[UIElement]:
     """Find elements matching label/identifier/type filters.
 
-    One selector chooses the candidates, in this order: label, label_contains,
-    label_prefix, identifier, element_type. Only the first one supplied is used
-    -- passing both a label and an identifier does not narrow to elements with
-    both, the identifier is simply ignored. `element_type` is the exception and
-    narrows whatever the chosen selector returned.
+    One label selector chooses the candidates -- label, label_contains or
+    label_prefix, whichever is supplied -- and `identifier` and `element_type`
+    then narrow the result. Every selector given must match the same element.
+
+    `identifier` used to be ignored whenever a label was also given, which was
+    silent: a caller naming both to disambiguate two same-labelled fields got
+    the first of them regardless.
 
     Args:
         elements: List of UI elements to search
@@ -203,7 +205,10 @@ def find_element(
         # No search criteria provided
         return []
 
-    # Optional type filter to narrow results
+    # Narrowing filters. Applied after the primary selector rather than instead
+    # of it, so naming both a label and an identifier means both must hold.
+    if identifier and matches:
+        matches = [e for e in matches if e.identifier == identifier]
     if element_type and matches:
         matches = find_by_type(matches, element_type)
 

--- a/server/models.py
+++ b/server/models.py
@@ -1157,6 +1157,16 @@ class TypeTextRequest(BaseModel):
     settle_delay: float = Field(default=1.0, ge=0, le=10)
 
 
+    @model_validator(mode="after")
+    def check_selectors(self) -> TypeTextRequest:
+        # An empty string is falsy, so it would slip past the targeting check
+        # and type untargeted -- the caller having asked for the opposite.
+        for name in ("label", "identifier"):
+            value = getattr(self, name)
+            if value is not None and not value.strip():
+                raise ValueError(f"{name} cannot be blank")
+        return self
+
 class WaitSettledRequest(BaseModel):
     """Request body for POST /device/ui/wait-settled."""
 

--- a/server/models.py
+++ b/server/models.py
@@ -1145,6 +1145,13 @@ class TypeTextRequest(BaseModel):
 
     text: str
     udid: str | None = None
+    label: str | None = None
+    identifier: str | None = None
+    """Which field to type into. Naming one makes the call verify itself: the
+    field is located, tapped and read back afterwards. Without one the text goes
+    wherever the keyboard is pointed, and whether that was anywhere cannot be
+    known."""
+
     include_screen_context: bool = False
     capture_screenshots: bool = False
     settle_delay: float = Field(default=1.0, ge=0, le=10)

--- a/tests/test_device_api.py
+++ b/tests/test_device_api.py
@@ -116,7 +116,8 @@ def mock_controller(app):
         }
     )
     ctrl.swipe = AsyncMock(return_value="AAAA-1111")
-    ctrl.type_text = AsyncMock(return_value="AAAA-1111")
+    ctrl.type_text = AsyncMock(
+        return_value={"udid": "AAAA-1111", "verified": False})
     ctrl.clear_text = AsyncMock(return_value="AAAA-1111")
     ctrl.press_button = AsyncMock(return_value="AAAA-1111")
     ctrl.set_location = AsyncMock(return_value="AAAA-1111")
@@ -772,7 +773,11 @@ class TestTypeText:
             )
         assert resp.status_code == 200
         assert resp.json()["status"] == "ok"
-        mock_controller.type_text.assert_called_once_with(text="hello world", udid=None)
+        # Untargeted, so the response says so rather than implying it landed.
+        assert resp.json()["verified"] is False
+        mock_controller.type_text.assert_called_once_with(
+            text="hello world", udid=None, label=None, identifier=None,
+        )
 
     async def test_type_text_no_auth(self, app):
         transport = ASGITransport(app=app)

--- a/tests/test_device_controller.py
+++ b/tests/test_device_controller.py
@@ -529,8 +529,12 @@ class TestTypeText:
         ctrl._active_udid = "AAAA-1111"
         ctrl.idb.type_text = AsyncMock()
 
-        udid = await ctrl.type_text("hello world")
-        assert udid == "AAAA-1111"
+        result = await ctrl.type_text("hello world")
+        assert result["udid"] == "AAAA-1111"
+        # Untargeted typing cannot be checked: nothing reports which element has
+        # focus, so the caller is told the result is unverified rather than left
+        # to assume it landed.
+        assert result["verified"] is False
         ctrl.idb.type_text.assert_called_once_with("AAAA-1111", "hello world")
 
 

--- a/tests/test_ui_elements.py
+++ b/tests/test_ui_elements.py
@@ -417,3 +417,48 @@ class TestGenerateScreenSummary:
         assert result["element_types"] == {}
         assert result["interactive_elements"] == []
         assert "Screen" in result["summary"]
+
+
+class TestCombinedSelectors:
+    """Naming a label and an identifier must mean both, not just the label.
+
+    It used to mean just the label, silently: a caller naming both to
+    disambiguate two same-labelled fields got the first of them regardless, and
+    tap_element passes both.
+    """
+
+    def _field(self, label, identifier, type_="TextField"):
+        return UIElement(type=type_, label=label, identifier=identifier,
+                         frame={"x": 0, "y": 0, "width": 10, "height": 10})
+
+    def test_identifier_narrows_a_label_match(self):
+        fields = [self._field("Email", "field.a"), self._field("Email", "field.b")]
+        got = find_element(fields, label="Email", identifier="field.b")
+        assert [e.identifier for e in got] == ["field.b"]
+
+    def test_selectors_that_disagree_match_nothing(self):
+        fields = [self._field("Email", "field.a")]
+        assert find_element(fields, label="Email", identifier="field.z") == []
+
+    def test_identifier_still_works_alone(self):
+        fields = [self._field("Email", "field.a"), self._field("Name", "field.b")]
+        got = find_element(fields, identifier="field.b")
+        assert [e.label for e in got] == ["Name"]
+
+    def test_label_still_works_alone(self):
+        fields = [self._field("Email", "field.a"), self._field("Name", "field.b")]
+        got = find_element(fields, label="Email")
+        assert [e.identifier for e in got] == ["field.a"]
+
+    def test_identifier_narrows_a_substring_match_too(self):
+        fields = [self._field("Email address", "field.a"),
+                  self._field("Email address", "field.b")]
+        got = find_element(fields, label_contains="Email", identifier="field.b")
+        assert [e.identifier for e in got] == ["field.b"]
+
+    def test_all_three_selectors_must_agree(self):
+        fields = [self._field("Email", "field.a", "TextField"),
+                  self._field("Email", "field.a", "Button")]
+        got = find_element(fields, label="Email", identifier="field.a",
+                           element_type="Button")
+        assert [e.type for e in got] == ["Button"]

--- a/tests/test_web_overlay.py
+++ b/tests/test_web_overlay.py
@@ -874,3 +874,32 @@ def test_a_secure_field_is_verified_by_length_not_content():
     # And an ordinary field still checks the content, so text landing in some
     # other field cannot pass.
     assert landed("", "goodbye", "hello", "TextField") is False
+
+
+async def test_typing_reads_the_screen_fresh_before_tapping():
+    """A cached tree can describe a screen that has since changed, and typing at
+    stale coordinates puts the text wherever they now point."""
+    ctrl, backend = _type_controller(_native_field(""), "hello")
+    seen: list = []
+    original = ctrl.get_ui_elements
+
+    async def recording(udid=None, **kw):
+        seen.append(kw.get("use_cache", True))
+        return await original(udid=udid, **kw)
+
+    ctrl.get_ui_elements = recording
+    await ctrl.type_text("hello", identifier="composition.text")
+    assert seen and seen[0] is False, "looked up the field in the cache"
+
+
+def test_both_selectors_must_match_the_same_field():
+    """find_element takes label *or* identifier, so a selector beside a label is
+    ignored -- and the lookup before typing and the read-back after are separate
+    lookups, which could then resolve to different fields."""
+    ctrl = DeviceController()
+    a = _native_field("")
+    a.label, a.identifier = "Email", "field.a"
+    b = _native_field("")
+    b.label, b.identifier = "Email", "field.b"
+    got = ctrl._matching_fields([a, b], "Email", "field.b")
+    assert [e.identifier for e in got] == ["field.b"]

--- a/tests/test_web_overlay.py
+++ b/tests/test_web_overlay.py
@@ -794,3 +794,83 @@ async def test_a_web_clear_on_another_simulator_does_not_count():
         assert cleared == [], "cleared an input on another simulator"
     finally:
         wi.simulator_udid_for_application = original
+
+
+# ------------------------------------------------- typing into a named field
+
+class _TypeBackend:
+    def __init__(self, landed: bool = True):
+        self.typed, self.taps, self.landed = [], [], landed
+
+    async def tap(self, udid, x, y):
+        self.taps.append((x, y))
+
+    async def type_text(self, udid, text):
+        self.typed.append(text)
+
+
+def _type_controller(field, after_value, backend=None):
+    ctrl = DeviceController()
+    ctrl.resolve_udid = lambda udid=None: _immediate("SIM")
+    ctrl._is_physical = lambda _u: False
+    ctrl._is_android = lambda _u: False
+    ctrl._invalidate_ui_cache = lambda *_a, **_k: None
+    backend = backend or _TypeBackend()
+    ctrl._ui_backend = lambda _u: backend
+    reads = {"n": 0}
+
+    async def elements(udid=None, **kw):
+        reads["n"] += 1
+        if reads["n"] > 1 and after_value is not None:
+            updated = _native_field(after_value)
+            updated.identifier = field.identifier
+            updated.label = field.label
+            updated.extra_attrs = field.extra_attrs
+            return [updated], "SIM"
+        return [field], "SIM"
+
+    ctrl.get_ui_elements = elements
+    return ctrl, backend
+
+
+async def test_typing_into_a_named_field_is_verified():
+    ctrl, backend = _type_controller(_native_field(""), "hello")
+    result = await ctrl.type_text("hello", identifier="composition.text")
+    assert result["verified"] is True
+    assert backend.taps, "did not focus the field before typing"
+    assert backend.typed == ["hello"]
+
+
+async def test_text_that_never_arrives_is_an_error_not_a_success():
+    """The failure this exists for: a tap that does not take focus, and the
+    keystrokes go nowhere while the call reports ok."""
+    ctrl, _ = _type_controller(_native_field(""), "")
+    with pytest.raises(DeviceError) as exc:
+        await ctrl.type_text("hello", identifier="composition.text")
+    assert "did not change" in str(exc.value)
+
+
+async def test_untargeted_typing_says_it_is_unverified():
+    """Nothing reports which element has focus, so the honest answer is to say
+    the result was not checked rather than to imply it was."""
+    ctrl, backend = _type_controller(_native_field(""), None)
+    result = await ctrl.type_text("hello")
+    assert result["verified"] is False
+    assert backend.taps == [], "tapped without being told which field"
+
+
+async def test_a_named_field_that_is_not_there_is_an_error():
+    ctrl, _ = _type_controller(_native_field(""), "hello")
+    with pytest.raises(DeviceError):
+        await ctrl.type_text("hello", identifier="nonexistent")
+
+
+def test_a_secure_field_is_verified_by_length_not_content():
+    """A password field reports dots, so the typed text is never visible in the
+    value and a containment check would fail every time."""
+    landed = DeviceController._text_landed
+    assert landed("", "•" * 5, "hello", "SecureTextField") is True
+    assert landed("", "", "hello", "SecureTextField") is False
+    # And an ordinary field still checks the content, so text landing in some
+    # other field cannot pass.
+    assert landed("", "goodbye", "hello", "TextField") is False


### PR DESCRIPTION
Closes #99.

## The bug

`type_text` returned `ok` whether or not the keystrokes reached a field. The
sharpest demonstration is that `clear_text`, in the same module, already got
this right:

```
screen with 0 text fields
POST /device/ui/type   → 200 {"status":"ok"}          ← typed into nothing
POST /device/ui/clear  → 500 "No text field found"    ← correct
```

And a tap that failed to take focus looked identical to one that worked — which
is how an OAuth sign-in submitted an address the page rejected several steps
later, with every call reporting success.

## The fix

Name the field and the call proves itself: located, tapped, typed into, read
back. A value that did not move is an error. A field that is not there is
refused, matching `clear_text`.

```
POST /device/ui/type {"text":"…","identifier":"composition.text"}
  → 500  "No text field matching 'composition.text' to type into"   (nothing there)
  → 200  {"status":"ok","verified":true}                            (it landed)
POST /device/ui/type {"text":"…"}
  → 200  {"status":"ok","verified":false}                           (untargeted)
```

## Why verification is opt-in

It costs a **fresh** tree read — ~1.8s natively, ~2s for web content, because
the overlay still holds the value from *before* the keystrokes, so consulting it
would only confirm what was already believed. Making that the default would tax
every keystroke in every flow to catch a case most of them never hit.

Untargeted typing therefore keeps its behaviour and simply stops implying more
than it knows: `verified: false`. Nothing in the accessibility tree reports which
element has focus, so that is the honest answer rather than a guess.

## One detail worth naming

A secure field is verified **by length**, not content: it reports dots, so the
typed text is never visible in the value and a containment check would fail
every time. An ordinary field still checks content, so text landing in some
*other* field cannot pass.

Suite 1664, ruff clean, MCP builds. Five new guards, each mutation-verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional label and identifier targeting when entering text.
  * Label and identifier selectors can be combined to locate a specific field.
  * Targeted text entry now confirms the expected value was entered and reports verification status.
  * Secure fields can be verified by text length.
  * Existing untargeted text entry remains supported, with verification reported as unavailable.

* **Bug Fixes**
  * Improved handling when fields cannot be found or entered text does not match the expected value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->