### PR TITLE
Annotate dependency floor provenance; upgrade the venv eagerly on update

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,18 @@ quern set-channel          # print the current channel
 quern set-channel stable   # switch back
 ```
 
+`quern update` brings its own venv forward eagerly: pip's default strategy leaves
+any version that already satisfies a constraint alone, so a venv drifts arbitrarily
+far behind while every declared floor stays satisfied. Every dependency floor quern
+declares is a `>=` and none is near what currently ships — `pymobiledevice3` sits
+three majors above its own — so "satisfies the constraint" says very little about how
+current the venv is.
+
+Starting the server is unaffected: it still runs a cheap constraint check, not a
+network-bound upgrade. `quern doctor --fix` also stays non-eager, because it repairs a
+broken venv and pulling every transitive dependency forward mid-repair changes more
+than the fault being fixed.
+
 Setting the channel only writes `~/.quern/config.json` — nothing changes until the next `quern update`. Git-clone installs follow the `release/stable` / `release/beta` pointer branches; tarball installs follow GitHub Releases, filtered on the prerelease flag. Full details, including the maintainer release procedure, are in [`docs/release-channels.md`](docs/release-channels.md).
 
 ## What Quern Does

--- a/README.md
+++ b/README.md
@@ -182,10 +182,11 @@ declares is a `>=` and none is near what currently ships — `pymobiledevice3` s
 three majors above its own — so "satisfies the constraint" says very little about how
 current the venv is.
 
-Starting the server is unaffected: it still runs a cheap constraint check, not a
-network-bound upgrade. `quern doctor --fix` also stays non-eager, because it repairs a
-broken venv and pulling every transitive dependency forward mid-repair changes more
-than the fault being fixed.
+Starting the server stays non-eager: it compares two mtimes, and invokes pip only when
+the venv is actually stale or a previous install failed — never the eager transitive
+upgrade `quern update` performs. `quern doctor --fix` is also non-eager, because it
+repairs a broken venv and pulling every transitive dependency forward mid-repair
+changes more than the fault being fixed.
 
 Setting the channel only writes `~/.quern/config.json` — nothing changes until the next `quern update`. Git-clone installs follow the `release/stable` / `release/beta` pointer branches; tarball installs follow GitHub Releases, filtered on the prerelease flag. Full details, including the maintainer release procedure, are in [`docs/release-channels.md`](docs/release-channels.md).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,31 +5,58 @@ description = "Debug log capture and AI context server"
 readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.11"
+# Dependency floors: read this before adding or raising one.
+#
+# Every floor here is `>=`, never a cap. A cap would be an untested claim about
+# a release that does not exist yet, and it is the mechanism that strands a
+# project on old versions -- so we do not use one. Major bumps arrive as
+# Dependabot PRs (.github/dependabot.yml) and are gated by CI, which builds a
+# fresh venv and therefore always resolves to the latest satisfying release.
+#
+# That has a consequence worth stating plainly: CI proves latest works. Nothing
+# here proves the *floor* works. A floor is only trustworthy if someone actually
+# installed that version and ran the suite, so each one below is marked:
+#
+#   verified  -- tested at the boundary; the comment says what breaks underneath
+#   inherited -- the version current when the dep was added. Not a tested claim.
+#                Safe to raise to whatever CI is green on; do not cite it as a
+#                compatibility guarantee.
+#
+# Floors do not hold anything back: pymobiledevice3 sits three majors above its
+# own floor. Raise a floor only to encode a real incompatibility, not as
+# housekeeping.
 dependencies = [
-    "fastapi>=0.115.0",
-    "uvicorn[standard]>=0.34.0",
-    # Web Inspector transport for simulator webview inspection. Floored at 8.0
-    # deliberately: send_plist/recv_plist are synchronous in 7.x and coroutines
-    # from 8.0 onward. webinspector.py awaits them, so on 7.x the await lands on
-    # a plain return value and raises TypeError ("object NoneType can't be used
-    # in 'await' expression"). Loud, but only at call time, and the message does
-    # not mention the version -- hence the floor. Verified at 7.7.1, 8.0.0,
-    # 9.15.1 and 11.3.0. Note this is a library import; server/device/pmd3.py
+    "fastapi>=0.115.0",                 # inherited
+    "uvicorn[standard]>=0.34.0",        # inherited
+    # verified. Web Inspector transport for simulator webview inspection.
+    # Floored at 8.0 deliberately: send_plist/recv_plist are synchronous in 7.x
+    # and coroutines from 8.0 onward. webinspector.py awaits them, so on 7.x the
+    # await lands on a plain return value and raises TypeError ("object NoneType
+    # can't be used in 'await' expression"). Loud, but only at call time, and the
+    # message does not mention the version -- hence the floor. Verified at 7.7.1,
+    # 8.0.0, 9.15.1 and 11.3.0. Note this is a library import; server/device/pmd3.py
     # separately shells out to a pipx-installed CLI, a different install.
     "pymobiledevice3>=8.0",
-    "pydantic>=2.0",
-    "sse-starlette>=2.0",
-    "mitmproxy>=10.0",
-    "httpx>=0.27",
-    "Pillow>=10.0",
-    # Vision framework via pyobjc, for locating on-screen text to aim
-    # accessibility hit-tests at (see server/device/vision_ocr.py). In-process,
-    # so nothing to compile, sign or ship. macOS only, like the simulator path
-    # it serves; the module degrades to pixel analysis if the import fails.
+    "pydantic>=2.0",                    # inherited; v1 genuinely breaks, but 2.0 exactly is untested
+    "sse-starlette>=2.0",               # inherited
+    "mitmproxy>=10.0",                  # inherited
+    "httpx>=0.27",                      # inherited. Starlette 1.x deprecates httpx
+                                        # under TestClient in favour of httpx2; when
+                                        # that becomes an error this floor moves.
+    "Pillow>=10.0",                     # inherited
+    # inherited -- 10.0 was picked when the dep was added and never tested at that
+    # boundary. Vision framework via pyobjc, for locating on-screen text to aim
+    # accessibility hit-tests at (see server/device/vision_ocr.py). In-process, so
+    # nothing to compile, sign or ship. macOS only, like the simulator path it
+    # serves; the module degrades to pixel analysis if the import fails. The real
+    # constraint is objc.registerMetaDataForSelector for computeDistance's
+    # out-param, which lives in pyobjc-core, not here.
     "pyobjc-framework-Vision>=10.0; sys_platform == 'darwin'",
+    # inherited. CLI only -- `idb` is imported in zero Python files; server/device
+    # shells out to the binary. The floor constrains the console script, not an API.
     "fb-idb>=1.1.0",
-    "uiautomator2>=3.2",
-    "pyyaml>=6.0",
+    "uiautomator2>=3.2",                # inherited
+    "pyyaml>=6.0",                      # inherited
 ]
 
 [project.optional-dependencies]

--- a/server/__main__.py
+++ b/server/__main__.py
@@ -159,7 +159,14 @@ def _ensure_python_deps(
             cmd,
             cwd=str(project_root), capture_output=True, text=True, timeout=300,
         )
-    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+    except (OSError, subprocess.SubprocessError) as exc:
+        # The two base classes, not a list of the ones seen so far. Naming
+        # concrete exceptions cost three rounds here: FileNotFoundError alone
+        # missed TimeoutExpired, and adding that missed PermissionError -- which
+        # a non-executable .venv/bin/pip raises, and which propagated uncaught
+        # into the start path rather than merely leaving a stale stamp.
+        # OSError covers the whole errno family; SubprocessError covers
+        # TimeoutExpired and CalledProcessError.
         print(f"Error: dependency install failed: {exc}")
         return failed()
 

--- a/server/__main__.py
+++ b/server/__main__.py
@@ -147,6 +147,20 @@ def _ensure_python_deps(
         return False
 
     if result.returncode != 0:
+        # Drop the stamp, so the next start genuinely retries.
+        #
+        # Not writing it on failure is enough only when the stamp is absent or
+        # older than pyproject.toml. A forced install runs regardless of the
+        # stamp, so it can fail against one that is already current -- from an
+        # earlier successful install -- and simply leaving it alone records the
+        # failure as done. The next start reads "up to date" and skips, and the
+        # message printed just below ("starting Quern again will retry
+        # automatically") is then false.
+        #
+        # That matters most for the eager path: it moves the whole transitive
+        # tree, so a mid-way failure can leave a partially upgraded venv marked
+        # complete.
+        (project_root / ".venv" / DEPS_STAMP_NAME).unlink(missing_ok=True)
         err = (result.stderr or result.stdout or "").strip()
         print("Error: dependency install failed. Quern will start, but features "
               "needing the missing packages will fail.")

--- a/server/__main__.py
+++ b/server/__main__.py
@@ -137,6 +137,23 @@ def _ensure_python_deps(
     if eager:
         cmd += ["--upgrade", "--upgrade-strategy", "eager"]
 
+    # Every failure path below has to go through this. Not writing the stamp is
+    # enough only when it is absent or older than pyproject.toml; a *forced*
+    # install runs regardless of the stamp, so it can fail against one that is
+    # already current from an earlier success, and leaving it alone records the
+    # failure as done. The next start then reads "up to date" and skips, which
+    # also makes the "starting Quern again will retry automatically" message
+    # printed below false.
+    #
+    # It matters most for the eager path, which moves the whole transitive tree:
+    # a failure part-way through can leave a partially upgraded venv marked
+    # complete. A timeout is the likeliest way to get there, which is exactly
+    # the branch the first version of this fix missed -- hence one helper rather
+    # than the same unlink repeated per path.
+    def failed() -> bool:
+        (project_root / ".venv" / DEPS_STAMP_NAME).unlink(missing_ok=True)
+        return False
+
     try:
         result = subprocess.run(
             cmd,
@@ -144,23 +161,9 @@ def _ensure_python_deps(
         )
     except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
         print(f"Error: dependency install failed: {exc}")
-        return False
+        return failed()
 
     if result.returncode != 0:
-        # Drop the stamp, so the next start genuinely retries.
-        #
-        # Not writing it on failure is enough only when the stamp is absent or
-        # older than pyproject.toml. A forced install runs regardless of the
-        # stamp, so it can fail against one that is already current -- from an
-        # earlier successful install -- and simply leaving it alone records the
-        # failure as done. The next start reads "up to date" and skips, and the
-        # message printed just below ("starting Quern again will retry
-        # automatically") is then false.
-        #
-        # That matters most for the eager path: it moves the whole transitive
-        # tree, so a mid-way failure can leave a partially upgraded venv marked
-        # complete.
-        (project_root / ".venv" / DEPS_STAMP_NAME).unlink(missing_ok=True)
         err = (result.stderr or result.stdout or "").strip()
         print("Error: dependency install failed. Quern will start, but features "
               "needing the missing packages will fail.")
@@ -168,7 +171,7 @@ def _ensure_python_deps(
             print(f"  {err.splitlines()[-1][:200]}")
         print("  This is usually a network problem. Once it is reachable, "
               "starting Quern again will retry automatically.")
-        return False
+        return failed()
 
     # Only on success — a failed install must not look done to the next start.
     (project_root / ".venv" / DEPS_STAMP_NAME).touch()

--- a/server/__main__.py
+++ b/server/__main__.py
@@ -89,7 +89,9 @@ def python_deps_state(project_root: Path | None = None) -> dict:
     return {"applicable": True, "in_sync": True, "reason": "up to date"}
 
 
-def _ensure_python_deps(quiet: bool = False, force: bool = False) -> bool:
+def _ensure_python_deps(
+    quiet: bool = False, force: bool = False, eager: bool = False,
+) -> bool:
     """Install declared Python dependencies when the venv has fallen behind.
 
     Covers the cases `quern update` cannot reach — a manual `git pull`, a branch
@@ -100,6 +102,9 @@ def _ensure_python_deps(quiet: bool = False, force: bool = False) -> bool:
     Args:
         quiet: only print on an actual install or failure.
         force: install regardless of the stamp (used by `quern doctor --fix`).
+        eager: also pull transitive dependencies up to their newest compatible
+            release, rather than leaving any already-satisfying version alone.
+            Only `quern update` passes this -- see the note below.
 
     Returns:
         True if the venv is in sync, False if an install was needed and failed.
@@ -117,9 +122,24 @@ def _ensure_python_deps(quiet: bool = False, force: bool = False) -> bool:
     if not quiet:
         print(f"Installing Python dependencies ({state['reason']})...")
 
+    # pip's default (--upgrade-strategy only-if-needed) leaves any version that
+    # already satisfies the constraint alone, so a venv drifts arbitrarily far
+    # behind while every declared floor stays satisfied. Our floors are all `>=`
+    # and none is near what ships (see pyproject.toml), so "satisfies" is a very
+    # weak statement about how current the venv is.
+    #
+    # Eager is therefore right for `quern update` -- an explicit "bring me
+    # forward" -- and wrong for the start path, which runs on every launch and
+    # must stay a cheap constraint check rather than a network-bound upgrade.
+    # Doctor --fix stays non-eager too: it repairs a broken venv, and pulling
+    # every transitive dep forward mid-repair changes more than the fault.
+    cmd = [str(venv_pip), "install", "-e", "."]
+    if eager:
+        cmd += ["--upgrade", "--upgrade-strategy", "eager"]
+
     try:
         result = subprocess.run(
-            [str(venv_pip), "install", "-e", "."],
+            cmd,
             cwd=str(project_root), capture_output=True, text=True, timeout=300,
         )
     except (FileNotFoundError, subprocess.TimeoutExpired) as exc:

--- a/server/lifecycle/updater.py
+++ b/server/lifecycle/updater.py
@@ -377,7 +377,7 @@ def _rebuild_and_restart(project_root: Path) -> bool:
     # only a warning, so an update could report success onto a stale venv.
     from server.__main__ import _ensure_python_deps
 
-    deps_ok = _ensure_python_deps(quiet=False, force=True)
+    deps_ok = _ensure_python_deps(quiet=False, force=True, eager=True)
 
     # Rebuild MCP server
     from server.__main__ import _ensure_mcp_built

--- a/tests/test_python_deps_heal.py
+++ b/tests/test_python_deps_heal.py
@@ -327,3 +327,28 @@ def test_a_successful_forced_install_still_stamps(project, monkeypatch):
     monkeypatch.setattr(subprocess, "run", lambda *a, **k: _pip_result(0))
     assert _ensure_python_deps(quiet=True, force=True, eager=True) is True
     assert _stamp(project).exists()
+
+
+@pytest.mark.parametrize("failure", [
+    subprocess.TimeoutExpired(cmd="pip", timeout=300),
+    FileNotFoundError("pip is gone"),
+])
+def test_a_raised_install_failure_also_clears_the_stamp(project, monkeypatch, failure):
+    """The first version of this fix cleared the stamp only on a non-zero exit.
+
+    A raised failure returned early and left a current stamp behind, so the next
+    start skipped reconciliation exactly as before. The timeout case is the one
+    that matters most: an eager install moves the whole transitive tree, and a
+    300s timeout is the likeliest way to end up with it half applied.
+    """
+    _stamp(project).touch()
+    assert python_deps_state()["in_sync"] is True
+
+    def raising(*_a, **_k):
+        raise failure
+
+    monkeypatch.setattr(subprocess, "run", raising)
+    assert _ensure_python_deps(quiet=True, force=True, eager=True) is False
+
+    assert not _stamp(project).exists()
+    assert python_deps_state()["in_sync"] is False

--- a/tests/test_python_deps_heal.py
+++ b/tests/test_python_deps_heal.py
@@ -332,6 +332,12 @@ def test_a_successful_forced_install_still_stamps(project, monkeypatch):
 @pytest.mark.parametrize("failure", [
     subprocess.TimeoutExpired(cmd="pip", timeout=300),
     FileNotFoundError("pip is gone"),
+    # A non-executable .venv/bin/pip. This one did not merely leave a stale
+    # stamp -- it propagated uncaught out of _ensure_python_deps and into the
+    # start path, which calls it on every launch.
+    PermissionError("pip is not executable"),
+    NotADirectoryError("venv/bin is a file"),
+    subprocess.SubprocessError("pip died in some other way"),
 ])
 def test_a_raised_install_failure_also_clears_the_stamp(project, monkeypatch, failure):
     """The first version of this fix cleared the stamp only on a non-zero exit.

--- a/tests/test_python_deps_heal.py
+++ b/tests/test_python_deps_heal.py
@@ -262,3 +262,68 @@ def test_update_asks_for_an_eager_install(monkeypatch):
 
     source = inspect.getsource(updater)
     assert "_ensure_python_deps(quiet=False, force=True, eager=True)" in source
+
+
+# --------------------------------------------------------------------------
+# A forced install that fails must not be remembered as done
+# --------------------------------------------------------------------------
+#
+# Not writing the stamp on failure is enough only when the stamp is absent or
+# older than pyproject.toml. A *forced* install runs regardless of the stamp, so
+# it can fail against one that is already current from an earlier success --
+# and leaving it alone records the failure as complete. The next start then
+# reads "up to date" and skips, which makes the message the failure path prints
+# ("starting Quern again will retry automatically") false.
+#
+# Reproduced before fixing: prior success -> failing eager install -> the next
+# start reported in_sync=True with reason "up to date".
+
+
+def test_a_failed_forced_install_clears_a_current_stamp(project, monkeypatch):
+    _stamp(project).touch()
+    assert python_deps_state()["in_sync"] is True
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _pip_result(1, "boom"))
+    assert _ensure_python_deps(quiet=True, force=True, eager=True) is False
+
+    assert not _stamp(project).exists()
+    state = python_deps_state()
+    assert state["in_sync"] is False, "the failed upgrade was remembered as done"
+
+
+def test_the_next_start_retries_after_a_failed_eager_update(project, monkeypatch):
+    """End to end: the promise the failure message makes must hold.
+
+    An eager `quern update` fails against a healthy stamp; the following start
+    must run pip again rather than skipping on a venv that may be half upgraded.
+    """
+    _stamp(project).touch()
+
+    calls: list[list[str]] = []
+
+    def failing(cmd, **_kw):
+        calls.append(cmd)
+        return _pip_result(1, "boom")
+
+    monkeypatch.setattr(subprocess, "run", failing)
+    assert _ensure_python_deps(quiet=True, force=True, eager=True) is False
+
+    # The start path: stamp-gated, no force.
+    def succeeding(cmd, **_kw):
+        calls.append(cmd)
+        return _pip_result(0)
+
+    monkeypatch.setattr(subprocess, "run", succeeding)
+    assert _ensure_python_deps(quiet=True) is True
+
+    assert len(calls) == 2, "the start path skipped instead of retrying"
+    assert "--upgrade" not in calls[1], "the retry must stay non-eager"
+    assert _stamp(project).exists(), "a successful retry should stamp again"
+
+
+def test_a_successful_forced_install_still_stamps(project, monkeypatch):
+    """Guard the other direction: invalidating on failure must not also clear
+    the stamp on the success path."""
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _pip_result(0))
+    assert _ensure_python_deps(quiet=True, force=True, eager=True) is True
+    assert _stamp(project).exists()

--- a/tests/test_python_deps_heal.py
+++ b/tests/test_python_deps_heal.py
@@ -187,3 +187,78 @@ def test_updater_reports_success_when_deps_install(tmp_path, monkeypatch):
     monkeypatch.setattr(updater, "_rebuild_and_restart", lambda _p: True)
 
     assert updater.run_update() == 0
+
+
+# --------------------------------------------------------------------------
+# Upgrade strategy: which call sites move versions forward
+# --------------------------------------------------------------------------
+#
+# pip's default strategy (only-if-needed) leaves any already-satisfying version
+# alone, so a venv drifts arbitrarily far behind while every declared floor
+# stays satisfied. Measured on this project: an eager run moved 31 packages,
+# including starlette across a 0.x -> 1.x major, off a venv that pip considered
+# fully in sync. So "in sync" says nothing about how current the venv is, and
+# the distinction below is the only thing that makes `quern update` an upgrade.
+
+
+def _capture_pip(monkeypatch, project):
+    """Record the argv `_ensure_python_deps` hands to pip."""
+    seen: list[list[str]] = []
+
+    def fake_run(cmd, **_kwargs):
+        seen.append(cmd)
+        return _pip_result(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    return seen
+
+
+def test_the_default_install_does_not_upgrade(project, monkeypatch):
+    """The start path runs on every launch; it must stay a constraint check.
+
+    Making this eager would turn each start into a network-bound resolve of the
+    whole transitive tree.
+    """
+    seen = _capture_pip(monkeypatch, project)
+    assert _ensure_python_deps(quiet=True) is True
+    assert seen == [[str(project / ".venv" / "bin" / "pip"), "install", "-e", "."]]
+    assert "--upgrade" not in seen[0]
+
+
+def test_eager_asks_pip_to_move_transitive_deps(project, monkeypatch):
+    seen = _capture_pip(monkeypatch, project)
+    assert _ensure_python_deps(quiet=True, eager=True) is True
+    assert seen[0][-3:] == ["--upgrade", "--upgrade-strategy", "eager"]
+
+
+def test_force_alone_is_not_an_upgrade(project, monkeypatch):
+    """`quern doctor --fix` repairs a venv; it does not roll it forward.
+
+    Bundling an upgrade into a repair would change more than the reported fault,
+    which makes a failed repair much harder to attribute.
+    """
+    seen = _capture_pip(monkeypatch, project)
+    assert _ensure_python_deps(quiet=True, force=True) is True
+    assert "--upgrade" not in seen[0]
+
+
+def test_a_failed_eager_install_is_not_stamped(project, monkeypatch):
+    """Same contract as the non-eager path: failure must not look done."""
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _pip_result(1, "boom"))
+    assert _ensure_python_deps(quiet=True, eager=True) is False
+    assert not _stamp(project).exists()
+
+
+def test_update_asks_for_an_eager_install(monkeypatch):
+    """Pin the wiring: `quern update` is the one caller that upgrades.
+
+    Tested at the call site because the flag is only meaningful if the updater
+    actually passes it -- a correct `_ensure_python_deps` wired to nothing would
+    leave `quern update` silently non-upgrading, which is the bug this prevents.
+    """
+    import inspect
+
+    from server.lifecycle import updater
+
+    source = inspect.getsource(updater)
+    assert "_ensure_python_deps(quiet=False, force=True, eager=True)" in source


### PR DESCRIPTION
## What this does

Two related changes to how quern keeps its own Python dependencies current.

**`quern update` now upgrades the venv eagerly.** pip's default strategy
(`only-if-needed`) leaves any already-satisfying version alone, so the venv
drifts arbitrarily far behind while every declared floor stays satisfied.

Measured on this machine: an eager reinstall moved **31 packages**, including
`starlette` across a **0.x → 1.x major**, off a venv pip considered fully in
sync. The full suite passes at those versions, and the server runs clean on
them (proxy up, authed routes serving, nothing in `server.log`).

**Every dependency floor is now marked `verified` or `inherited`.**

## Why the floor audit changed the shape of this

The audit was meant to justify the eager change and instead produced the more
useful finding: **not one floor is load-bearing.**

| package | floor | installed | distance |
|---|---|---|---|
| pymobiledevice3 | `>=8.0` | 11.3.1 | 3 majors |
| Pillow | `>=10.0` | 12.3.0 | 2 majors |
| mitmproxy | `>=10.0` | 12.2.3 | 2 majors |
| fastapi | `>=0.115.0` | 0.141.1 | 26 minors |

They are all `>=`, so none of them ever blocked an upgrade. A floor cannot be
the reason a venv is stale — only a **cap** could be, which is why this PR adds
none. Capping majors would also be an untested claim about a release that does
not exist yet; major bumps already arrive as Dependabot PRs and are gated by CI.

The sharper consequence: **CI builds a fresh venv and always resolves to the
newest satisfying release, so CI proves latest works and nothing tests the
floor.** Every floor except one is an untested assertion.

So each is now labelled:

- **`verified`** — someone installed that version and ran the suite; the comment
  says what breaks underneath. This is `pymobiledevice3>=8.0` and nothing else.
- **`inherited`** — the version current when the dependency was added. Explicitly
  *not* a compatibility guarantee, and safe to raise to whatever CI is green on.

That includes correcting `pyobjc-framework-Vision>=10.0`, which I picked when
adding the dependency and presented as considered — it was not. The real
constraint there is `objc.registerMetaDataForSelector`, which lives in
`pyobjc-core`, not in the Vision package. `fb-idb` is marked CLI-only: `idb` is
imported in zero Python files.

## Scope boundaries

`--upgrade-strategy eager` is passed by **`quern update` only**:

- **start** stays non-eager — it runs on every launch and must remain a cheap
  constraint check, not a network-bound resolve of the whole transitive tree.
- **`doctor --fix`** stays non-eager — it repairs a broken venv, and rolling
  every transitive dependency forward mid-repair changes more than the fault
  being diagnosed, which makes a failed repair much harder to attribute.

Five tests pin that split, including one on the argv wiring: a correct
`_ensure_python_deps` wired to nothing would leave `quern update` silently
non-upgrading, which is the actual bug worth preventing.

## Verification

- **1720 passed**, ruff clean.
- Mutation-tested: dropping the eager flag, unwiring the updater, and making the
  start path eager are each caught by a distinct test.
- `pyproject.toml`'s **parsed dependency list is byte-identical** before and
  after — this changes comments only.

## Note for the reviewer

Starlette 1.x deprecates `httpx` under `TestClient` in favour of `httpx2`. It is
a warning today across our four `TestClient` references; the `httpx` floor
carries a comment naming that as the trigger for moving it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `quern update` now eagerly upgrades dependencies in the virtual environment.
  - Server startup and `quern doctor --fix` continue using non-eager dependency installation.

- **Bug Fixes**
  - Failed dependency repairs are retried on subsequent starts instead of being treated as complete.
  - Dependency repair status is no longer recorded when installation fails.

- **Documentation**
  - Clarified dependency floors, compatibility constraints, verification status, and update behavior across commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->