### PR TITLE
feat(doctor): report which tools are actually in use, and from where

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -91,9 +91,10 @@ reviews:
 
     - path: "docs/api-reference.md"
       instructions: |
-        Generated from the source — every tool with the endpoint behind it,
-        derived from each tool's own apiRequest call. Hand-edits get overwritten.
-        Changes belong in the generator or the tool definitions.
+        Every tool with the endpoint behind it. Hand-maintained, and guarded by
+        tests/test_readme_sync.py, which fails when a registered route or tool
+        is missing here or listed here without existing. There is no generator —
+        edit this file directly and let the guard check it.
 
     - path: "docs/release-channels.md"
       instructions: |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -206,7 +206,7 @@ public probes, and a few operations the CLI uses directly.
 | GET | `/api/v1/proxy/flows/stream` | SSE real-time flow stream |
 | GET | `/api/v1/system/channel` | Current update channel preference |
 | GET | `/health` | Fast liveness ping (public). Does no device-tool probing — kept sub-millisecond so CLI health checks can't time out |
-| GET | `/tools` | Device-tool availability and UI cache stats (public). Backs `quern doctor` and `quern status` |
+| GET | `/tools` | Device-tool availability, per-install-site versions and provenance, and UI cache stats (public). Backs `quern doctor` and `quern status` |
 | GET | `/video-test` | Internal preview test page (public) |
 | POST | `/api/v1/builds/parse` | Submit xcodebuild output |
 | POST | `/api/v1/device/active` | Set the active device by UDID |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -206,7 +206,8 @@ public probes, and a few operations the CLI uses directly.
 | GET | `/api/v1/proxy/flows/stream` | SSE real-time flow stream |
 | GET | `/api/v1/system/channel` | Current update channel preference |
 | GET | `/health` | Fast liveness ping (public). Does no device-tool probing — kept sub-millisecond so CLI health checks can't time out |
-| GET | `/tools` | Device-tool availability, per-install-site versions and provenance, and UI cache stats (public). Backs `quern doctor` and `quern status` |
+| GET | `/tools` | Device-tool availability and UI cache stats (public). Backs `quern doctor` and `quern status` |
+| GET | `/api/v1/device/tools/sites` | Per-install-site tool versions and provenance. Authenticated: it returns absolute paths, which `/tools` deliberately does not |
 | GET | `/video-test` | Internal preview test page (public) |
 | POST | `/api/v1/builds/parse` | Submit xcodebuild output |
 | POST | `/api/v1/device/active` | Set the active device by UDID |

--- a/server/api/device.py
+++ b/server/api/device.py
@@ -31,6 +31,7 @@ from server.models import (
     StopDeviceLogRequest,
     StopSimLogRequest,
     TerminateAppRequest,
+    ToolSitesResponse,
     UninstallAppRequest,
     WdaElementNotFoundError,
     WdaElementNotInteractableError,
@@ -120,6 +121,24 @@ def _handle_device_error(e: DeviceError) -> HTTPException:
 # ---------------------------------------------------------------------------
 # Device management
 # ---------------------------------------------------------------------------
+
+
+@router.get("/tools/sites", response_model=ToolSitesResponse)
+async def tool_sites(request: Request) -> ToolSitesResponse:
+    """Every install site quern uses, with versions and provenance.
+
+    Authenticated, unlike the public /tools: `path` carries account names and
+    filesystem layout. /tools keeps returning availability flags only.
+
+    Two entries share a name where two installs do. `pymobiledevice3` is a
+    library imported for web content and a binary run by tunneld, and they drift
+    apart -- measured at 11.3.1 and 9.15.1 on one machine.
+    """
+    controller = _get_controller(request)
+    try:
+        return ToolSitesResponse(sites=await controller.tool_sites())
+    except DeviceError as e:
+        raise _handle_device_error(e)
 
 
 @router.get("/list")

--- a/server/device/controller.py
+++ b/server/device/controller.py
@@ -98,6 +98,38 @@ class DeviceController(DeviceControllerUI):
             "sim_bridge": await self.sim_bridge_manager.is_available(),
         }
 
+    async def tool_sites(self) -> list[dict]:
+        """Every install site quern uses, with versions and provenance.
+
+        Separate from `check_tools()` rather than folded into it. That returns
+        one boolean per tool name and is consumed by truthiness -- `main.py`
+        decides whether to use the sim-bridge backend from it -- so widening
+        the values to dictionaries would make every tool read as available,
+        including the missing ones.
+
+        The names also do not line up: `pymobiledevice3` is two installs at
+        different versions serving different code paths, which is the confusion
+        this reports its way out of.
+        """
+        from server.device.tool_versions import collect_sites, upgrade_note
+
+        sites = []
+        for site in await collect_sites():
+            sites.append({
+                "name": site.name,
+                "role": site.role,
+                "available": site.available,
+                "version": site.version,
+                "path": site.path,
+                "source": site.source,
+                "detail": site.detail,
+                "volatile_path": site.volatile_path,
+                "requested": site.requested,
+                "required_by": site.required_by,
+                "upgrade_note": upgrade_note(site),
+            })
+        return sites
+
     def _device_type(self, udid: str) -> DeviceType:
         """Look up device type from cache. Defaults to simulator if unknown."""
         return self._device_type_cache.get(udid, DeviceType.SIMULATOR)

--- a/server/device/controller.py
+++ b/server/device/controller.py
@@ -98,7 +98,7 @@ class DeviceController(DeviceControllerUI):
             "sim_bridge": await self.sim_bridge_manager.is_available(),
         }
 
-    async def tool_sites(self) -> list[dict]:
+    async def tool_sites(self) -> list:
         """Every install site quern uses, with versions and provenance.
 
         Separate from `check_tools()` rather than folded into it. That returns
@@ -112,23 +112,24 @@ class DeviceController(DeviceControllerUI):
         this reports its way out of.
         """
         from server.device.tool_versions import collect_sites, upgrade_note
+        from server.models import ToolSiteInfo
 
-        sites = []
-        for site in await collect_sites():
-            sites.append({
-                "name": site.name,
-                "role": site.role,
-                "available": site.available,
-                "version": site.version,
-                "path": site.path,
-                "source": site.source,
-                "detail": site.detail,
-                "volatile_path": site.volatile_path,
-                "requested": site.requested,
-                "required_by": site.required_by,
-                "upgrade_note": upgrade_note(site),
-            })
-        return sites
+        return [
+            ToolSiteInfo(
+                name=site.name,
+                role=site.role,
+                available=site.available,
+                version=site.version,
+                path=site.path,
+                source=site.source,
+                detail=site.detail,
+                volatile_path=site.volatile_path,
+                requested=site.requested,
+                required_by=site.required_by,
+                upgrade_note=upgrade_note(site),
+            )
+            for site in await collect_sites()
+        ]
 
     def _device_type(self, udid: str) -> DeviceType:
         """Look up device type from cache. Defaults to simulator if unknown."""

--- a/server/device/tool_versions.py
+++ b/server/device/tool_versions.py
@@ -21,9 +21,9 @@ timestamp, so it is recorded as provenance rather than as a location to revisit.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import re
 import shutil
-import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -34,7 +34,7 @@ from pathlib import Path
 #   adb              ->  Android Debug Bridge version 1.0.41
 #   node             ->  v22.22.2
 #   mitmdump         ->  Mitmproxy: 12.2.3
-_VERSION_RE = re.compile(r"\bv?(\d+(?:\.\d+){1,3}(?:[-.][A-Za-z0-9]+)?)\b")
+_VERSION_RE = re.compile(r"\bv?(\d+(?:\.\d+){1,3}(?:-[A-Za-z0-9]+(?:\.[A-Za-z0-9]+)*)?)")
 
 # Paths whose spelling changes between shells. fnm hands out a per-shell
 # directory named for the pid that asked, so the path is evidence of where a
@@ -92,9 +92,16 @@ def is_volatile(path: str | None) -> bool:
 
 
 def classify_source(path: str | None) -> str:
-    """Where a binary came from, judged by where it sits."""
+    """Where a binary came from, judged by where it sits.
+
+    Symlinks are followed first. Brew links its binaries into `bin` directories
+    that look like system paths, so classifying the link would report `system`
+    for a formula and skip its provenance entirely.
+    """
     if not path:
         return "unknown"
+    with contextlib.suppress(OSError):
+        path = str(Path(path).resolve())
     if "fnm_multishells" in path or "/fnm/" in path:
         return "fnm"
     if "/pipx/" in path:
@@ -103,7 +110,10 @@ def classify_source(path: str | None) -> str:
         return "android-sdk"
     if "/Xcode.app/" in path or path.startswith("/Applications/Xcode"):
         return "xcode"
-    if path.startswith(("/opt/homebrew/", "/usr/local/Cellar/", "/home/linuxbrew/")):
+    # By segment, not prefix: brew's root moves between /opt/homebrew,
+    # /usr/local, linuxbrew and whatever HOMEBREW_PREFIX says, but a formula's
+    # files always live under a Cellar.
+    if "/Cellar/" in path or path.startswith(("/opt/homebrew/", "/home/linuxbrew/")):
         return "brew"
     if "/.venv/" in path or path.startswith(str(Path(sys.executable).parent)):
         return "venv"
@@ -126,6 +136,23 @@ def package_version(distribution: str) -> str | None:
         return None
 
 
+async def _run(args: list[str], timeout: float) -> tuple[int, str]:
+    """Run a command off the event loop, returning (exit code, stdout)."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *args, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
+        )
+        out, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except TimeoutError:
+        proc.kill()
+        with contextlib.suppress(Exception):
+            await proc.wait()
+        return 1, ""
+    except OSError:
+        return 1, ""
+    return proc.returncode or 0, out.decode(errors="replace")
+
+
 async def binary_version(path: str, args: list[str], timeout: float = 5.0) -> str | None:
     """Run a binary's version command and pull the version out of it."""
     try:
@@ -134,13 +161,24 @@ async def binary_version(path: str, args: list[str], timeout: float = 5.0) -> st
             stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT,
         )
         out, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
-    except (OSError, TimeoutError):
+    except TimeoutError:
+        # Kill it: communicate() leaves the child running, and a version
+        # command that hangs would otherwise stay alive across requests.
+        proc.kill()
+        with contextlib.suppress(Exception):
+            await proc.wait()
+        return None
+    except OSError:
         return None
     return parse_version(out.decode(errors="replace"))
 
 
-def brew_provenance(formula: str) -> tuple[bool | None, list[str]]:
+async def brew_provenance(formula: str) -> tuple[bool | None, list[str]]:
     """Whether a formula was asked for, and what else depends on it.
+
+    Run off the event loop -- `brew info` and `brew uses` are slow enough that
+    doing them synchronously would stall every other request for as long as
+    they take.
 
     Both are best effort. `installed_on_request` is absent on installs old
     enough to predate it -- measured, `libusbmuxd` and `openssl@3` carry
@@ -151,12 +189,9 @@ def brew_provenance(formula: str) -> tuple[bool | None, list[str]]:
     try:
         import json
 
-        raw = subprocess.run(
-            ["brew", "info", "--json=v2", formula],
-            capture_output=True, text=True, timeout=15,
-        )
-        if raw.returncode == 0:
-            for entry in (json.loads(raw.stdout).get("formulae") or []):
+        code, stdout = await _run(["brew", "info", "--json=v2", formula], timeout=15)
+        if code == 0:
+            for entry in (json.loads(stdout).get("formulae") or []):
                 for installed in entry.get("installed") or []:
                     if installed.get("installed_on_request"):
                         requested = True
@@ -167,12 +202,9 @@ def brew_provenance(formula: str) -> tuple[bool | None, list[str]]:
 
     required_by: list[str] = []
     try:
-        uses = subprocess.run(
-            ["brew", "uses", "--installed", formula],
-            capture_output=True, text=True, timeout=20,
-        )
-        if uses.returncode == 0:
-            required_by = uses.stdout.split()
+        code, stdout = await _run(["brew", "uses", "--installed", formula], timeout=20)
+        if code == 0:
+            required_by = stdout.split()
     except Exception:
         pass
     return requested, required_by
@@ -256,7 +288,7 @@ async def collect_sites() -> list[ToolSite]:
         path=imd_path, source=classify_source(imd_path),
     )
     if site.source == "brew":
-        site.requested, site.required_by = brew_provenance("libimobiledevice")
+        site.requested, site.required_by = await brew_provenance("libimobiledevice")
     sites.append(site)
 
     # --- node -------------------------------------------------------------

--- a/server/device/tool_versions.py
+++ b/server/device/tool_versions.py
@@ -115,11 +115,20 @@ def classify_source(path: str | None) -> str:
     # files always live under a Cellar.
     if "/Cellar/" in path or path.startswith(("/opt/homebrew/", "/home/linuxbrew/")):
         return "brew"
-    if "/.venv/" in path or path.startswith(str(Path(sys.executable).parent)):
+    if "/.venv/" in path:
+        return "venv"
+    # Only meaningful inside a virtualenv. Run under a system interpreter,
+    # sys.executable's directory is /usr/bin, and every binary there would be
+    # reported as living in quern's environment.
+    if _in_virtualenv() and path.startswith(str(Path(sys.executable).parent)):
         return "venv"
     if path.startswith(("/usr/bin/", "/usr/local/bin/", "/bin/")):
         return "system"
     return "unknown"
+
+
+def _in_virtualenv() -> bool:
+    return sys.prefix != sys.base_prefix
 
 
 def package_version(distribution: str) -> str | None:
@@ -277,6 +286,7 @@ async def collect_sites() -> list[ToolSite]:
         available=adb_path is not None,
         version=await binary_version(adb_path, ["version"]) if adb_path else None,
         path=adb_path, source=classify_source(adb_path),
+        volatile_path=is_volatile(adb_path),
     ))
 
     # --- libimobiledevice -------------------------------------------------
@@ -286,6 +296,7 @@ async def collect_sites() -> list[ToolSite]:
         available=imd_path is not None,
         version=await binary_version(imd_path, ["--version"]) if imd_path else None,
         path=imd_path, source=classify_source(imd_path),
+        volatile_path=is_volatile(imd_path),
     )
     if site.source == "brew":
         site.requested, site.required_by = await brew_provenance("libimobiledevice")

--- a/server/device/tool_versions.py
+++ b/server/device/tool_versions.py
@@ -1,0 +1,300 @@
+"""What external tools quern is actually using, and where they came from.
+
+`check_tools()` used to answer with booleans, one per tool name. That is not
+enough to settle a "works on mine": two machines comparing `pymobiledevice3` in
+that form agreed they both had it while being three majors apart, and the
+disagreement surfaced instead as one of them reading code the other did not
+have.
+
+A name is not one thing. Measured on a single machine, `pymobiledevice3` is
+**two** installs at once -- an 11.3.1 library imported by `webinspector.py`, and
+a 9.15.1 command-line binary used by `tunneld` and the device log -- serving
+different code paths. Reporting one number for that name would be reporting a
+number nobody is running. So the unit here is the install *site*, not the tool.
+
+Paths are resolved the way quern resolves them rather than through `PATH`,
+which does not find `idb` or `mitmdump` on at least one machine. Some are not
+durable either: node arrives from fnm at a path containing a pid and a
+timestamp, so it is recorded as provenance rather than as a location to revisit.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# A version anywhere in a line: every tool writes it differently.
+#   pymobiledevice3  ->  9.15.1
+#   idevice_id       ->  idevice_id 1.4.0
+#   adb              ->  Android Debug Bridge version 1.0.41
+#   node             ->  v22.22.2
+#   mitmdump         ->  Mitmproxy: 12.2.3
+_VERSION_RE = re.compile(r"\bv?(\d+(?:\.\d+){1,3}(?:[-.][A-Za-z0-9]+)?)\b")
+
+# Paths whose spelling changes between shells. fnm hands out a per-shell
+# directory named for the pid that asked, so the path is evidence of where a
+# tool came from and useless as somewhere to look again.
+_VOLATILE_MARKERS = ("fnm_multishells", "/private/var/folders/", "/tmp/")
+
+
+@dataclass
+class ToolSite:
+    """One place a tool is installed, and what quern uses it for."""
+
+    name: str
+    role: str
+    """What quern uses this copy as: "library" or "cli"."""
+
+    available: bool = False
+    version: str | None = None
+    path: str | None = None
+    source: str = "unknown"
+    """Where it came from: brew, pipx, venv, fnm, android-sdk, xcode, system."""
+
+    detail: str | None = None
+    """Anything a reader needs that the fields above cannot carry."""
+
+    volatile_path: bool = False
+    """The path will not survive a new shell, so it identifies provenance
+    rather than a location."""
+
+    requested: bool | None = None
+    """For brew: installed deliberately (True), pulled in as a dependency
+    (False), or not recorded (None -- older installs carry neither flag)."""
+
+    required_by: list[str] = field(default_factory=list)
+    """Other installed formulae that depend on this one, so a reader knows what
+    an upgrade would touch."""
+
+    def describe(self) -> str:
+        if not self.available:
+            return f"{self.name} ({self.role}): not found"
+        where = self.path or self.source
+        return f"{self.name} ({self.role}) {self.version or '?'} — {where}"
+
+
+def parse_version(output: str) -> str | None:
+    """The version in a tool's version output, whatever shape it takes."""
+    for line in output.splitlines():
+        match = _VERSION_RE.search(line)
+        if match:
+            return match.group(1)
+    return None
+
+
+def is_volatile(path: str | None) -> bool:
+    return bool(path) and any(marker in path for marker in _VOLATILE_MARKERS)
+
+
+def classify_source(path: str | None) -> str:
+    """Where a binary came from, judged by where it sits."""
+    if not path:
+        return "unknown"
+    if "fnm_multishells" in path or "/fnm/" in path:
+        return "fnm"
+    if "/pipx/" in path:
+        return "pipx"
+    if "/Android/sdk/" in path or "/android-sdk/" in path:
+        return "android-sdk"
+    if "/Xcode.app/" in path or path.startswith("/Applications/Xcode"):
+        return "xcode"
+    if path.startswith(("/opt/homebrew/", "/usr/local/Cellar/", "/home/linuxbrew/")):
+        return "brew"
+    if "/.venv/" in path or path.startswith(str(Path(sys.executable).parent)):
+        return "venv"
+    if path.startswith(("/usr/bin/", "/usr/local/bin/", "/bin/")):
+        return "system"
+    return "unknown"
+
+
+def package_version(distribution: str) -> str | None:
+    """A Python package's version, from its metadata rather than its output.
+
+    Exact, and it works for tools that have no --version at all: `idb` prints
+    usage for one.
+    """
+    try:
+        import importlib.metadata as metadata
+
+        return metadata.version(distribution)
+    except Exception:
+        return None
+
+
+async def binary_version(path: str, args: list[str], timeout: float = 5.0) -> str | None:
+    """Run a binary's version command and pull the version out of it."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            path, *args,
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT,
+        )
+        out, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except (OSError, TimeoutError):
+        return None
+    return parse_version(out.decode(errors="replace"))
+
+
+def brew_provenance(formula: str) -> tuple[bool | None, list[str]]:
+    """Whether a formula was asked for, and what else depends on it.
+
+    Both are best effort. `installed_on_request` is absent on installs old
+    enough to predate it -- measured, `libusbmuxd` and `openssl@3` carry
+    neither flag on this machine -- so "not recorded" is a real answer and not
+    the same as "arrived as a dependency".
+    """
+    requested: bool | None = None
+    try:
+        import json
+
+        raw = subprocess.run(
+            ["brew", "info", "--json=v2", formula],
+            capture_output=True, text=True, timeout=15,
+        )
+        if raw.returncode == 0:
+            for entry in (json.loads(raw.stdout).get("formulae") or []):
+                for installed in entry.get("installed") or []:
+                    if installed.get("installed_on_request"):
+                        requested = True
+                    elif installed.get("installed_as_dependency"):
+                        requested = False
+    except Exception:
+        return None, []
+
+    required_by: list[str] = []
+    try:
+        uses = subprocess.run(
+            ["brew", "uses", "--installed", formula],
+            capture_output=True, text=True, timeout=20,
+        )
+        if uses.returncode == 0:
+            required_by = uses.stdout.split()
+    except Exception:
+        pass
+    return requested, required_by
+
+
+def which(name: str) -> str | None:
+    """The venv's copy first, then PATH -- how quern already resolves idb."""
+    venv_copy = Path(sys.executable).parent / name
+    if venv_copy.is_file():
+        return str(venv_copy)
+    return shutil.which(name)
+
+
+# The sites quern actually uses, in the order a reader wants them. Two entries
+# for pymobiledevice3 on purpose: the library and the binary are separate
+# installs that drift apart, and collapsing them is what made a three-major gap
+# look like agreement.
+async def collect_sites() -> list[ToolSite]:
+    """Every install site quern depends on, with versions and provenance."""
+    sites: list[ToolSite] = []
+
+    # --- pymobiledevice3, as a library ------------------------------------
+    library = package_version("pymobiledevice3")
+    sites.append(ToolSite(
+        name="pymobiledevice3", role="library",
+        available=library is not None, version=library,
+        path=str(Path(sys.executable).parent.parent), source="venv",
+        detail="imported by webinspector.py for web content on simulators",
+    ))
+
+    # --- pymobiledevice3, as a binary -------------------------------------
+    from server.device.tunneld import find_pymobiledevice3_binary
+
+    binary = find_pymobiledevice3_binary()
+    binary_path = str(binary) if binary else None
+    sites.append(ToolSite(
+        name="pymobiledevice3", role="cli",
+        available=binary_path is not None,
+        version=await binary_version(binary_path, ["version"]) if binary_path else None,
+        path=binary_path, source=classify_source(binary_path),
+        volatile_path=is_volatile(binary_path),
+        detail="run by tunneld and the device log; a separate install from the library",
+    ))
+
+    # --- idb --------------------------------------------------------------
+    idb_path = which("idb")
+    sites.append(ToolSite(
+        name="idb", role="cli",
+        available=idb_path is not None,
+        # From metadata: `idb --version` prints usage rather than a version.
+        version=package_version("fb-idb"),
+        path=idb_path, source=classify_source(idb_path),
+        volatile_path=is_volatile(idb_path),
+    ))
+
+    # --- mitmproxy --------------------------------------------------------
+    mitm_path = which("mitmdump")
+    sites.append(ToolSite(
+        name="mitmproxy", role="cli",
+        available=mitm_path is not None,
+        version=package_version("mitmproxy"),
+        path=mitm_path, source=classify_source(mitm_path),
+        volatile_path=is_volatile(mitm_path),
+    ))
+
+    # --- adb --------------------------------------------------------------
+    adb_path = shutil.which("adb") or _android_sdk_adb()
+    sites.append(ToolSite(
+        name="adb", role="cli",
+        available=adb_path is not None,
+        version=await binary_version(adb_path, ["version"]) if adb_path else None,
+        path=adb_path, source=classify_source(adb_path),
+    ))
+
+    # --- libimobiledevice -------------------------------------------------
+    imd_path = shutil.which("idevice_id")
+    site = ToolSite(
+        name="libimobiledevice", role="cli",
+        available=imd_path is not None,
+        version=await binary_version(imd_path, ["--version"]) if imd_path else None,
+        path=imd_path, source=classify_source(imd_path),
+    )
+    if site.source == "brew":
+        site.requested, site.required_by = brew_provenance("libimobiledevice")
+    sites.append(site)
+
+    # --- node -------------------------------------------------------------
+    node_path = shutil.which("node")
+    sites.append(ToolSite(
+        name="node", role="cli",
+        available=node_path is not None,
+        version=await binary_version(node_path, ["--version"]) if node_path else None,
+        path=node_path, source=classify_source(node_path),
+        volatile_path=is_volatile(node_path),
+        detail="runs the MCP server",
+    ))
+
+    return sites
+
+
+def _android_sdk_adb() -> str | None:
+    candidate = Path.home() / "Library" / "Android" / "sdk" / "platform-tools" / "adb"
+    return str(candidate) if candidate.is_file() else None
+
+
+def upgrade_note(site: ToolSite) -> str | None:
+    """What a reader should know before upgrading this one.
+
+    Only for brew, and only when brew actually recorded something: an install
+    predating the flag reports neither, and "not recorded" must not be read as
+    "arrived as a dependency".
+    """
+    if site.source != "brew":
+        return None
+    parts: list[str] = []
+    if site.requested is False:
+        parts.append(
+            "arrived as a dependency of something else, so upgrading it "
+            "directly may be undone by whatever pulled it in"
+        )
+    elif site.requested is None:
+        parts.append("brew did not record whether this was asked for")
+    if site.required_by:
+        parts.append("also required by " + ", ".join(sorted(site.required_by)))
+    return "; ".join(parts) or None

--- a/server/lifecycle/setup.py
+++ b/server/lifecycle/setup.py
@@ -2153,12 +2153,29 @@ def record_tool_sites() -> None:
 
 
 def _load_recorded_sites() -> dict:
+    """The recorded snapshot, or nothing if it is not one.
+
+    Shape-checked rather than trusted. It is a file on disk that a person can
+    edit, and a doctor run that raises on a malformed snapshot fails at the
+    point it was meant to be reporting.
+    """
     import json
 
     try:
-        return json.loads(TOOL_SNAPSHOT.read_text())
+        data = json.loads(TOOL_SNAPSHOT.read_text())
     except (FileNotFoundError, json.JSONDecodeError, OSError):
         return {}
+    if not isinstance(data, dict):
+        return {}
+    sites = data.get("sites")
+    if not isinstance(sites, list):
+        return {}
+    usable = [
+        s for s in sites
+        if isinstance(s, dict) and isinstance(s.get("name"), str)
+        and isinstance(s.get("role"), str)
+    ]
+    return {"recorded_at": data.get("recorded_at"), "sites": usable}
 
 
 def report_tool_sites(record: bool = False) -> list[CheckResult]:

--- a/server/lifecycle/setup.py
+++ b/server/lifecycle/setup.py
@@ -2163,7 +2163,9 @@ def _load_recorded_sites() -> dict:
 
     try:
         data = json.loads(TOOL_SNAPSHOT.read_text())
-    except (FileNotFoundError, json.JSONDecodeError, OSError):
+    except (OSError, ValueError):
+        # ValueError covers both JSONDecodeError and UnicodeDecodeError: bytes
+        # that are not valid text fail in read_text, before json sees them.
         return {}
     if not isinstance(data, dict):
         return {}

--- a/server/lifecycle/setup.py
+++ b/server/lifecycle/setup.py
@@ -2081,10 +2081,147 @@ def run_setup() -> int:
     if node_result.status == CheckStatus.OK and project_root:
         report.add(_build_mcp(project_root))
 
+    # ── Tool inventory ──
+    #
+    # Last, and never fatal: it answers "what is this machine actually
+    # running", which is the question a "works on mine" turns into. Recording
+    # it here means a later doctor can say what moved.
+
+    for result in report_tool_sites(record=True):
+        report.add(result)
+
     # ── Summary ──
 
     report.print_summary()
     return 1 if report.has_errors else 0
+
+
+# ── Tool inventory ───────────────────────────────────────────────────────
+
+
+TOOL_SNAPSHOT = Path.home() / ".quern" / "tool-sites.json"
+
+
+def _collect_sites_sync() -> list[dict]:
+    """Every install site quern uses. Sync, because setup is."""
+    import asyncio
+
+    from server.device.tool_versions import collect_sites, upgrade_note
+
+    try:
+        sites = asyncio.run(collect_sites())
+    except Exception:
+        return []
+    return [
+        {
+            "name": s.name, "role": s.role, "version": s.version,
+            "path": s.path, "source": s.source, "available": s.available,
+            "volatile_path": s.volatile_path, "upgrade_note": upgrade_note(s),
+        }
+        for s in sites
+    ]
+
+
+def record_tool_sites() -> None:
+    """Write down what was in use, so a later run can see what moved.
+
+    A snapshot of observed reality with a timestamp, not a claim about what
+    was tested -- it cannot go stale in the way a hand-maintained manifest can,
+    because nothing has to remember to update it.
+
+    Volatile paths are stored with the path dropped. fnm hands node out from a
+    directory named for the pid that asked, so recording the path would
+    guarantee a spurious "moved" on the next shell; the source is the durable
+    part.
+    """
+    import json
+
+    sites = _collect_sites_sync()
+    if not sites:
+        return
+    for site in sites:
+        if site.get("volatile_path"):
+            site["path"] = None
+    try:
+        TOOL_SNAPSHOT.parent.mkdir(parents=True, exist_ok=True)
+        TOOL_SNAPSHOT.write_text(json.dumps(
+            {"recorded_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"), "sites": sites},
+            indent=2,
+        ))
+    except OSError:
+        pass
+
+
+def _load_recorded_sites() -> dict:
+    import json
+
+    try:
+        return json.loads(TOOL_SNAPSHOT.read_text())
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+
+
+def report_tool_sites(record: bool = False) -> list[CheckResult]:
+    """What quern is using, and anything that has moved since it was recorded."""
+    sites = _collect_sites_sync()
+    if not sites:
+        return []
+
+    results: list[CheckResult] = []
+    for site in sites:
+        label = f"{site['name']} ({site['role']})"
+        if not site["available"]:
+            results.append(CheckResult(
+                name=label, status=CheckStatus.SKIPPED, message="not found",
+            ))
+            continue
+        where = site["source"]
+        if site["volatile_path"]:
+            where += " (per-shell path)"
+        results.append(CheckResult(
+            name=label,
+            status=CheckStatus.OK,
+            message=f"{site['version'] or 'version unknown'} — {where}",
+            detail=site.get("upgrade_note") or "",
+        ))
+
+    results.extend(_report_drift(sites))
+    if record:
+        record_tool_sites()
+    return results
+
+
+def _report_drift(sites: list[dict]) -> list[CheckResult]:
+    """Anything that changed version or moved since it was last recorded."""
+    recorded = _load_recorded_sites()
+    previous = {(s["name"], s["role"]): s for s in recorded.get("sites", [])}
+    if not previous:
+        return []
+
+    drifted: list[str] = []
+    for site in sites:
+        was = previous.get((site["name"], site["role"]))
+        if was is None:
+            continue
+        if was.get("version") and site["version"] and was["version"] != site["version"]:
+            drifted.append(
+                f"{site['name']} ({site['role']}) {was['version']} → {site['version']}"
+            )
+        # A volatile path was recorded as None, so it cannot report a move it
+        # would make on every shell.
+        elif was.get("path") and site["path"] and was["path"] != site["path"]:
+            drifted.append(
+                f"{site['name']} ({site['role']}) moved: {was['path']} → {site['path']}"
+            )
+    if not drifted:
+        return []
+    return [CheckResult(
+        name="tool drift",
+        status=CheckStatus.WARNING,
+        message=f"{len(drifted)} change(s) since {recorded.get('recorded_at', 'the last record')}",
+        detail="\n".join("  " + d for d in drifted)
+               + "\n  Re-record with: ./quern setup",
+    )]
 
 
 # ── Uninstall ────────────────────────────────────────────────────────────

--- a/server/main.py
+++ b/server/main.py
@@ -628,15 +628,13 @@ fetch('/api/v1/device/list', {
         """
         tools_status: dict = {}
         cache_stats: dict = {}
-        sites: list = []
         if hasattr(app.state, "device_controller") and app.state.device_controller:
-            controller = app.state.device_controller
-            tools_status = await controller.check_tools()
-            cache_stats = controller.get_cache_stats()
-            # Versions and provenance alongside the flags, not instead of them:
-            # existing callers read `tools` by truthiness.
-            sites = await controller.tool_sites()
-        return {"tools": tools_status, "sites": sites, "ui_cache": cache_stats}
+            tools_status = await app.state.device_controller.check_tools()
+            cache_stats = app.state.device_controller.get_cache_stats()
+        # Availability flags only. The per-site inventory carries absolute
+        # paths -- account names and filesystem layout -- and lives behind auth
+        # at /api/v1/tools/sites instead.
+        return {"tools": tools_status, "ui_cache": cache_stats}
 
     return app
 

--- a/server/main.py
+++ b/server/main.py
@@ -628,10 +628,15 @@ fetch('/api/v1/device/list', {
         """
         tools_status: dict = {}
         cache_stats: dict = {}
+        sites: list = []
         if hasattr(app.state, "device_controller") and app.state.device_controller:
-            tools_status = await app.state.device_controller.check_tools()
-            cache_stats = app.state.device_controller.get_cache_stats()
-        return {"tools": tools_status, "ui_cache": cache_stats}
+            controller = app.state.device_controller
+            tools_status = await controller.check_tools()
+            cache_stats = controller.get_cache_stats()
+            # Versions and provenance alongside the flags, not instead of them:
+            # existing callers read `tools` by truthiness.
+            sites = await controller.tool_sites()
+        return {"tools": tools_status, "sites": sites, "ui_cache": cache_stats}
 
     return app
 

--- a/server/main.py
+++ b/server/main.py
@@ -633,7 +633,7 @@ fetch('/api/v1/device/list', {
             cache_stats = app.state.device_controller.get_cache_stats()
         # Availability flags only. The per-site inventory carries absolute
         # paths -- account names and filesystem layout -- and lives behind auth
-        # at /api/v1/tools/sites instead.
+        # at /api/v1/device/tools/sites instead.
         return {"tools": tools_status, "ui_cache": cache_stats}
 
     return app

--- a/server/models.py
+++ b/server/models.py
@@ -1167,6 +1167,32 @@ class TypeTextRequest(BaseModel):
                 raise ValueError(f"{name} cannot be blank")
         return self
 
+class ToolSiteInfo(BaseModel):
+    """One place a tool is installed, and what quern uses it for."""
+
+    name: str
+    role: str
+    available: bool
+    version: str | None = None
+    path: str | None = None
+    source: str = "unknown"
+    detail: str | None = None
+    volatile_path: bool = False
+    requested: bool | None = None
+    required_by: list[str] = Field(default_factory=list)
+    upgrade_note: str | None = None
+
+
+class ToolSitesResponse(BaseModel):
+    """Every install site quern uses.
+
+    Authenticated: `path` exposes account names and filesystem layout, which is
+    why this is not on the public /tools endpoint beside the availability flags.
+    """
+
+    sites: list[ToolSiteInfo]
+
+
 class WaitSettledRequest(BaseModel):
     """Request body for POST /device/ui/wait-settled."""
 

--- a/tests/test_tool_versions.py
+++ b/tests/test_tool_versions.py
@@ -1,0 +1,228 @@
+"""Reporting which external tools quern is actually using.
+
+The failure this exists for is quiet: two machines comparing `pymobiledevice3`
+as a boolean agreed they both had it while being three majors apart, and the
+disagreement surfaced instead as one of them reading code the other did not
+have. A name is not one thing -- on a single machine it is a library and a
+binary at different versions -- so these tests care mostly about not collapsing
+things that differ.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from server.device.tool_versions import (
+    ToolSite,
+    classify_source,
+    is_volatile,
+    parse_version,
+    upgrade_note,
+)
+from server.lifecycle import setup as setup_mod
+
+
+class TestParseVersion:
+    """Every tool writes its version differently; all of these are real."""
+
+    def test_bare_version(self):
+        assert parse_version("9.15.1") == "9.15.1"
+
+    def test_name_then_version(self):
+        assert parse_version("idevice_id 1.4.0") == "1.4.0"
+
+    def test_version_buried_in_prose(self):
+        assert parse_version("Android Debug Bridge version 1.0.41") == "1.0.41"
+
+    def test_v_prefix_is_dropped(self):
+        assert parse_version("v22.22.2") == "22.22.2"
+
+    def test_name_colon_version(self):
+        assert parse_version("Mitmproxy: 12.2.3") == "12.2.3"
+
+    def test_a_prerelease_suffix_survives(self):
+        assert parse_version("quern 0.14.1-beta.2") == "0.14.1-beta"
+
+    def test_output_with_no_version_reports_none(self):
+        assert parse_version("usage: idb [-h] [--log {DEBUG,INFO}]") is None
+
+    def test_the_first_version_line_wins(self):
+        assert parse_version("Mitmproxy: 12.2.3\nPython: 3.12.1") == "12.2.3"
+
+
+class TestClassifySource:
+    def test_brew(self):
+        assert classify_source("/opt/homebrew/bin/idevice_id") == "brew"
+
+    def test_pipx(self):
+        assert classify_source("/opt/pipx/venvs/pymobiledevice3/bin/pymobiledevice3") == "pipx"
+
+    def test_fnm(self):
+        assert classify_source("/Users/x/.local/state/fnm_multishells/1794_17/bin/node") == "fnm"
+
+    def test_android_sdk(self):
+        assert classify_source("/Users/x/Library/Android/sdk/platform-tools/adb") == "android-sdk"
+
+    def test_system(self):
+        assert classify_source("/usr/local/bin/pymobiledevice3") == "system"
+
+    def test_nothing_to_go_on(self):
+        assert classify_source(None) == "unknown"
+
+
+class TestVolatilePaths:
+    """A path that changes between shells identifies where a tool came from,
+    and is useless as somewhere to look again."""
+
+    def test_fnm_hands_out_a_per_shell_path(self):
+        assert is_volatile("/Users/x/.local/state/fnm_multishells/1794_1787032486225/bin/node")
+
+    def test_a_stable_path_is_not_volatile(self):
+        assert not is_volatile("/opt/homebrew/bin/idevice_id")
+
+    def test_no_path_is_not_volatile(self):
+        assert not is_volatile(None)
+
+
+class TestUpgradeNote:
+    def _brew(self, **kw):
+        return ToolSite(name="libimobiledevice", role="cli", available=True,
+                        source="brew", **kw)
+
+    def test_a_dependency_says_an_upgrade_may_be_undone(self):
+        note = upgrade_note(self._brew(requested=False))
+        assert "arrived as a dependency" in note
+
+    def test_unrecorded_provenance_is_not_reported_as_a_dependency(self):
+        """Installs predating the flag carry neither, and treating that as
+        "arrived as a dependency" would be inventing a fact."""
+        note = upgrade_note(self._brew(requested=None))
+        assert "did not record" in note
+        assert "arrived as a dependency" not in note
+
+    def test_dependents_are_named_so_the_blast_radius_is_visible(self):
+        note = upgrade_note(self._brew(
+            requested=True, required_by=["ios-webkit-debug-proxy", "ideviceinstaller"]))
+        assert "ideviceinstaller, ios-webkit-debug-proxy" in note
+
+    def test_a_requested_formula_nothing_depends_on_needs_no_note(self):
+        assert upgrade_note(self._brew(requested=True)) is None
+
+    def test_non_brew_tools_get_no_brew_advice(self):
+        site = ToolSite(name="node", role="cli", available=True, source="fnm",
+                        requested=False, required_by=["something"])
+        assert upgrade_note(site) is None
+
+
+class TestDescribe:
+    def test_a_missing_tool_says_so(self):
+        assert "not found" in ToolSite(name="idb", role="cli").describe()
+
+    def test_the_role_distinguishes_two_installs_of_one_name(self):
+        library = ToolSite(name="pymobiledevice3", role="library", available=True,
+                           version="11.3.1", source="venv")
+        cli = ToolSite(name="pymobiledevice3", role="cli", available=True,
+                       version="9.15.1", path="/opt/pipx/bin/pymobiledevice3")
+        assert library.describe() != cli.describe()
+        assert "library" in library.describe() and "cli" in cli.describe()
+
+
+# ── the recorded snapshot, and drift against it ──────────────────────────
+
+
+@pytest.fixture
+def snapshot(tmp_path, monkeypatch):
+    path = tmp_path / "tool-sites.json"
+    monkeypatch.setattr(setup_mod, "TOOL_SNAPSHOT", path)
+    return path
+
+
+def _site(name="pymobiledevice3", role="cli", version="9.15.1",
+          path="/opt/pipx/bin/pymobiledevice3", **kw):
+    return {"name": name, "role": role, "version": version, "path": path,
+            "source": "pipx", "available": True, "volatile_path": False,
+            "upgrade_note": None, **kw}
+
+
+def _record(snapshot, sites):
+    snapshot.write_text(json.dumps({"recorded_at": "2026-01-01T00:00:00", "sites": sites}))
+
+
+def test_a_version_change_is_reported(snapshot):
+    _record(snapshot, [_site(version="7.7.1")])
+    drift = setup_mod._report_drift([_site(version="9.15.1")])
+    assert drift and "7.7.1 → 9.15.1" in drift[0].detail
+
+
+def test_a_move_is_reported(snapshot):
+    _record(snapshot, [_site(path="/usr/local/bin/pymobiledevice3")])
+    drift = setup_mod._report_drift([_site(path="/opt/pipx/bin/pymobiledevice3")])
+    assert drift and "moved" in drift[0].detail
+
+
+def test_nothing_changed_reports_nothing(snapshot):
+    _record(snapshot, [_site()])
+    assert setup_mod._report_drift([_site()]) == []
+
+
+def test_with_no_record_there_is_nothing_to_compare(snapshot):
+    assert setup_mod._report_drift([_site()]) == []
+
+
+def test_a_tool_absent_from_the_record_is_not_drift(snapshot):
+    """It was installed since. That is news, but it is not a change to
+    something that was working, and calling it drift would cry wolf."""
+    _record(snapshot, [_site()])
+    drift = setup_mod._report_drift([_site(), _site(name="adb", role="cli")])
+    assert drift == []
+
+
+def test_a_per_shell_path_cannot_report_a_move(snapshot):
+    """fnm names node's directory for the pid that asked, so a recorded path
+    would differ on every shell and drift would fire constantly."""
+    _record(snapshot, [_site(name="node", version="22.22.2", path=None,
+                             volatile_path=True)])
+    drift = setup_mod._report_drift([
+        _site(name="node", version="22.22.2", volatile_path=True,
+              path="/x/.local/state/fnm_multishells/999_1/bin/node"),
+    ])
+    assert drift == []
+
+
+def test_a_per_shell_tool_still_reports_a_version_change(snapshot):
+    """Dropping the path must not drop the tool from the comparison."""
+    _record(snapshot, [_site(name="node", version="20.1.0", path=None,
+                             volatile_path=True)])
+    drift = setup_mod._report_drift([
+        _site(name="node", version="22.22.2", volatile_path=True, path=None),
+    ])
+    assert drift and "20.1.0 → 22.22.2" in drift[0].detail
+
+
+def test_recording_drops_volatile_paths(snapshot, monkeypatch):
+    monkeypatch.setattr(
+        setup_mod, "_collect_sites_sync",
+        lambda: [_site(name="node", volatile_path=True,
+                       path="/x/fnm_multishells/1_2/bin/node")],
+    )
+    setup_mod.record_tool_sites()
+    stored = json.loads(snapshot.read_text())["sites"][0]
+    assert stored["path"] is None
+    assert stored["version"] == "9.15.1"
+
+
+def test_the_two_pymobiledevice3_installs_are_tracked_apart(snapshot):
+    """The whole point: one name, two installs, and a change to one of them
+    must not be hidden by the other agreeing."""
+    _record(snapshot, [
+        _site(role="library", version="11.3.1", path=None),
+        _site(role="cli", version="9.15.1"),
+    ])
+    drift = setup_mod._report_drift([
+        _site(role="library", version="11.3.1", path=None),
+        _site(role="cli", version="7.7.1"),
+    ])
+    assert drift and "9.15.1 → 7.7.1" in drift[0].detail
+    assert "library" not in drift[0].detail

--- a/tests/test_tool_versions.py
+++ b/tests/test_tool_versions.py
@@ -270,3 +270,11 @@ class TestSnapshotIsShapeChecked:
     def test_a_malformed_snapshot_reports_no_drift_rather_than_raising(self, snapshot):
         snapshot.write_text("{ not json")
         assert setup_mod._report_drift([_site()]) == []
+
+
+def test_a_snapshot_that_is_not_text_reports_nothing(snapshot):
+    """UnicodeDecodeError is a ValueError, not an OSError, and read_text raises
+    it before json ever sees the bytes."""
+    snapshot.write_bytes(b"\xff\xfe\x00not valid utf-8 \xc3\x28")
+    assert setup_mod._load_recorded_sites() == {}
+    assert setup_mod._report_drift([_site()]) == []

--- a/tests/test_tool_versions.py
+++ b/tests/test_tool_versions.py
@@ -42,8 +42,10 @@ class TestParseVersion:
     def test_name_colon_version(self):
         assert parse_version("Mitmproxy: 12.2.3") == "12.2.3"
 
-    def test_a_prerelease_suffix_survives(self):
-        assert parse_version("quern 0.14.1-beta.2") == "0.14.1-beta"
+    def test_a_prerelease_keeps_its_build_number(self):
+        """Truncating to `0.14.1-beta` makes beta.1 and beta.2 compare equal,
+        so drift between two prereleases would go unreported."""
+        assert parse_version("quern 0.14.1-beta.2") == "0.14.1-beta.2"
 
     def test_output_with_no_version_reports_none(self):
         assert parse_version("usage: idb [-h] [--log {DEBUG,INFO}]") is None
@@ -66,7 +68,23 @@ class TestClassifySource:
         assert classify_source("/Users/x/Library/Android/sdk/platform-tools/adb") == "android-sdk"
 
     def test_system(self):
-        assert classify_source("/usr/local/bin/pymobiledevice3") == "system"
+        # A path that does not exist, so resolve() leaves it alone: on a real
+        # machine /usr/local/bin is full of symlinks into Cellar and pipx.
+        assert classify_source("/usr/bin/nonexistent-tool-xyz") == "system"
+
+    def test_a_symlink_is_followed_before_classifying(self, tmp_path):
+        """Brew links its binaries into bin directories that look like system
+        paths. Classifying the link reports `system` for a formula, and its
+        provenance is then never looked up."""
+        cellar = tmp_path / "usr" / "local" / "Cellar" / "x" / "1.0" / "bin"
+        cellar.mkdir(parents=True)
+        real = cellar / "idevice_id"
+        real.write_text("")
+        link = tmp_path / "bin" / "idevice_id"
+        link.parent.mkdir(parents=True)
+        link.symlink_to(real)
+        # The link is classified by what it points at, not by where it sits.
+        assert classify_source(str(link)) == "brew"
 
     def test_nothing_to_go_on(self):
         assert classify_source(None) == "unknown"
@@ -226,3 +244,29 @@ def test_the_two_pymobiledevice3_installs_are_tracked_apart(snapshot):
     ])
     assert drift and "9.15.1 → 7.7.1" in drift[0].detail
     assert "library" not in drift[0].detail
+
+
+class TestSnapshotIsShapeChecked:
+    """It is a file on disk that a person can edit. A doctor run that raises on
+    a malformed snapshot fails at the point it was meant to be reporting."""
+
+    def test_a_list_instead_of_an_object(self, snapshot):
+        snapshot.write_text("[]")
+        assert setup_mod._load_recorded_sites() == {}
+
+    def test_sites_that_is_not_a_list(self, snapshot):
+        snapshot.write_text(json.dumps({"sites": "nope"}))
+        assert setup_mod._load_recorded_sites() == {}
+
+    def test_a_null_entry_is_dropped_not_crashed_on(self, snapshot):
+        snapshot.write_text(json.dumps({"sites": [None, _site()]}))
+        loaded = setup_mod._load_recorded_sites()
+        assert [s["name"] for s in loaded["sites"]] == ["pymobiledevice3"]
+
+    def test_an_entry_missing_its_key_fields_is_dropped(self, snapshot):
+        snapshot.write_text(json.dumps({"sites": [{"version": "1.0"}, _site()]}))
+        assert len(setup_mod._load_recorded_sites()["sites"]) == 1
+
+    def test_a_malformed_snapshot_reports_no_drift_rather_than_raising(self, snapshot):
+        snapshot.write_text("{ not json")
+        assert setup_mod._report_drift([_site()]) == []

--- a/tests/test_tool_versions.py
+++ b/tests/test_tool_versions.py
@@ -278,3 +278,60 @@ def test_a_snapshot_that_is_not_text_reports_nothing(snapshot):
     snapshot.write_bytes(b"\xff\xfe\x00not valid utf-8 \xc3\x28")
     assert setup_mod._load_recorded_sites() == {}
     assert setup_mod._report_drift([_site()]) == []
+
+
+class TestVenvDetectionUnderASystemPython:
+    """`sys.executable`'s directory is only quern's environment when quern is
+    in a virtualenv. Under a system interpreter it is /usr/bin, and matching on
+    it would report every binary there as living in quern's environment."""
+
+    def test_a_system_binary_is_not_called_venv(self, monkeypatch):
+        from server.device import tool_versions as tv
+        monkeypatch.setattr(tv.sys, "executable", "/usr/bin/python3")
+        monkeypatch.setattr(tv.sys, "prefix", "/usr")
+        monkeypatch.setattr(tv.sys, "base_prefix", "/usr")   # not a virtualenv
+        assert tv.classify_source("/usr/bin/some-tool") == "system"
+
+    def test_inside_a_virtualenv_the_interpreter_directory_counts(
+        self, monkeypatch, tmp_path,
+    ):
+        from server.device import tool_versions as tv
+        venv_bin = tmp_path / "env" / "bin"
+        venv_bin.mkdir(parents=True)
+        monkeypatch.setattr(tv.sys, "executable", str(venv_bin / "python"))
+        monkeypatch.setattr(tv.sys, "prefix", str(tmp_path / "env"))
+        monkeypatch.setattr(tv.sys, "base_prefix", "/usr")   # is a virtualenv
+        assert tv.classify_source(str(venv_bin / "idb")) == "venv"
+
+
+async def test_every_cli_site_is_asked_whether_its_path_survives_a_shell(monkeypatch):
+    """One site forgetting means the snapshot records a path that changes on
+    its own, and the next doctor reports a move that never happened.
+
+    Every tool is pointed at a volatile path here, so the check does not depend
+    on where this machine happens to keep them -- adb sits in a stable SDK
+    directory locally, and the omission it is guarding against was invisible
+    for exactly that reason.
+    """
+    from server.device import tool_versions as tv
+
+    volatile = "/x/.local/state/fnm_multishells/1_2/bin/tool"
+    monkeypatch.setattr(tv.shutil, "which", lambda _n: volatile)
+    monkeypatch.setattr(tv, "which", lambda _n: volatile)
+    monkeypatch.setattr(tv, "brew_provenance", _no_provenance)
+    monkeypatch.setattr(tv, "binary_version", _no_version)
+
+    for site in await tv.collect_sites():
+        if site.role != "cli" or not site.path:
+            continue
+        assert site.volatile_path, (
+            f"{site.name} does not report whether its path is volatile"
+        )
+
+
+async def _no_provenance(_formula):
+    return None, []
+
+
+async def _no_version(*_a, **_kw):
+    return None


### PR DESCRIPTION
Stage 1 of #67. Not stages 2–4 — see the note at the end.

## The reframing

The issue describes two machines drifting apart. Measuring first turned up
something narrower and more actionable: **on this single machine,
`pymobiledevice3` is two installs at different versions**, serving different
code paths.

```
pymobiledevice3 (library) 11.3.1 — venv          ← imported by webinspector.py
pymobiledevice3 (cli)      9.15.1 — pipx          ← run by tunneld, device log
```

The issue's own table lists "scorpius: 9.15.1" — that's the CLI. The library was
never in the comparison. And `check_tools()` reported both as
`pymobiledevice3: true`.

So the defect is upstream of drift: **a tool name isn't one thing, and nothing
reported what was actually loaded.** "Works on mine" wasn't caused by missing
pins — it was two people comparing a number that identified neither of them.
The unit here is therefore the install *site*, not the tool.

## What `quern doctor` now shows

```
✓ pymobiledevice3 (library)    11.3.1 — venv
✓ pymobiledevice3 (cli)        9.15.1 — pipx
✓ idb (cli)                    1.1.7 — venv
✓ mitmproxy (cli)              12.2.3 — venv
✓ adb (cli)                    1.0.41 — android-sdk
✓ libimobiledevice (cli)       1.4.0 — brew
      also required by ideviceinstaller, ios-webkit-debug-proxy
✓ node (cli)                   22.22.2 — fnm (per-shell path)
```

Versions come from **package metadata** where the tool is a Python package —
exact, and it works where parsing cannot: `idb --version` prints usage. The rest
are parsed, and the formats really do all differ (`9.15.1`, `idevice_id 1.4.0`,
`Android Debug Bridge version 1.0.41`, `v22.22.2`, `Mitmproxy: 12.2.3`).

Paths resolve the way quern resolves them, not through `PATH` — which finds
neither `idb` nor `mitmdump` here, and finds `pymobiledevice3` at
`/usr/local/bin` where quern uses `/opt/pipx/...`.

## Brew provenance

Verified available and wired in: whether a formula was **asked for** or
**arrived as a dependency**, plus what else depends on it, so a reader can see
what an upgrade would touch.

Deliberately best-effort. `libusbmuxd` and `openssl@3` on this machine carry
*neither* flag — installs predating it — so "not recorded" is reported as
itself rather than as "arrived as a dependency", which would be inventing a
fact.

## The install-time record

`quern setup` writes what it saw to `~/.quern/tool-sites.json`, and a later
`doctor` reports what moved:

```
⚠ tool drift: 2 change(s) since 2026-09-04T17:17:57-0700
    pymobiledevice3 (cli) 7.7.1 → 9.15.1
    adb (cli) moved: /opt/homebrew/bin/adb → …/Android/sdk/platform-tools/adb
    Re-record with: ./quern setup
```

This is a **snapshot of observed reality with a timestamp**, not a claim about
what was tested — so it cannot rot the way a hand-maintained manifest does,
because nothing has to remember to update it. That distinction is why it does
not carry stage 4's obligation.

Volatile paths are stored *without* the path: fnm hands `node` out from a
directory named for the pid that asked, so recording it would fire a spurious
"moved" on the very next shell. The source is the durable part. A per-shell tool
still reports version changes — dropping the path must not drop the tool.

## One deliberate non-change

`check_tools()` keeps its shape. The issue proposes extending it to carry
versions, but its values are consumed **by truthiness** — `main.py:297` decides
whether to use the sim-bridge backend from one — so widening them to
dictionaries would silently make every tool read as available, including missing
ones. `tool_sites()` is a sibling, and `/tools` returns both.

## Stages 2–4

Not built, per the issue's own conditional: *"If stage 4 is not going to be
built, stage 1 alone is the better stopping point."* Worth adding that the
library half already has a version mechanism (`pymobiledevice3>=8.0` in
`pyproject.toml`) — it's the CLI that has no floor and nothing checking it, so a
manifest may only genuinely be needed for the non-Python tools.

33 new tests, mutation-verified. Suite 1705, ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authenticated endpoint for detailed tool installation-site information, including versions, paths, availability, provenance, dependencies, and upgrade guidance.
  * Tool reporting distinguishes library and command-line installations, identifies volatile paths, and detects version or path changes.
  * Setup now records and validates tool inventory snapshots while safely handling malformed or invalid data.

* **Documentation**
  * Updated API documentation to distinguish basic tool availability and cache statistics from detailed installation-site information.

* **Tests**
  * Added coverage for version reporting, source classification, snapshots, drift detection, malformed data, and upgrade notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->