### PR TITLE
Report and optionally apply external tool upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ quern start -f             # run in the foreground (Ctrl-C to stop)
 quern status               # check status
 quern stop                 # stop
 quern update               # update to latest release and rebuild
+quern update --tools       # ...and upgrade external tools (pipx/brew) too
 quern grant-full-perms     # allow all quern MCP tools in Claude Code without prompting
 quern mcp-install          # register quern MCP server with AI coding tools
 quern uninstall            # remove Quern and its dependencies
@@ -187,6 +188,28 @@ the venv is actually stale or a previous install failed — never the eager tran
 upgrade `quern update` performs. `quern doctor --fix` is also non-eager, because it
 repairs a broken venv and pulling every transitive dependency forward mid-repair
 changes more than the fault being fixed.
+
+External tools are a separate matter. `pymobiledevice3` is installed twice on a
+typical machine — a library in the venv and a `pipx` binary — and they drift apart.
+Every update run reports external tools that have fallen behind, with the exact
+command to move each one; `--tools` runs those commands for you.
+
+Reporting is the default because a `pipx` or `brew` upgrade changes state for every
+other consumer on the machine, not just quern. Tools that arrived as a dependency of
+something else are reported but not offered — upgrading those directly can be undone
+by whatever pulled them in. Tools quern does not manage (node under `fnm`, `adb`
+inside Android Studio's SDK) are named along with who does manage them, decided by
+where the tool came from rather than by its name.
+
+`quern doctor` shows the same analysis for *every* install site, not just the stale
+ones, including which other brew formulae depend on each — the thing that turns a
+later upgrade into a decision rather than a command. Use it when two machines
+disagree about behaviour: a boolean "is pymobiledevice3 installed" reads identical on
+both while one runs a 9.15.1 binary and the other an 11.3.1 one.
+
+`quern doctor --fix` reconciles the venv and stops there. It does not upgrade external
+tools, and says so when it finds some it cannot help with, rather than printing
+"nothing to do" above a tool it just flagged as behind.
 
 Setting the channel only writes `~/.quern/config.json` — nothing changes until the next `quern update`. Git-clone installs follow the `release/stable` / `release/beta` pointer branches; tarball installs follow GitHub Releases, filtered on the prerelease flag. Full details, including the maintainer release procedure, are in [`docs/release-channels.md`](docs/release-channels.md).
 
@@ -275,9 +298,11 @@ quern start -f               # Foreground
 quern stop                   # Graceful shutdown
 quern restart                # Stop + start
 quern status                 # Show PID, URL, uptime, tool availability
-quern doctor                 # Read-only device-tool diagnostics
+quern doctor                 # Read-only diagnostics: device tools, venv, external tool versions
+quern doctor --fix           # ...and reconcile the venv with pyproject.toml (venv only)
 quern version                # Print the installed version
 quern update                 # Update to the latest release on your channel and rebuild
+quern update --tools         # Also upgrade external tools quern installed (pipx, brew)
 quern set-channel [name]     # Show or set the update channel (stable / beta)
 quern uninstall              # Remove Quern and dependencies installed by setup
 quern regenerate-key         # New API key

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -441,7 +441,7 @@ Use `ensure_devices` to boot multiple simulators at once, then run different tes
 
 ## Troubleshooting
 
-**Tools missing or misbehaving?** `quern doctor` reports device-tool availability
+**Tools missing or misbehaving?** `quern doctor` reports device-tool availability, venv sync, and the version and provenance of every external tool quern uses (including what would upgrade each one)
 (adb, simctl, idb, devicectl, pymobiledevice3) as read-only diagnostics, and
 `GET /tools` returns the same data over HTTP. Both are deliberately kept off the
 `/health` path so the liveness probe stays sub-millisecond — do not expect

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -441,7 +441,7 @@ Use `ensure_devices` to boot multiple simulators at once, then run different tes
 
 ## Troubleshooting
 
-**Tools missing or misbehaving?** `quern doctor` reports device-tool availability, venv sync, and the version and provenance of every external tool quern uses (including what would upgrade each one)
+**Tools missing or misbehaving?** `quern doctor` reports device-tool availability and venv sync, plus the version, provenance and upgrade command for the tools quern tracks as install sites (`pymobiledevice3`, `idb`, `mitmproxy`, `adb`, `libimobiledevice`, `node`). `simctl` and `devicectl` ship inside Xcode and are reported as available or not, without version detail
 (adb, simctl, idb, devicectl, pymobiledevice3) as read-only diagnostics, and
 `GET /tools` returns the same data over HTTP. Both are deliberately kept off the
 `/health` path so the liveness probe stays sub-millisecond — do not expect

--- a/server/__main__.py
+++ b/server/__main__.py
@@ -589,7 +589,7 @@ def main() -> None:
 
     if len(sys.argv) >= 2 and sys.argv[1] == "update":
         from server.lifecycle.updater import run_update
-        sys.exit(run_update())
+        sys.exit(run_update(apply_tools="--tools" in sys.argv[2:]))
 
     if len(sys.argv) >= 2 and sys.argv[1] == "set-channel":
         sys.exit(_cmd_set_channel(sys.argv[2:]))

--- a/server/device/tool_updates.py
+++ b/server/device/tool_updates.py
@@ -144,7 +144,7 @@ async def pypi_latest(package: str) -> str | None:
         return None
 
 
-async def brew_outdated() -> dict[str, str] | None:
+async def brew_outdated() -> dict[str, str] | None:  # noqa: D401
     """Formula name -> newest version for outdated formulae, or None if unasked.
 
     One call for every formula rather than one per tool: `brew outdated` is slow
@@ -165,11 +165,19 @@ async def brew_outdated() -> dict[str, str] | None:
         payload = json.loads(stdout)
     except (ValueError, TypeError):
         return None
+    # Casks as well as formulae: `adb` arrives from the android-platform-tools
+    # cask, and reading only `formulae` meant an outdated cask was reported as
+    # up to date. Their version key differs -- casks carry `current_version`
+    # under the same name but are listed separately -- so both arrays are read.
     latest: dict[str, str] = {}
-    for entry in payload.get("formulae") or []:
-        name, current = entry.get("name"), entry.get("current_version")
-        if name and current:
-            latest[name] = current
+    for key in ("formulae", "casks"):
+        for entry in payload.get(key) or []:
+            name = entry.get("name")
+            current = entry.get("current_version")
+            if isinstance(name, list):          # casks report a list of tokens
+                name = name[0] if name else None
+            if name and current:
+                latest[name] = current
     return latest
 
 
@@ -232,19 +240,35 @@ async def _plan_one(
     # Without it a failed lookup is indistinguishable from a successful one that
     # found nothing newer, and the tool reports a clean bill of health for a
     # question it never got to ask.
+    # The package manager's name for this tool, which is not always quern's:
+    # `idb` ships from `fb-idb`, `adb` from the `android-platform-tools` cask.
+    # Using `site.name` here queried the wrong PyPI project and emitted an
+    # upgrade command for a package that does not exist.
+    package = site.package
+    if package is None:
+        base.action = "unknown"
+        base.reason = (
+            "no package identity recorded, so the newest version cannot be "
+            "looked up safely"
+        )
+        return base
+
     checked = True
     if site.source == "pipx":
-        base.latest = await pypi(site.name)
+        base.latest = await pypi(package)
         checked = base.latest is not None
-        base.command = ["pipx", "upgrade", site.name]
+        base.command = ["pipx", "upgrade", package]
     elif site.source == "brew":
         if brew_latest is None:
             checked = False
         else:
             # brew outdated is exhaustive: absent from it means up to date, so
             # the current version is the newest one.
-            base.latest = brew_latest.get(site.name, site.version)
-        base.command = ["brew", "upgrade", site.name]
+            base.latest = brew_latest.get(package, site.version)
+        base.command = ["brew", "upgrade"]
+        if site.brew_cask:
+            base.command.append("--cask")
+        base.command.append(package)
     else:
         base.action = "unknown"
         base.reason = f"no upgrade route known for source {site.source!r}"

--- a/server/device/tool_updates.py
+++ b/server/device/tool_updates.py
@@ -1,0 +1,378 @@
+"""Which install sites are behind, and what it would take to move them.
+
+`tool_versions.collect_sites` answers what is installed. What to do about it
+turned out to be a different question with a different shape, so it lives here.
+
+Three findings set the design.
+
+**The floor is not the driver.** Every floor quern declares is a `>=`, and on
+the machine this was written on not one was load-bearing -- pymobiledevice3 sat
+three majors above its own floor. A floor answers "is this broken", which is
+almost never true, so a floor-driven updater sits silent while tools age
+indefinitely. Latest is the driver here; a floor only escalates an offer into a
+requirement.
+
+**How a tool updates is a property of where it came from, not of its name.**
+adb is left alone because it lives in Android Studio's SDK and node because fnm
+hands it out -- not because either is named in a list. The same tool installed
+from brew on another machine is offered normally. An earlier sketch hardcoded
+the exceptions by name and would have been wrong on the next machine.
+
+**Arriving as a dependency is a reason to leave a tool alone.** brew records
+`installed_as_dependency`, and upgrading such a formula directly can be undone
+by whatever pulled it in. Those are reported but not offered -- unless they are
+below a floor, where staying put is not an option either.
+
+Nothing here changes anything. `plan_updates` returns intent; running it is the
+caller's decision, and `quern update` asks first.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+
+from server.device.tool_versions import ToolSite, _run, upgrade_note
+
+# Sources quern knows how to move. Anything else is somebody else's to update,
+# and the reason matters more than the fact -- a reader who is told only "not
+# managed" goes looking for a quern setting that does not exist.
+UNMANAGED_REASONS = {
+    "fnm": "fnm manages node; quern does not change node versions",
+    "android-sdk": "Android Studio's SDK Manager owns this copy",
+    "xcode": "ships inside Xcode; update Xcode instead",
+    "system": "part of the OS image",
+    "unknown": "quern cannot tell how this was installed",
+}
+
+# Floors for CLI sites. Deliberately empty, and that is the finding rather than
+# an omission: no CLI version boundary has ever been tested against quern, and
+# inventing one here would repeat the mistake pyproject.toml was just annotated
+# to stop making. Add an entry only with a comment saying what breaks below it
+# and at which versions that was verified.
+#
+#   ("pymobiledevice3", "cli"): "10.0",   # example shape -- do not add unverified
+CLI_FLOORS: dict[tuple[str, str], str] = {}
+
+# Actions, most urgent first. Ordering is a property of the data, so callers
+# that sort by it cannot disagree about which is worse.
+ACTION_ORDER = ("upgrade_required", "upgrade_available", "current", "unmanaged", "unknown")
+
+
+@dataclass
+class ToolUpdate:
+    """What should happen to one install site, and why."""
+
+    name: str
+    role: str
+    action: str
+    """One of ACTION_ORDER."""
+
+    current: str | None = None
+    latest: str | None = None
+    source: str = "unknown"
+    """Where the site came from -- this is what decided the action."""
+
+    floor: str | None = None
+    command: list[str] = field(default_factory=list)
+    """Exactly what would be run. Empty when there is nothing to run."""
+
+    reason: str | None = None
+    """Why this action, in a form a reader can act on."""
+
+    note: str | None = None
+    """Provenance context -- what else an upgrade would touch."""
+
+    @property
+    def actionable(self) -> bool:
+        return self.action in ("upgrade_required", "upgrade_available")
+
+    def describe(self) -> str:
+        head = f"{self.name} ({self.role})"
+        if self.action == "current":
+            return f"{head} {self.current} — up to date"
+        if self.action in ("unmanaged", "unknown"):
+            return f"{head} {self.current or '?'} — {self.reason}"
+        return f"{head} {self.current} → {self.latest}"
+
+
+def version_tuple(version: str | None) -> tuple[int, ...] | None:
+    """A comparable form of a dotted version, or None if it is not one.
+
+    Pre-release suffixes are dropped rather than ordered. The comparison here
+    only ever decides "is there something newer", and getting 1.0.0-rc1 versus
+    1.0.0 subtly wrong is not worth a dependency on `packaging`, which quern
+    does not declare (it is present transitively, which is not the same thing).
+    """
+    if not version:
+        return None
+    head = version.split("-", 1)[0].split("+", 1)[0]
+    parts: list[int] = []
+    for chunk in head.split("."):
+        if not chunk.isdigit():
+            return None
+        parts.append(int(chunk))
+    return tuple(parts) or None
+
+
+def is_behind(current: str | None, target: str | None) -> bool:
+    """True only when both parse and current is genuinely lower.
+
+    Unparseable versions read as "not behind" on purpose: offering an upgrade
+    off a version nobody could compare is how a tool gets bumped for no reason.
+    """
+    a, b = version_tuple(current), version_tuple(target)
+    if a is None or b is None:
+        return False
+    return a < b
+
+
+async def pypi_latest(package: str) -> str | None:
+    """The newest release on PyPI, or None if it cannot be determined."""
+    try:
+        import httpx
+
+        async with httpx.AsyncClient(timeout=10) as client:
+            response = await client.get(f"https://pypi.org/pypi/{package}/json")
+            if response.status_code != 200:
+                return None
+            return (response.json().get("info") or {}).get("version")
+    except Exception:
+        # Offline is a normal state for this call. A version check must never
+        # be the reason `quern update` fails.
+        return None
+
+
+async def brew_outdated() -> dict[str, str] | None:
+    """Formula name -> newest version for outdated formulae, or None if unasked.
+
+    One call for every formula rather than one per tool: `brew outdated` is slow
+    enough that per-tool invocations dominated the whole update step. A formula
+    absent from the result is up to date, which is why this returns a mapping
+    rather than answering per name.
+
+    The None is load-bearing. An empty mapping means "brew checked and nothing
+    is outdated"; None means "brew could not be asked". Collapsing the two --
+    which the first version did -- reports every formula as current on a machine
+    with no brew installed, which is a false all-clear rather than a missing
+    answer.
+    """
+    code, stdout = await _run(["brew", "outdated", "--json=v2"], timeout=60)
+    if code != 0:
+        return None
+    try:
+        payload = json.loads(stdout)
+    except (ValueError, TypeError):
+        return None
+    latest: dict[str, str] = {}
+    for entry in payload.get("formulae") or []:
+        name, current = entry.get("name"), entry.get("current_version")
+        if name and current:
+            latest[name] = current
+    return latest
+
+
+LatestFn = Callable[[str], Awaitable[str | None]]
+
+
+async def plan_updates(
+    sites: list[ToolSite],
+    *,
+    pypi: LatestFn | None = None,
+    brew: Callable[[], Awaitable[dict[str, str] | None]] | None = None,
+) -> list[ToolUpdate]:
+    """What to do about every install site, without doing any of it.
+
+    `pypi` and `brew` are injected so this is testable with no network and no
+    homebrew -- the same shape `probe_container` uses for `describe_point`.
+    """
+    pypi = pypi or pypi_latest
+    brew = brew or brew_outdated
+
+    # Only pay for the brew query if something actually came from brew.
+    brew_latest: dict[str, str] | None = None
+    if any(site.source == "brew" and site.available for site in sites):
+        brew_latest = await brew()
+
+    updates: list[ToolUpdate] = []
+    for site in sites:
+        updates.append(await _plan_one(site, pypi, brew_latest))
+    return updates
+
+
+async def _plan_one(
+    site: ToolSite, pypi: LatestFn, brew_latest: dict[str, str] | None,
+) -> ToolUpdate:
+    floor = CLI_FLOORS.get((site.name, site.role))
+    base = ToolUpdate(
+        name=site.name, role=site.role, action="unknown", source=site.source,
+        current=site.version, floor=floor, note=upgrade_note(site),
+    )
+
+    if not site.available:
+        base.action = "unknown"
+        base.reason = "not installed; run `quern setup`"
+        return base
+
+    if site.source == "venv":
+        # Already covered: `quern update` reinstalls the venv eagerly, so
+        # offering a second route to the same packages would be two mechanisms
+        # racing over one directory.
+        base.action = "current"
+        base.reason = "installed in quern's venv; `quern update` keeps it current"
+        return base
+
+    if site.source in UNMANAGED_REASONS:
+        base.action = "unmanaged"
+        base.reason = UNMANAGED_REASONS[site.source]
+        return base
+
+    # `checked` records whether the newest version could actually be looked up.
+    # Without it a failed lookup is indistinguishable from a successful one that
+    # found nothing newer, and the tool reports a clean bill of health for a
+    # question it never got to ask.
+    checked = True
+    if site.source == "pipx":
+        base.latest = await pypi(site.name)
+        checked = base.latest is not None
+        base.command = ["pipx", "upgrade", site.name]
+    elif site.source == "brew":
+        if brew_latest is None:
+            checked = False
+        else:
+            # brew outdated is exhaustive: absent from it means up to date, so
+            # the current version is the newest one.
+            base.latest = brew_latest.get(site.name, site.version)
+        base.command = ["brew", "upgrade", site.name]
+    else:
+        base.action = "unknown"
+        base.reason = f"no upgrade route known for source {site.source!r}"
+        return base
+
+    if not checked:
+        base.action = "unknown"
+        base.reason = (
+            "could not check for a newer version; leaving it alone rather than "
+            "reporting it current"
+        )
+        base.command = []
+        return base
+
+    below_floor = floor is not None and is_behind(site.version, floor)
+    behind_latest = is_behind(site.version, base.latest)
+
+    if below_floor:
+        base.action = "upgrade_required"
+        base.reason = f"below the {floor} quern requires"
+        # A floor overrides the dependency exemption below: a tool that is too
+        # old to work is not made acceptable by something else having installed
+        # it. The note still says what the upgrade would touch.
+        return base
+
+    if not behind_latest:
+        base.action = "current"
+        base.reason = f"up to date at {base.latest}"
+        base.command = []
+        return base
+
+    if site.requested is False:
+        # Arrived as a dependency and is above any floor quern cares about.
+        # Upgrading it directly can be reverted by whatever pulled it in, so it
+        # is reported rather than offered.
+        base.action = "current"
+        base.reason = (
+            f"{base.latest} is available, but this arrived as a dependency "
+            "and works; leaving it to whatever installed it"
+        )
+        base.command = []
+        return base
+
+    base.action = "upgrade_available"
+    base.reason = f"newer release available ({base.latest})"
+    return base
+
+
+def actionable(updates: list[ToolUpdate]) -> list[ToolUpdate]:
+    """Just the ones with something to run, most urgent first."""
+    return sorted(
+        (u for u in updates if u.actionable),
+        key=lambda u: ACTION_ORDER.index(u.action),
+    )
+
+
+def format_offer(updates: list[ToolUpdate]) -> str:
+    """The block `quern update` prints. Empty string when there is nothing.
+
+    Every line carries the command, because the alternative is a reader who
+    knows a tool is stale and has to go and find out how it was installed --
+    which is the work this module exists to have already done.
+    """
+    todo = actionable(updates)
+    if not todo:
+        return ""
+
+    lines = ["", "External tools with updates available:"]
+    for update in todo:
+        marker = "!" if update.action == "upgrade_required" else "-"
+        lines.append(f"  {marker} {update.describe()}")
+        if update.action == "upgrade_required":
+            lines.append(f"      required: {update.reason}")
+        if update.note:
+            lines.append(f"      note: {update.note}")
+        lines.append(f"      {' '.join(update.command)}")
+    return "\n".join(lines)
+
+
+# How each action reads at a glance. `quern update` only ever prints the first
+# two; doctor prints all of them, which is the difference between "what should I
+# do" and "what is actually here".
+ACTION_MARKERS = {
+    "upgrade_required": "!",
+    "upgrade_available": "\u2191",
+    "current": "\u2713",
+    "unmanaged": "\u2013",
+    "unknown": "?",
+}
+
+
+def format_report(updates: list[ToolUpdate]) -> str:
+    """The full picture, for `quern doctor`.
+
+    Deliberately wider than `format_offer`. The offer answers "what should I
+    run" and so shows only what is actionable; a diagnostic that hid everything
+    working would be useless for the question doctor actually gets asked, which
+    is "why is this machine behaving differently from that one".
+
+    In particular the brew dependents are shown for tools that need no action at
+    all. `libimobiledevice` being current is not the interesting part -- that
+    `ideviceinstaller` and `ios-webkit-debug-proxy` also depend on it is, because
+    that is what turns a later upgrade into a decision rather than a command.
+    """
+    if not updates:
+        return "External tools:\n  (none detected)"
+
+    def _label(update: ToolUpdate) -> str:
+        return f"{update.name} ({update.role})"
+
+    def _version(update: ToolUpdate) -> str:
+        if update.actionable and update.latest:
+            return f"{update.current} \u2192 {update.latest}"
+        return update.current or "not found"
+
+    label_width = max(len(_label(u)) for u in updates)
+    version_width = max(len(_version(u)) for u in updates)
+
+    lines = ["External tools:"]
+    for update in sorted(updates, key=lambda u: (ACTION_ORDER.index(u.action), u.name)):
+        marker = ACTION_MARKERS.get(update.action, "?")
+        label = _label(update).ljust(label_width)
+        version = _version(update).ljust(version_width)
+        lines.append(f"  {marker} {label}  {version}  ({update.source})")
+        if update.reason:
+            lines.append(f"      {update.reason}")
+        if update.note:
+            lines.append(f"      {update.note}")
+        if update.command:
+            lines.append(f"      run: {' '.join(update.command)}")
+    return "\n".join(lines)

--- a/server/device/tool_versions.py
+++ b/server/device/tool_versions.py
@@ -56,6 +56,19 @@ class ToolSite:
     source: str = "unknown"
     """Where it came from: brew, pipx, venv, fnm, android-sdk, xcode, system."""
 
+    package: str | None = None
+    """What the package manager calls this, which is not always what quern does.
+
+    `idb` ships from the `fb-idb` distribution and `adb` from the
+    `android-platform-tools` cask, so using the tool's own name to look up a
+    version or build an upgrade command reaches the wrong project. None means no
+    identity is recorded, which planners must treat as unknown rather than
+    guessing from `name`.
+    """
+
+    brew_cask: bool = False
+    """Installed by `brew install --cask`, so upgrading needs `--cask`."""
+
     detail: str | None = None
     """Anything a reader needs that the fields above cannot carry."""
 
@@ -238,7 +251,7 @@ async def collect_sites() -> list[ToolSite]:
     # --- pymobiledevice3, as a library ------------------------------------
     library = package_version("pymobiledevice3")
     sites.append(ToolSite(
-        name="pymobiledevice3", role="library",
+        name="pymobiledevice3", role="library", package="pymobiledevice3",
         available=library is not None, version=library,
         path=str(Path(sys.executable).parent.parent), source="venv",
         detail="imported by webinspector.py for web content on simulators",
@@ -250,7 +263,7 @@ async def collect_sites() -> list[ToolSite]:
     binary = find_pymobiledevice3_binary()
     binary_path = str(binary) if binary else None
     sites.append(ToolSite(
-        name="pymobiledevice3", role="cli",
+        name="pymobiledevice3", role="cli", package="pymobiledevice3",
         available=binary_path is not None,
         version=await binary_version(binary_path, ["version"]) if binary_path else None,
         path=binary_path, source=classify_source(binary_path),
@@ -261,7 +274,7 @@ async def collect_sites() -> list[ToolSite]:
     # --- idb --------------------------------------------------------------
     idb_path = which("idb")
     sites.append(ToolSite(
-        name="idb", role="cli",
+        name="idb", role="cli", package="fb-idb",
         available=idb_path is not None,
         # From metadata: `idb --version` prints usage rather than a version.
         version=package_version("fb-idb"),
@@ -272,7 +285,7 @@ async def collect_sites() -> list[ToolSite]:
     # --- mitmproxy --------------------------------------------------------
     mitm_path = which("mitmdump")
     sites.append(ToolSite(
-        name="mitmproxy", role="cli",
+        name="mitmproxy", role="cli", package="mitmproxy",
         available=mitm_path is not None,
         version=package_version("mitmproxy"),
         path=mitm_path, source=classify_source(mitm_path),
@@ -282,7 +295,9 @@ async def collect_sites() -> list[ToolSite]:
     # --- adb --------------------------------------------------------------
     adb_path = shutil.which("adb") or _android_sdk_adb()
     sites.append(ToolSite(
-        name="adb", role="cli",
+        # There is no `adb` formula: brew ships the binary in the
+        # android-platform-tools *cask*.
+        name="adb", role="cli", package="android-platform-tools", brew_cask=True,
         available=adb_path is not None,
         version=await binary_version(adb_path, ["version"]) if adb_path else None,
         path=adb_path, source=classify_source(adb_path),
@@ -292,7 +307,7 @@ async def collect_sites() -> list[ToolSite]:
     # --- libimobiledevice -------------------------------------------------
     imd_path = shutil.which("idevice_id")
     sites.append(ToolSite(
-        name="libimobiledevice", role="cli",
+        name="libimobiledevice", role="cli", package="libimobiledevice",
         available=imd_path is not None,
         version=await binary_version(imd_path, ["--version"]) if imd_path else None,
         path=imd_path, source=classify_source(imd_path),
@@ -302,7 +317,7 @@ async def collect_sites() -> list[ToolSite]:
     # --- node -------------------------------------------------------------
     node_path = shutil.which("node")
     sites.append(ToolSite(
-        name="node", role="cli",
+        name="node", role="cli", package="node",
         available=node_path is not None,
         version=await binary_version(node_path, ["--version"]) if node_path else None,
         path=node_path, source=classify_source(node_path),
@@ -331,7 +346,8 @@ async def _attach_brew_provenance(sites: list[ToolSite]) -> None:
     if not brewed:
         return
     results = await asyncio.gather(
-        *(brew_provenance(site.name) for site in brewed), return_exceptions=True,
+        *(brew_provenance(site.package or site.name) for site in brewed),
+        return_exceptions=True,
     )
     for site, result in zip(brewed, results, strict=True):
         if isinstance(result, BaseException):

--- a/server/device/tool_versions.py
+++ b/server/device/tool_versions.py
@@ -291,16 +291,13 @@ async def collect_sites() -> list[ToolSite]:
 
     # --- libimobiledevice -------------------------------------------------
     imd_path = shutil.which("idevice_id")
-    site = ToolSite(
+    sites.append(ToolSite(
         name="libimobiledevice", role="cli",
         available=imd_path is not None,
         version=await binary_version(imd_path, ["--version"]) if imd_path else None,
         path=imd_path, source=classify_source(imd_path),
         volatile_path=is_volatile(imd_path),
-    )
-    if site.source == "brew":
-        site.requested, site.required_by = await brew_provenance("libimobiledevice")
-    sites.append(site)
+    ))
 
     # --- node -------------------------------------------------------------
     node_path = shutil.which("node")
@@ -313,7 +310,36 @@ async def collect_sites() -> list[ToolSite]:
         detail="runs the MCP server",
     ))
 
+    await _attach_brew_provenance(sites)
     return sites
+
+
+async def _attach_brew_provenance(sites: list[ToolSite]) -> None:
+    """Fill in `requested` and `required_by` for every site that came from brew.
+
+    This used to be done for `libimobiledevice` alone, because that was the only
+    brew install on the machine it was written on. That is a property of one
+    machine, not of the tool: mitmproxy, adb and pymobiledevice3 are all
+    brew-installable, and on a machine that installed them that way the
+    provenance -- which is the thing that decides whether an upgrade is safe to
+    offer -- was simply missing.
+
+    Concurrent because each formula costs a `brew info` plus a `brew uses`, and
+    serially that is the slowest thing in the inventory.
+    """
+    brewed = [s for s in sites if s.source == "brew" and s.available]
+    if not brewed:
+        return
+    results = await asyncio.gather(
+        *(brew_provenance(site.name) for site in brewed), return_exceptions=True,
+    )
+    for site, result in zip(brewed, results, strict=True):
+        if isinstance(result, BaseException):
+            # Best effort, as brew_provenance already documents: an unreadable
+            # formula leaves both fields at their "not recorded" defaults rather
+            # than failing the whole inventory.
+            continue
+        site.requested, site.required_by = result
 
 
 def _android_sdk_adb() -> str | None:

--- a/server/lifecycle/updater.py
+++ b/server/lifecycle/updater.py
@@ -366,29 +366,45 @@ def _update_via_tarball(project_root: Path) -> int:
 # ---------------------------------------------------------------------------
 
 
-def _rebuild_and_restart(project_root: Path) -> bool:
+def _rebuild_and_restart(project_root: Path) -> list[str]:
     """Reinstall deps, rebuild MCP, run setup, restart server if running.
 
-    Returns False if dependency installation failed, so the caller can report
-    the update as unsuccessful rather than announcing success onto a stale venv.
+    Returns the steps that failed, empty when everything worked.
+
+    Every step runs even after an earlier one fails -- an update that cannot
+    build the MCP wrapper should still reconcile the venv -- but each failure is
+    recorded, because only `deps` used to be. A failed MCP build was a warning,
+    `run_setup`'s exit code was discarded outright, and the restart's was never
+    read, so `quern update` could exit 0 having left the MCP tools stale or the
+    server down.
+
+    Named steps rather than one bool so the caller can say which part failed:
+    reporting "dependencies could not be installed" after a failed restart sends
+    the reader to the wrong place.
     """
+    failures: list[str] = []
+
     # Reinstall Python deps. Delegated so there is one implementation and one
     # failure semantic — this used to be a separate pip call whose failure was
     # only a warning, so an update could report success onto a stale venv.
     from server.__main__ import _ensure_python_deps
 
-    deps_ok = _ensure_python_deps(quiet=False, force=True, eager=True)
+    if not _ensure_python_deps(quiet=False, force=True, eager=True):
+        failures.append("dependencies")
 
     # Rebuild MCP server
     from server.__main__ import _ensure_mcp_built
 
     if not _ensure_mcp_built(quiet=False):
         print("Warning: MCP server build failed — MCP tools may be stale")
+        failures.append("MCP build")
 
     # Run setup to check for new external dependencies
     from server.lifecycle.setup import run_setup
 
-    run_setup()
+    if run_setup() != 0:
+        print("Warning: setup reported errors — see above")
+        failures.append("setup")
 
     # Restart the server if it was running
     from server.lifecycle.state import is_server_healthy, read_state
@@ -397,15 +413,26 @@ def _rebuild_and_restart(project_root: Path) -> bool:
     if state and is_server_healthy(state.get("server_port", 9100)):
         print("Restarting server to pick up changes...")
         venv_python = project_root / ".venv" / "bin" / "python"
-        subprocess.run(
-            [str(venv_python), "-m", "server", "restart"],
-            cwd=str(project_root),
-            timeout=30,
-        )
+        try:
+            restart = subprocess.run(
+                [str(venv_python), "-m", "server", "restart"],
+                cwd=str(project_root),
+                timeout=30,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            # A 30s timeout here left the exception uncaught, so an update that
+            # hung on restart crashed rather than reporting.
+            print(f"Warning: restart failed: {exc}")
+            failures.append("restart")
+        else:
+            if restart.returncode != 0:
+                print(f"Warning: restart exited {restart.returncode} — "
+                      "the server may be down; check `quern status`")
+                failures.append("restart")
     else:
         print("Server is not running — start it with: quern start")
 
-    return deps_ok
+    return failures
 
 
 def _report_tool_updates(apply: bool = False) -> bool:
@@ -494,10 +521,13 @@ def run_update(apply_tools: bool = False) -> int:
         # Nothing to rebuild, but external tools age independently of quern.
         return 0 if _report_tool_updates(apply_tools) else 1
 
-    if not _rebuild_and_restart(project_root):
-        # The source is updated but the venv is not. Saying "success" here is
-        # the exact failure this reporting exists to prevent.
-        print("Update incomplete: dependencies could not be installed.")
+    failures = _rebuild_and_restart(project_root)
+    if failures:
+        # The source moved but part of the rebuild did not. Saying "success"
+        # here is the exact failure this reporting exists to prevent, and
+        # naming the step matters: "dependencies could not be installed" after
+        # a failed restart sends the reader to the wrong place.
+        print(f"Update incomplete: {', '.join(failures)} failed.")
         return 1
 
     return 0 if _report_tool_updates(apply_tools) else 1

--- a/server/lifecycle/updater.py
+++ b/server/lifecycle/updater.py
@@ -408,7 +408,7 @@ def _rebuild_and_restart(project_root: Path) -> bool:
     return deps_ok
 
 
-def _report_tool_updates(apply: bool = False) -> None:
+def _report_tool_updates(apply: bool = False) -> bool:
     """Show external tools that have moved on, and optionally move them.
 
     Runs on every `quern update`, including the "already up to date" path.
@@ -420,6 +420,11 @@ def _report_tool_updates(apply: bool = False) -> None:
     project -- a pipx or brew upgrade affects every other consumer on the
     machine, and doing that unasked as a side effect of updating quern is not
     the caller's decision to have made for them.
+
+    Returns False only when `apply` was asked for and an upgrade command failed.
+    Reporting alone always returns True: a stale tool is information, not a
+    failed update. But `--tools` is an instruction, and printing "failed" while
+    the process still exits 0 tells a script the opposite of what happened.
     """
     import asyncio
 
@@ -434,27 +439,34 @@ def _report_tool_updates(apply: bool = False) -> None:
     except Exception as exc:
         # Never fail an update over a version check.
         print(f"Note: could not check external tool versions ({exc}).")
-        return
+        return True
 
     offer = format_offer(updates)
     if not offer:
-        return
+        return True
     print(offer)
 
     todo = actionable(updates)
     if not apply:
         print("\n  Run `quern update --tools` to apply these.")
-        return
+        return True
 
+    failures: list[str] = []
     for update in todo:
         print(f"\nUpgrading {update.name}...")
         try:
             result = subprocess.run(update.command, timeout=600)
-        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        except (OSError, subprocess.SubprocessError) as exc:
             print(f"  failed: {exc}")
+            failures.append(update.name)
             continue
         if result.returncode != 0:
             print(f"  failed: {' '.join(update.command)} exited {result.returncode}")
+            failures.append(update.name)
+
+    if failures:
+        print(f"\n{len(failures)} tool upgrade(s) failed: {', '.join(failures)}")
+    return not failures
 
 
 def run_update(apply_tools: bool = False) -> int:
@@ -480,8 +492,7 @@ def run_update(apply_tools: bool = False) -> int:
         return 1  # Error
     if rc == 2:
         # Nothing to rebuild, but external tools age independently of quern.
-        _report_tool_updates(apply_tools)
-        return 0
+        return 0 if _report_tool_updates(apply_tools) else 1
 
     if not _rebuild_and_restart(project_root):
         # The source is updated but the venv is not. Saying "success" here is
@@ -489,5 +500,4 @@ def run_update(apply_tools: bool = False) -> int:
         print("Update incomplete: dependencies could not be installed.")
         return 1
 
-    _report_tool_updates(apply_tools)
-    return 0
+    return 0 if _report_tool_updates(apply_tools) else 1

--- a/server/lifecycle/updater.py
+++ b/server/lifecycle/updater.py
@@ -395,8 +395,16 @@ def _rebuild_and_restart(project_root: Path) -> list[str]:
     # Rebuild MCP server
     from server.__main__ import _ensure_mcp_built
 
-    if not _ensure_mcp_built(quiet=False):
-        print("Warning: MCP server build failed — MCP tools may be stale")
+    try:
+        if not _ensure_mcp_built(quiet=False):
+            print("Warning: MCP server build failed — MCP tools may be stale")
+            failures.append("MCP build")
+    except (OSError, subprocess.SubprocessError) as exc:
+        # _ensure_mcp_built shells out to npm twice with timeouts and catches
+        # neither, so a machine without npm -- or a slow install -- raised
+        # straight through this function and crashed `quern update` before it
+        # could report anything, or run setup and restart.
+        print(f"Warning: MCP server build failed: {exc}")
         failures.append("MCP build")
 
     # Run setup to check for new external dependencies
@@ -522,6 +530,13 @@ def run_update(apply_tools: bool = False) -> int:
         return 0 if _report_tool_updates(apply_tools) else 1
 
     failures = _rebuild_and_restart(project_root)
+
+    # External tools live outside the project and do not depend on the rebuild
+    # having worked, so they are reported either way. Returning early here meant
+    # a failed rebuild also silently dropped `--tools`, which the caller asked
+    # for explicitly.
+    tools_ok = _report_tool_updates(apply_tools)
+
     if failures:
         # The source moved but part of the rebuild did not. Saying "success"
         # here is the exact failure this reporting exists to prevent, and
@@ -530,4 +545,4 @@ def run_update(apply_tools: bool = False) -> int:
         print(f"Update incomplete: {', '.join(failures)} failed.")
         return 1
 
-    return 0 if _report_tool_updates(apply_tools) else 1
+    return 0 if tools_ok else 1

--- a/server/lifecycle/updater.py
+++ b/server/lifecycle/updater.py
@@ -408,8 +408,61 @@ def _rebuild_and_restart(project_root: Path) -> bool:
     return deps_ok
 
 
-def run_update() -> int:
+def _report_tool_updates(apply: bool = False) -> None:
+    """Show external tools that have moved on, and optionally move them.
+
+    Runs on every `quern update`, including the "already up to date" path.
+    External tools go stale on their own schedule, so gating this on quern
+    having an update means learning about a two-major-old binary only when
+    something unrelated happens to ship.
+
+    Reporting is the default because these commands touch state outside the
+    project -- a pipx or brew upgrade affects every other consumer on the
+    machine, and doing that unasked as a side effect of updating quern is not
+    the caller's decision to have made for them.
+    """
+    import asyncio
+
+    from server.device.tool_updates import actionable, format_offer, plan_updates
+    from server.device.tool_versions import collect_sites
+
+    try:
+        async def gather():
+            return await plan_updates(await collect_sites())
+
+        updates = asyncio.run(gather())
+    except Exception as exc:
+        # Never fail an update over a version check.
+        print(f"Note: could not check external tool versions ({exc}).")
+        return
+
+    offer = format_offer(updates)
+    if not offer:
+        return
+    print(offer)
+
+    todo = actionable(updates)
+    if not apply:
+        print("\n  Run `quern update --tools` to apply these.")
+        return
+
+    for update in todo:
+        print(f"\nUpgrading {update.name}...")
+        try:
+            result = subprocess.run(update.command, timeout=600)
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            print(f"  failed: {exc}")
+            continue
+        if result.returncode != 0:
+            print(f"  failed: {' '.join(update.command)} exited {result.returncode}")
+
+
+def run_update(apply_tools: bool = False) -> int:
     """Pull latest changes and rebuild.
+
+    Args:
+        apply_tools: also run the external-tool upgrades, instead of only
+            reporting them.
 
     Returns 0 on success, 1 on failure.
     """
@@ -426,11 +479,15 @@ def run_update() -> int:
     if rc == 1:
         return 1  # Error
     if rc == 2:
-        return 0  # Already up to date — nothing to rebuild
+        # Nothing to rebuild, but external tools age independently of quern.
+        _report_tool_updates(apply_tools)
+        return 0
 
     if not _rebuild_and_restart(project_root):
         # The source is updated but the venv is not. Saying "success" here is
         # the exact failure this reporting exists to prevent.
         print("Update incomplete: dependencies could not be installed.")
         return 1
+
+    _report_tool_updates(apply_tools)
     return 0

--- a/server/main.py
+++ b/server/main.py
@@ -1048,7 +1048,14 @@ def _cmd_doctor(args: argparse.Namespace) -> None:
         # Still report dependencies — an installation without a device
         # controller is exactly one where a missing dependency is plausible,
         # so this is the worst possible place to skip the check.
+        #
+        # The same argument covers the external tools: a missing device
+        # controller often *is* a missing or stale external tool, so this branch
+        # is where their versions matter most. Skipping it here also made the
+        # README's description of `quern doctor` false on exactly the machines
+        # someone runs it on.
         _report_python_deps(getattr(args, "fix", False))
+        _report_external_tools(getattr(args, "fix", False))
         sys.exit(0)
 
     print("Device tools:")

--- a/server/main.py
+++ b/server/main.py
@@ -1056,7 +1056,59 @@ def _cmd_doctor(args: argparse.Namespace) -> None:
         print(f"  {'✓' if ok else '✗'} {name}")
 
     _report_python_deps(getattr(args, "fix", False))
+    _report_external_tools(getattr(args, "fix", False))
     sys.exit(0)
+
+
+def _report_external_tools(fix: bool = False) -> None:
+    """Every install site quern uses, what manages it, and what it is behind.
+
+    Read-only, like the rest of doctor: this reports the upgrade commands and
+    never runs them -- including under `--fix`.
+
+    That is a deliberate boundary rather than an omission. `--fix` is scoped to
+    "exactly what server startup runs" (see `_report_python_deps`), which is the
+    venv and nothing else; a pipx or brew upgrade changes state for every other
+    consumer on the machine, which is further out of scope than `quern setup` --
+    already ruled out for `--fix` on the same grounds. Having two commands that
+    both upgrade external tools would also be two things to keep in agreement.
+
+    What `--fix` must not do is stay silent about it. Printing "--fix: nothing to
+    do" for the venv directly above a tool marked as behind reads as "and nothing
+    to do about that either", so when `--fix` is asked for and cannot help, it
+    says so and names the command that can.
+
+    The full list rather than only the stale ones, because the question doctor
+    gets asked is "why does this machine behave differently from that one", and
+    two machines comparing only their problems will agree they have none while
+    running three-major-apart copies of the same tool.
+    """
+    import asyncio
+
+    from server.device.tool_updates import format_report, plan_updates
+    from server.device.tool_versions import collect_sites
+
+    print()
+    try:
+        async def gather():
+            return await plan_updates(await collect_sites())
+
+        updates = asyncio.run(gather())
+    except Exception as exc:
+        # Diagnostics must not be the thing that breaks. A machine where this
+        # raises is exactly one someone is running doctor on.
+        print(f"External tools: could not be checked ({exc})")
+        return
+
+    print(format_report(updates))
+
+    from server.device.tool_updates import actionable
+
+    if fix and actionable(updates):
+        print()
+        print("  --fix does not upgrade external tools: these commands change")
+        print("  state for every consumer on this machine, not just quern.")
+        print("  Run them yourself, or: quern update --tools")
 
 
 def _report_python_deps(fix: bool) -> None:

--- a/tests/test_python_deps_heal.py
+++ b/tests/test_python_deps_heal.py
@@ -173,9 +173,14 @@ def test_updater_propagates_a_failed_install(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(updater, "_is_git_install", lambda _p: True)
     monkeypatch.setattr(updater, "_update_via_git", lambda _p: 0)
     monkeypatch.setattr(updater, "_rebuild_and_restart", lambda _p: ["dependencies"])
+    monkeypatch.setattr(updater, "_report_tool_updates", lambda apply=False: True)
 
     assert updater.run_update() == 1
-    assert "Update incomplete" in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert "Update incomplete" in out
+    # Name the step, not just the failure: the message is the only thing
+    # telling a reader which part of the rebuild to go and look at.
+    assert "dependencies failed" in out
 
 
 def test_updater_reports_success_when_deps_install(tmp_path, monkeypatch):
@@ -185,6 +190,10 @@ def test_updater_reports_success_when_deps_install(tmp_path, monkeypatch):
     monkeypatch.setattr(updater, "_is_git_install", lambda _p: True)
     monkeypatch.setattr(updater, "_update_via_git", lambda _p: 0)
     monkeypatch.setattr(updater, "_rebuild_and_restart", lambda _p: [])
+    # Without this the success path runs the real _report_tool_updates, which
+    # calls collect_sites() and plan_updates() with no injected lookups -- so
+    # the suite would query PyPI and shell out to brew for real.
+    monkeypatch.setattr(updater, "_report_tool_updates", lambda apply=False: True)
 
     assert updater.run_update() == 0
 

--- a/tests/test_python_deps_heal.py
+++ b/tests/test_python_deps_heal.py
@@ -172,7 +172,7 @@ def test_updater_propagates_a_failed_install(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(updater, "_find_project_root", lambda: tmp_path)
     monkeypatch.setattr(updater, "_is_git_install", lambda _p: True)
     monkeypatch.setattr(updater, "_update_via_git", lambda _p: 0)
-    monkeypatch.setattr(updater, "_rebuild_and_restart", lambda _p: False)
+    monkeypatch.setattr(updater, "_rebuild_and_restart", lambda _p: ["dependencies"])
 
     assert updater.run_update() == 1
     assert "Update incomplete" in capsys.readouterr().out
@@ -184,7 +184,7 @@ def test_updater_reports_success_when_deps_install(tmp_path, monkeypatch):
     monkeypatch.setattr(updater, "_find_project_root", lambda: tmp_path)
     monkeypatch.setattr(updater, "_is_git_install", lambda _p: True)
     monkeypatch.setattr(updater, "_update_via_git", lambda _p: 0)
-    monkeypatch.setattr(updater, "_rebuild_and_restart", lambda _p: True)
+    monkeypatch.setattr(updater, "_rebuild_and_restart", lambda _p: [])
 
     assert updater.run_update() == 0
 

--- a/tests/test_tool_updates.py
+++ b/tests/test_tool_updates.py
@@ -1,0 +1,786 @@
+"""Tests for deciding which install sites are behind (#67, stage 2).
+
+Stage 1 built the inventory and stopped there: it could say pymobiledevice3 was
+a 11.3.1 library and a 9.15.1 binary at once, and had nothing to say about what
+to do with that. This is the deciding half.
+
+The behaviours worth pinning are the ones where a wrong answer is *quiet*:
+
+- a lookup that fails must not read as "up to date" -- on a machine with no brew
+  every formula would otherwise get a clean bill of health
+- a tool that arrived as a dependency must not be offered, because upgrading it
+  directly can be undone by whatever pulled it in
+- ...unless it is below a floor, where leaving it is not an option either
+- exclusion is decided by `source`, so the same tool from brew on another
+  machine is still offered
+
+No test here reaches the network or runs brew: both lookups are injected, the
+same way `probe_container` takes `describe_point`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from server.device.tool_updates import (
+    CLI_FLOORS,
+    format_offer,
+    is_behind,
+    plan_updates,
+    version_tuple,
+)
+from server.device.tool_versions import ToolSite
+
+
+def _site(name="pymobiledevice3", role="cli", source="pipx", version="9.15.1", **kw):
+    return ToolSite(
+        name=name, role=role, source=source, version=version,
+        available=kw.pop("available", True), path=kw.pop("path", f"/opt/{source}/bin/{name}"),
+        **kw,
+    )
+
+
+async def _plan(sites, *, pypi=None, brew=None):
+    async def no_pypi(_name):
+        return None
+
+    async def no_brew():
+        return {}
+
+    return await plan_updates(
+        sites,
+        pypi=pypi or no_pypi,
+        brew=brew or no_brew,
+    )
+
+
+def _by_name(updates, name, role="cli"):
+    return next(u for u in updates if u.name == name and u.role == role)
+
+
+# --------------------------------------------------------------------------
+# Version comparison
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("a", "b", "expected"), [
+    ("9.15.1", "11.3.1", True),      # the real gap this was built for
+    ("11.3.1", "9.15.1", False),
+    ("1.4.0", "1.4.0", False),
+    ("1.0.41", "1.0.41", False),
+    ("22.22.2", "22.22.10", True),   # not string ordering
+    ("2", "2.0.1", True),
+])
+def test_is_behind(a, b, expected):
+    assert is_behind(a, b) is expected
+
+
+@pytest.mark.parametrize("bad", [None, "", "unknown", "v-next", "1.2.x"])
+def test_unparseable_versions_do_not_compare(bad):
+    """Offering an upgrade off a version nobody could parse bumps a tool for no
+    reason, so an unreadable version reads as 'not behind' in both directions."""
+    assert version_tuple(bad) is None
+    assert is_behind(bad, "9.9.9") is False
+    assert is_behind("9.9.9", bad) is False
+
+
+# --------------------------------------------------------------------------
+# A failed lookup must never read as up to date
+# --------------------------------------------------------------------------
+
+
+async def test_unreachable_pypi_is_not_a_clean_bill_of_health():
+    updates = await _plan([_site()])
+    update = _by_name(updates, "pymobiledevice3")
+    assert update.action == "unknown"
+    assert not update.actionable
+    assert "could not check" in update.reason
+    assert update.command == []
+
+
+async def test_absent_brew_is_not_a_clean_bill_of_health():
+    """The bug this guards: an empty mapping means 'brew checked, nothing
+    outdated'; None means 'brew could not be asked'. Collapsing them reports
+    every formula current on a machine with no brew installed."""
+    async def no_brew():
+        return None
+
+    updates = await _plan([_site(name="libimobiledevice", source="brew", version="1.4.0")],
+                          brew=no_brew)
+    update = _by_name(updates, "libimobiledevice")
+    assert update.action == "unknown"
+    assert "could not check" in update.reason
+
+
+async def test_brew_answering_with_nothing_outdated_does_mean_current():
+    """`brew outdated` is exhaustive, so absence from it is a real answer."""
+    async def empty_brew():
+        return {}
+
+    updates = await _plan([_site(name="libimobiledevice", source="brew", version="1.4.0")],
+                          brew=empty_brew)
+    update = _by_name(updates, "libimobiledevice")
+    assert update.action == "current"
+    assert update.latest == "1.4.0"
+
+
+# --------------------------------------------------------------------------
+# The offer itself
+# --------------------------------------------------------------------------
+
+
+async def test_a_behind_pipx_tool_is_offered_with_its_command():
+    async def pypi(_name):
+        return "11.3.1"
+
+    updates = await _plan([_site()], pypi=pypi)
+    update = _by_name(updates, "pymobiledevice3")
+    assert update.action == "upgrade_available"
+    assert update.current == "9.15.1"
+    assert update.latest == "11.3.1"
+    assert update.command == ["pipx", "upgrade", "pymobiledevice3"]
+
+
+async def test_a_current_tool_is_not_offered():
+    async def pypi(_name):
+        return "9.15.1"
+
+    updates = await _plan([_site()], pypi=pypi)
+    assert _by_name(updates, "pymobiledevice3").action == "current"
+    assert format_offer(updates) == ""
+
+
+# --------------------------------------------------------------------------
+# Exclusion is decided by source, not by name
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("source", "fragment"), [
+    ("fnm", "fnm manages node"),
+    ("android-sdk", "Android Studio"),
+    ("xcode", "update Xcode"),
+    ("system", "OS image"),
+])
+async def test_tools_quern_does_not_manage_are_explained_not_offered(source, fragment):
+    updates = await _plan([_site(name="node", source=source, version="22.0.0")])
+    update = _by_name(updates, "node")
+    assert update.action == "unmanaged"
+    assert not update.actionable
+    assert fragment in update.reason
+
+
+async def test_the_same_tool_from_brew_is_offered():
+    """The reason adb and node are left alone is where they came from, not what
+    they are called. An earlier sketch keyed the exclusions off the name and
+    would have refused to update a brew-installed copy on another machine."""
+    async def brew():
+        return {"adb": "2.0.0"}
+
+    excluded = await _plan([_site(name="adb", source="android-sdk", version="1.0.41")])
+    assert _by_name(excluded, "adb").action == "unmanaged"
+
+    offered = await _plan([_site(name="adb", source="brew", version="1.0.41")], brew=brew)
+    update = _by_name(offered, "adb")
+    assert update.action == "upgrade_available"
+    assert update.command == ["brew", "upgrade", "adb"]
+
+
+async def test_venv_tools_defer_to_quern_update():
+    """`quern update` already reinstalls the venv eagerly. A second route to the
+    same packages would be two mechanisms racing over one directory."""
+    updates = await _plan([_site(name="mitmproxy", source="venv", version="12.2.3")])
+    update = _by_name(updates, "mitmproxy")
+    assert update.action == "current"
+    assert "quern update" in update.reason
+    assert update.command == []
+
+
+# --------------------------------------------------------------------------
+# Arriving as a dependency
+# --------------------------------------------------------------------------
+
+
+async def test_a_dependency_install_is_reported_but_not_offered():
+    async def brew():
+        return {"libimobiledevice": "1.5.0"}
+
+    site = _site(name="libimobiledevice", source="brew", version="1.4.0")
+    site.requested = False
+    site.required_by = ["ideviceinstaller"]
+
+    update = _by_name(await _plan([site], brew=brew), "libimobiledevice")
+    assert update.action == "current"
+    assert not update.actionable
+    assert "arrived as a dependency" in update.reason
+    assert "1.5.0 is available" in update.reason
+
+
+async def test_a_requested_install_is_offered_even_with_dependents():
+    """`required_by` is context for the reader, not a veto. libimobiledevice on
+    this machine is requested=True with two dependents and should still update."""
+    async def brew():
+        return {"libimobiledevice": "1.5.0"}
+
+    site = _site(name="libimobiledevice", source="brew", version="1.4.0")
+    site.requested = True
+    site.required_by = ["ideviceinstaller", "ios-webkit-debug-proxy"]
+
+    update = _by_name(await _plan([site], brew=brew), "libimobiledevice")
+    assert update.action == "upgrade_available"
+    assert "also required by" in update.note
+
+
+async def test_an_unrecorded_install_is_still_offered():
+    """brew predates `installed_on_request` for old installs; 'not recorded'
+    must not be read as 'arrived as a dependency'."""
+    async def brew():
+        return {"libimobiledevice": "1.5.0"}
+
+    site = _site(name="libimobiledevice", source="brew", version="1.4.0")
+    site.requested = None
+
+    update = _by_name(await _plan([site], brew=brew), "libimobiledevice")
+    assert update.action == "upgrade_available"
+    assert "did not record" in update.note
+
+
+# --------------------------------------------------------------------------
+# Floors escalate, and override the dependency exemption
+# --------------------------------------------------------------------------
+
+
+async def test_no_cli_floors_are_declared_unverified():
+    """Guards the finding, not the code. Every floor quern declared was a `>=`
+    that nothing had tested; adding an unverified CLI floor here would repeat
+    exactly that. A new entry must arrive with a comment saying what breaks
+    below it and where that was measured."""
+    assert CLI_FLOORS == {}, (
+        "adding a CLI floor is a decision -- document what breaks below it "
+        "and at which versions that was verified"
+    )
+
+
+async def test_below_floor_escalates_to_required(monkeypatch):
+    async def pypi(_name):
+        return "11.3.1"
+
+    monkeypatch.setitem(CLI_FLOORS, ("pymobiledevice3", "cli"), "10.0")
+    update = _by_name(await _plan([_site()], pypi=pypi), "pymobiledevice3")
+    assert update.action == "upgrade_required"
+    assert "below the 10.0" in update.reason
+
+
+async def test_a_floor_overrides_the_dependency_exemption(monkeypatch):
+    """Something else having installed a tool does not make a broken version
+    acceptable -- the exemption is for tools that merely aren't newest."""
+    async def brew():
+        return {"libimobiledevice": "2.0.0"}
+
+    monkeypatch.setitem(CLI_FLOORS, ("libimobiledevice", "cli"), "1.9")
+    site = _site(name="libimobiledevice", source="brew", version="1.4.0")
+    site.requested = False
+    site.required_by = ["ideviceinstaller"]
+
+    update = _by_name(await _plan([site], brew=brew), "libimobiledevice")
+    assert update.action == "upgrade_required"
+    assert update.note and "arrived as a dependency" in update.note
+
+
+async def test_a_tool_above_its_floor_but_behind_latest_is_still_offered(monkeypatch):
+    """The floor is not an excuse to sit on an old version -- it only decides
+    how urgent the offer is."""
+    async def pypi(_name):
+        return "11.3.1"
+
+    monkeypatch.setitem(CLI_FLOORS, ("pymobiledevice3", "cli"), "9.0")
+    update = _by_name(await _plan([_site()], pypi=pypi), "pymobiledevice3")
+    assert update.action == "upgrade_available"
+
+
+# --------------------------------------------------------------------------
+# Missing tools, and the rendered block
+# --------------------------------------------------------------------------
+
+
+async def test_a_missing_tool_points_at_setup():
+    update = _by_name(await _plan([_site(available=False, version=None)]), "pymobiledevice3")
+    assert update.action == "unknown"
+    assert "quern setup" in update.reason
+
+
+async def test_the_offer_carries_every_command_and_flags_required(monkeypatch):
+    async def pypi(_name):
+        return "11.3.1"
+
+    async def brew():
+        return {"libimobiledevice": "1.5.0"}
+
+    monkeypatch.setitem(CLI_FLOORS, ("libimobiledevice", "cli"), "1.5")
+    lib = _site(name="libimobiledevice", source="brew", version="1.4.0")
+    lib.requested = True
+
+    text = format_offer(await _plan([_site(), lib], pypi=pypi, brew=brew))
+    assert "pipx upgrade pymobiledevice3" in text
+    assert "brew upgrade libimobiledevice" in text
+    assert "9.15.1 → 11.3.1" in text
+    # Required sorts above merely-available so the urgent one is read first.
+    assert text.index("libimobiledevice") < text.index("pymobiledevice3")
+    assert "! libimobiledevice" in text
+
+
+async def test_nothing_to_do_renders_nothing():
+    """An update run with no tool work must print no tool section at all."""
+    updates = await _plan([_site(name="mitmproxy", source="venv", version="12.2.3")])
+    assert format_offer(updates) == ""
+
+
+# --------------------------------------------------------------------------
+# Wiring into `quern update`
+# --------------------------------------------------------------------------
+#
+# The planner being correct is worth nothing if the updater never calls it, or
+# calls it in a mode nobody asked for. Both failures are silent, so both are
+# pinned here rather than left to the module tests above.
+
+
+@pytest.fixture
+def stale_tool(monkeypatch):
+    """One actionable upgrade, with no network, no brew and no real sites."""
+    from server.device import tool_updates
+
+    async def fake_sites():
+        return [_site()]
+
+    async def fake_plan(_sites, **_kw):
+        return [
+            tool_updates.ToolUpdate(
+                name="pymobiledevice3", role="cli", action="upgrade_available",
+                current="9.15.1", latest="11.3.1",
+                command=["pipx", "upgrade", "pymobiledevice3"],
+                reason="newer release available (11.3.1)",
+            ),
+        ]
+
+    monkeypatch.setattr("server.device.tool_versions.collect_sites", fake_sites)
+    monkeypatch.setattr("server.device.tool_updates.plan_updates", fake_plan)
+
+    ran: list[list[str]] = []
+    monkeypatch.setattr(
+        "server.lifecycle.updater.subprocess.run",
+        lambda cmd, **kw: ran.append(cmd) or __import__("types").SimpleNamespace(returncode=0),
+    )
+    return ran
+
+
+def test_reporting_never_runs_the_upgrade(stale_tool, capsys):
+    """The default must not touch pipx or brew. These commands change state for
+    every other consumer on the machine, so running them as a side effect of
+    updating quern is not a decision to make on the caller's behalf."""
+    from server.lifecycle.updater import _report_tool_updates
+
+    _report_tool_updates(apply=False)
+    out = capsys.readouterr().out
+    assert "pipx upgrade pymobiledevice3" in out
+    assert "quern update --tools" in out
+    assert stale_tool == [], "reporting must not execute anything"
+
+
+def test_applying_runs_each_command(stale_tool, capsys):
+    from server.lifecycle.updater import _report_tool_updates
+
+    _report_tool_updates(apply=True)
+    assert stale_tool == [["pipx", "upgrade", "pymobiledevice3"]]
+
+
+def test_a_broken_version_check_does_not_fail_the_update(monkeypatch, capsys):
+    """A version lookup is advisory. Letting it abort `quern update` would make
+    an offline machine unable to update quern itself."""
+    async def boom():
+        raise RuntimeError("no network")
+
+    monkeypatch.setattr("server.device.tool_versions.collect_sites", boom)
+
+    from server.lifecycle.updater import _report_tool_updates
+
+    _report_tool_updates(apply=True)
+    assert "could not check external tool versions" in capsys.readouterr().out
+
+
+def test_already_up_to_date_still_checks_tools(monkeypatch):
+    """External tools age independently of quern. Gating the check on quern
+    having an update means learning about a two-major-old binary only when
+    something unrelated happens to ship."""
+    from server.lifecycle import updater
+
+    monkeypatch.setattr(updater, "_find_project_root", lambda: __import__("pathlib").Path("/tmp"))
+    monkeypatch.setattr(updater, "_is_git_install", lambda _root: True)
+    monkeypatch.setattr(updater, "_update_via_git", lambda _root: 2)  # already current
+
+    called: list[bool] = []
+    monkeypatch.setattr(updater, "_report_tool_updates", lambda apply=False: called.append(apply))
+
+    assert updater.run_update() == 0
+    assert called == [False], "the up-to-date path skipped the tool check"
+
+
+def test_the_tools_flag_reaches_the_updater(monkeypatch):
+    """Pin the argv wiring: a correct planner behind a flag nobody parses is
+    the same as no planner."""
+    import inspect
+
+    from server import __main__ as entry
+
+    source = inspect.getsource(entry)
+    assert 'run_update(apply_tools="--tools" in sys.argv[2:])' in source
+
+
+# --------------------------------------------------------------------------
+# brew_outdated itself
+# --------------------------------------------------------------------------
+#
+# The planner tests above inject a fake brew, so they pin how a None is
+# *handled* and say nothing about whether the real function ever produces one.
+# A mutation making brew_outdated return {} on failure passed all 37 of them --
+# which is precisely the false all-clear the None exists to prevent, sitting in
+# production code with a green suite over it.
+
+
+@pytest.fixture
+def fake_brew_run(monkeypatch):
+    def install(code: int, stdout: str):
+        async def _run(_args, timeout):  # noqa: ARG001
+            return code, stdout
+
+        monkeypatch.setattr("server.device.tool_updates._run", _run)
+
+    return install
+
+
+async def test_brew_outdated_returns_none_when_brew_is_missing(fake_brew_run):
+    """`_run` reports a non-zero code for a binary that does not exist, which is
+    the no-homebrew machine. That must not read as 'nothing is outdated'."""
+    from server.device.tool_updates import brew_outdated
+
+    fake_brew_run(1, "")
+    assert await brew_outdated() is None
+
+
+async def test_brew_outdated_returns_none_on_unparseable_output(fake_brew_run):
+    from server.device.tool_updates import brew_outdated
+
+    fake_brew_run(0, "not json at all")
+    assert await brew_outdated() is None
+
+
+async def test_brew_outdated_distinguishes_nothing_outdated_from_failure(fake_brew_run):
+    """A successful call with an empty formulae list is a real answer."""
+    from server.device.tool_updates import brew_outdated
+
+    fake_brew_run(0, '{"formulae": [], "casks": []}')
+    assert await brew_outdated() == {}
+
+
+async def test_brew_outdated_maps_name_to_current_version(fake_brew_run):
+    from server.device.tool_updates import brew_outdated
+
+    fake_brew_run(0, '{"formulae": [{"name": "libimobiledevice", '
+                     '"installed_versions": ["1.4.0"], "current_version": "1.5.0"}]}')
+    assert await brew_outdated() == {"libimobiledevice": "1.5.0"}
+
+
+async def test_brew_outdated_skips_entries_missing_a_version(fake_brew_run):
+    """Guards against a partial entry becoming a None latest, which would read
+    downstream as 'up to date at None'."""
+    from server.device.tool_updates import brew_outdated
+
+    fake_brew_run(0, '{"formulae": [{"name": "x"}, {"current_version": "2.0"}]}')
+    assert await brew_outdated() == {}
+
+
+# --------------------------------------------------------------------------
+# The doctor report
+# --------------------------------------------------------------------------
+#
+# `format_offer` and `format_report` answer different questions and must not be
+# collapsed. The offer is "what should I run", so it hides everything healthy.
+# The report is "why does this machine differ from that one", so hiding the
+# healthy entries is precisely the failure -- two machines comparing only their
+# problems agree they have none while running three-major-apart copies.
+
+
+async def test_the_report_shows_brew_dependents_for_a_tool_needing_no_action():
+    """The reason this exists. libimobiledevice being current is not the
+    interesting part; that two other formulae depend on it is, because that is
+    what turns a later upgrade into a decision rather than a command."""
+    from server.device.tool_updates import format_report
+
+    async def brew():
+        return {}
+
+    site = _site(name="libimobiledevice", source="brew", version="1.4.0")
+    site.requested = True
+    site.required_by = ["ideviceinstaller", "ios-webkit-debug-proxy"]
+
+    updates = await _plan([site], brew=brew)
+    assert _by_name(updates, "libimobiledevice").action == "current"
+
+    text = format_report(updates)
+    assert "ideviceinstaller" in text
+    assert "ios-webkit-debug-proxy" in text
+    # The offer, by contrast, has nothing to say about it.
+    assert format_offer(updates) == ""
+
+
+async def test_the_report_lists_every_site_including_unmanaged():
+    from server.device.tool_updates import format_report
+
+    async def pypi(_name):
+        return "11.3.1"
+
+    text = format_report(await _plan([
+        _site(),
+        _site(name="node", source="fnm", version="22.22.2"),
+        _site(name="adb", source="android-sdk", version="1.0.41"),
+        _site(name="mitmproxy", source="venv", version="12.2.3"),
+    ], pypi=pypi))
+
+    for name in ("pymobiledevice3", "node", "adb", "mitmproxy"):
+        assert name in text
+    assert "fnm manages node" in text
+    assert "Android Studio" in text
+
+
+async def test_the_report_sorts_actionable_first():
+    from server.device.tool_updates import format_report
+
+    async def pypi(_name):
+        return "11.3.1"
+
+    text = format_report(await _plan([
+        _site(name="node", source="fnm", version="22.22.2"),
+        _site(),
+    ], pypi=pypi))
+    assert text.index("pymobiledevice3") < text.index("node")
+
+
+async def test_the_report_carries_the_source_that_decided_the_action():
+    """Without it a reader sees 'not managed' and goes looking for a quern
+    setting to change, rather than for Android Studio."""
+    from server.device.tool_updates import format_report
+
+    text = format_report(await _plan([_site(name="adb", source="android-sdk", version="1.0.41")]))
+    assert "(android-sdk)" in text
+
+
+def test_the_report_survives_having_nothing_to_report():
+    from server.device.tool_updates import format_report
+
+    assert "none detected" in format_report([])
+
+
+def test_doctor_reports_without_running_anything(monkeypatch, capsys):
+    """Doctor is documented as read-only diagnostics. It prints the upgrade
+    commands; `quern update --tools` is the only thing that runs them."""
+    import subprocess as sp
+
+    from server.device import tool_updates
+
+    async def fake_sites():
+        return [_site()]
+
+    async def fake_plan(_sites, **_kw):
+        return [tool_updates.ToolUpdate(
+            name="pymobiledevice3", role="cli", action="upgrade_available",
+            current="9.15.1", latest="11.3.1", source="pipx",
+            command=["pipx", "upgrade", "pymobiledevice3"],
+            reason="newer release available (11.3.1)",
+        )]
+
+    monkeypatch.setattr("server.device.tool_versions.collect_sites", fake_sites)
+    monkeypatch.setattr("server.device.tool_updates.plan_updates", fake_plan)
+
+    ran = []
+    monkeypatch.setattr(sp, "run", lambda *a, **k: ran.append(a))
+
+    from server.main import _report_external_tools
+
+    _report_external_tools()
+    out = capsys.readouterr().out
+    assert "pipx upgrade pymobiledevice3" in out
+    assert ran == [], "doctor must not execute upgrade commands"
+
+
+def test_a_broken_check_does_not_break_doctor(monkeypatch, capsys):
+    """A machine where this raises is exactly one someone is running doctor on."""
+    async def boom():
+        raise RuntimeError("brew exploded")
+
+    monkeypatch.setattr("server.device.tool_versions.collect_sites", boom)
+
+    from server.main import _report_external_tools
+
+    _report_external_tools()
+    assert "could not be checked" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------
+# brew provenance is fetched for every brew site
+# --------------------------------------------------------------------------
+
+
+async def test_provenance_is_attached_to_every_brew_site_not_just_one():
+    """It used to be fetched for libimobiledevice alone, because that was the
+    only brew install on the machine it was written on. mitmproxy, adb and
+    pymobiledevice3 are all brew-installable, and on a machine that installed
+    them that way the field that decides whether an upgrade is safe to offer was
+    simply absent."""
+    from server.device import tool_versions
+
+    asked: list[str] = []
+
+    async def fake_provenance(formula):
+        asked.append(formula)
+        return True, [f"{formula}-consumer"]
+
+    import server.device.tool_versions as tv
+
+    original = tv.brew_provenance
+    tv.brew_provenance = fake_provenance
+    try:
+        sites = [
+            _site(name="libimobiledevice", source="brew"),
+            _site(name="mitmproxy", source="brew"),
+            _site(name="node", source="fnm"),
+            _site(name="gone", source="brew", available=False),
+        ]
+        await tool_versions._attach_brew_provenance(sites)
+    finally:
+        tv.brew_provenance = original
+
+    assert sorted(asked) == ["libimobiledevice", "mitmproxy"]
+    assert sites[1].required_by == ["mitmproxy-consumer"]
+    assert sites[2].requested is None, "non-brew sites must be left alone"
+
+
+async def test_one_unreadable_formula_does_not_lose_the_others():
+    """Best effort per formula: `brew info` failing on one must not cost the
+    provenance of every other, which a bare gather would do."""
+    from server.device import tool_versions
+
+    async def flaky(formula):
+        if formula == "broken":
+            raise RuntimeError("brew info exploded")
+        return True, ["consumer"]
+
+    import server.device.tool_versions as tv
+
+    original = tv.brew_provenance
+    tv.brew_provenance = flaky
+    try:
+        sites = [_site(name="broken", source="brew"), _site(name="fine", source="brew")]
+        await tool_versions._attach_brew_provenance(sites)
+    finally:
+        tv.brew_provenance = original
+
+    assert sites[0].requested is None
+    assert sites[1].required_by == ["consumer"]
+
+
+# --------------------------------------------------------------------------
+# `doctor --fix` and the boundary it does not cross
+# --------------------------------------------------------------------------
+#
+# `--fix` is scoped to "exactly what server startup runs" -- the venv, nothing
+# else. A pipx or brew upgrade changes state for every consumer on the machine,
+# further out of scope than `quern setup`, which `--fix` already refuses to run.
+#
+# The risk is not that it does too much; it is that it stays quiet. "--fix:
+# nothing to do" printed above a tool marked as behind reads as "and nothing to
+# do about that either", which is the one way this section can mislead.
+
+
+@pytest.fixture
+def doctor_with_stale_tool(monkeypatch):
+    from server.device import tool_updates
+
+    async def fake_sites():
+        return [_site()]
+
+    async def fake_plan(_sites, **_kw):
+        return [tool_updates.ToolUpdate(
+            name="pymobiledevice3", role="cli", action="upgrade_available",
+            current="9.15.1", latest="11.3.1", source="pipx",
+            command=["pipx", "upgrade", "pymobiledevice3"],
+            reason="newer release available (11.3.1)",
+        )]
+
+    monkeypatch.setattr("server.device.tool_versions.collect_sites", fake_sites)
+    monkeypatch.setattr("server.device.tool_updates.plan_updates", fake_plan)
+
+    import subprocess as sp
+
+    ran: list = []
+    monkeypatch.setattr(sp, "run", lambda *a, **k: ran.append(a))
+    return ran
+
+
+def test_fix_does_not_upgrade_external_tools(doctor_with_stale_tool, capsys):
+    from server.main import _report_external_tools
+
+    _report_external_tools(fix=True)
+    capsys.readouterr()
+    assert doctor_with_stale_tool == [], (
+        "--fix must not run pipx or brew: those change state for every consumer "
+        "on the machine, not just quern"
+    )
+
+
+def test_fix_says_it_cannot_help_rather_than_staying_quiet(doctor_with_stale_tool, capsys):
+    from server.main import _report_external_tools
+
+    _report_external_tools(fix=True)
+    out = capsys.readouterr().out
+    assert "--fix does not upgrade external tools" in out
+    assert "quern update --tools" in out
+
+
+def test_without_fix_there_is_no_disclaimer(doctor_with_stale_tool, capsys):
+    """The note answers a question only `--fix` raises. Printing it always would
+    be noise on the read-only path."""
+    from server.main import _report_external_tools
+
+    _report_external_tools(fix=False)
+    assert "--fix does not upgrade" not in capsys.readouterr().out
+
+
+def test_fix_is_silent_when_every_tool_is_current(monkeypatch, capsys):
+    """No disclaimer when there is nothing it could have fixed anyway."""
+    from server.device import tool_updates
+
+    async def fake_sites():
+        return [_site()]
+
+    async def fake_plan(_sites, **_kw):
+        return [tool_updates.ToolUpdate(
+            name="mitmproxy", role="cli", action="current", current="12.2.3",
+            source="venv", reason="up to date at 12.2.3",
+        )]
+
+    monkeypatch.setattr("server.device.tool_versions.collect_sites", fake_sites)
+    monkeypatch.setattr("server.device.tool_updates.plan_updates", fake_plan)
+
+    from server.main import _report_external_tools
+
+    _report_external_tools(fix=True)
+    assert "--fix does not upgrade" not in capsys.readouterr().out
+
+
+def test_doctor_passes_the_fix_flag_through():
+    """Pin the wiring: the flag reached `_report_python_deps` and not this
+    section, which is how the inconsistency arose in the first place."""
+    import inspect
+
+    from server import main
+
+    source = inspect.getsource(main._cmd_doctor)
+    assert '_report_external_tools(getattr(args, "fix", False))' in source

--- a/tests/test_tool_updates.py
+++ b/tests/test_tool_updates.py
@@ -1073,8 +1073,67 @@ def test_run_update_names_the_step_that_failed(monkeypatch, capsys):
     monkeypatch.setattr(updater, "_is_git_install", lambda _r: True)
     monkeypatch.setattr(updater, "_update_via_git", lambda _r: 0)
     monkeypatch.setattr(updater, "_rebuild_and_restart", lambda _p: ["restart"])
+    # run_update now reports external tools before checking rebuild failures,
+    # so without this the test would query PyPI and shell out to brew.
+    monkeypatch.setattr(updater, "_report_tool_updates", lambda apply=False: True)
 
     assert updater.run_update() == 1
     out = capsys.readouterr().out
     assert "restart failed" in out
     assert "dependencies could not be installed" not in out
+
+
+def test_external_tools_are_reported_even_when_the_rebuild_failed(monkeypatch, capsys):
+    """A failed rebuild used to return before the tool report, so `--tools`
+    was silently dropped even though the caller asked for it explicitly.
+
+    External tools live outside the project and do not depend on the rebuild
+    having worked, so the two are independent.
+    """
+    from server.lifecycle import updater
+
+    monkeypatch.setattr(updater, "_find_project_root", lambda: __import__("pathlib").Path("/tmp"))
+    monkeypatch.setattr(updater, "_is_git_install", lambda _r: True)
+    monkeypatch.setattr(updater, "_update_via_git", lambda _r: 0)
+    monkeypatch.setattr(updater, "_rebuild_and_restart", lambda _p: ["dependencies"])
+
+    asked: list[bool] = []
+
+    def record(apply=False):
+        asked.append(apply)
+        return True
+
+    monkeypatch.setattr(updater, "_report_tool_updates", record)
+
+    assert updater.run_update(apply_tools=True) == 1
+    assert asked == [True], "--tools was dropped when the rebuild failed"
+
+
+def test_a_raised_mcp_build_does_not_crash_the_update(rebuild):
+    """_ensure_mcp_built shells out to npm twice with timeouts and catches
+    neither, so a machine without npm raised straight through the rebuild."""
+    import server.__main__ as entry
+
+    def boom(**_kw):
+        raise FileNotFoundError("npm not found")
+
+    original = entry._ensure_mcp_built
+    entry._ensure_mcp_built = boom
+    try:
+        assert rebuild["_run"]() == ["MCP build"]
+    finally:
+        entry._ensure_mcp_built = original
+
+
+def test_an_mcp_build_timeout_is_recorded(rebuild):
+    import server.__main__ as entry
+
+    def boom(**_kw):
+        raise subprocess.TimeoutExpired(cmd="npm run build", timeout=60)
+
+    original = entry._ensure_mcp_built
+    entry._ensure_mcp_built = boom
+    try:
+        assert rebuild["_run"]() == ["MCP build"]
+    finally:
+        entry._ensure_mcp_built = original

--- a/tests/test_tool_updates.py
+++ b/tests/test_tool_updates.py
@@ -21,6 +21,8 @@ same way `probe_container` takes `describe_point`.
 from __future__ import annotations
 
 import json
+import subprocess
+from types import SimpleNamespace
 
 import pytest
 
@@ -981,3 +983,98 @@ def test_doctor_reports_external_tools_when_no_device_tools_are_found(monkeypatc
     source = inspect.getsource(main._cmd_doctor)
     empty_branch = source.split("if not tools:")[1].split("sys.exit(0)")[0]
     assert "_report_external_tools" in empty_branch
+
+
+# --------------------------------------------------------------------------
+# Every rebuild step has to reach the exit code
+# --------------------------------------------------------------------------
+#
+# `_rebuild_and_restart` used to return only the dependency result. A failed MCP
+# build was a warning, `run_setup`'s exit code was discarded outright, and the
+# restart's was never read -- so `quern update` could exit 0 having left the MCP
+# tools stale or the server down.
+
+
+@pytest.fixture
+def rebuild(monkeypatch, tmp_path):
+    """Drive each step of _rebuild_and_restart independently."""
+    from server.lifecycle import updater
+
+    state = {"deps": True, "mcp": True, "setup": 0, "restart": 0, "running": True}
+
+    monkeypatch.setattr("server.__main__._ensure_python_deps",
+                        lambda **_kw: state["deps"])
+    monkeypatch.setattr("server.__main__._ensure_mcp_built", lambda **_kw: state["mcp"])
+    monkeypatch.setattr("server.lifecycle.setup.run_setup", lambda: state["setup"])
+    monkeypatch.setattr("server.lifecycle.state.read_state",
+                        lambda: {"server_port": 9100} if state["running"] else None)
+    monkeypatch.setattr("server.lifecycle.state.is_server_healthy", lambda _p: state["running"])
+
+    def fake_run(_cmd, **_kw):
+        if isinstance(state["restart"], BaseException):
+            raise state["restart"]
+        return SimpleNamespace(returncode=state["restart"])
+
+    monkeypatch.setattr(updater.subprocess, "run", fake_run)
+    state["_run"] = lambda: updater._rebuild_and_restart(tmp_path)
+    return state
+
+
+def test_everything_working_reports_no_failures(rebuild):
+    assert rebuild["_run"]() == []
+
+
+def test_a_failed_mcp_build_is_no_longer_only_a_warning(rebuild):
+    rebuild["mcp"] = False
+    assert rebuild["_run"]() == ["MCP build"]
+
+
+def test_a_nonzero_setup_is_reported(rebuild):
+    rebuild["setup"] = 1
+    assert rebuild["_run"]() == ["setup"]
+
+
+def test_a_failed_restart_is_reported(rebuild):
+    """Leaving the server down and exiting 0 is the worst of these: the update
+    looks clean and nothing is listening."""
+    rebuild["restart"] = 1
+    assert rebuild["_run"]() == ["restart"]
+
+
+def test_a_restart_that_raises_does_not_crash_the_update(rebuild):
+    """The restart carries a 30s timeout whose exception was uncaught, so an
+    update that hung on restart crashed instead of reporting."""
+    rebuild["restart"] = subprocess.TimeoutExpired(cmd="restart", timeout=30)
+    assert rebuild["_run"]() == ["restart"]
+
+
+def test_later_steps_still_run_after_an_early_failure(rebuild):
+    """An update that cannot build the MCP wrapper should still reconcile the
+    venv, so failures accumulate rather than short-circuiting."""
+    rebuild["deps"] = False
+    rebuild["mcp"] = False
+    rebuild["setup"] = 1
+    rebuild["restart"] = 1
+    assert rebuild["_run"]() == ["dependencies", "MCP build", "setup", "restart"]
+
+
+def test_no_restart_is_attempted_when_the_server_is_stopped(rebuild):
+    rebuild["running"] = False
+    rebuild["restart"] = 1          # would fail if it were attempted
+    assert rebuild["_run"]() == []
+
+
+def test_run_update_names_the_step_that_failed(monkeypatch, capsys):
+    """"dependencies could not be installed" after a failed restart sends the
+    reader to the wrong place."""
+    from server.lifecycle import updater
+
+    monkeypatch.setattr(updater, "_find_project_root", lambda: __import__("pathlib").Path("/tmp"))
+    monkeypatch.setattr(updater, "_is_git_install", lambda _r: True)
+    monkeypatch.setattr(updater, "_update_via_git", lambda _r: 0)
+    monkeypatch.setattr(updater, "_rebuild_and_restart", lambda _p: ["restart"])
+
+    assert updater.run_update() == 1
+    out = capsys.readouterr().out
+    assert "restart failed" in out
+    assert "dependencies could not be installed" not in out

--- a/tests/test_tool_updates.py
+++ b/tests/test_tool_updates.py
@@ -20,6 +20,8 @@ same way `probe_container` takes `describe_point`.
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from server.device.tool_updates import (
@@ -33,8 +35,12 @@ from server.device.tool_versions import ToolSite
 
 
 def _site(name="pymobiledevice3", role="cli", source="pipx", version="9.15.1", **kw):
+    # `package` defaults to the tool's own name, which is true for most sites.
+    # The ones where it is not -- idb/fb-idb, adb/android-platform-tools -- are
+    # set explicitly by the tests that care.
     return ToolSite(
         name=name, role=role, source=source, version=version,
+        package=kw.pop("package", name), brew_cask=kw.pop("brew_cask", False),
         available=kw.pop("available", True), path=kw.pop("path", f"/opt/{source}/bin/{name}"),
         **kw,
     )
@@ -417,7 +423,12 @@ def test_already_up_to_date_still_checks_tools(monkeypatch):
     monkeypatch.setattr(updater, "_update_via_git", lambda _root: 2)  # already current
 
     called: list[bool] = []
-    monkeypatch.setattr(updater, "_report_tool_updates", lambda apply=False: called.append(apply))
+
+    def record(apply=False):
+        called.append(apply)
+        return True
+
+    monkeypatch.setattr(updater, "_report_tool_updates", record)
 
     assert updater.run_update() == 0
     assert called == [False], "the up-to-date path skipped the tool check"
@@ -784,3 +795,189 @@ def test_doctor_passes_the_fix_flag_through():
 
     source = inspect.getsource(main._cmd_doctor)
     assert '_report_external_tools(getattr(args, "fix", False))' in source
+
+
+# --------------------------------------------------------------------------
+# Package identity: what the manager calls a tool is not what quern calls it
+# --------------------------------------------------------------------------
+#
+# `collect_sites` records `idb` from the `fb-idb` distribution and `adb` from
+# the `android-platform-tools` cask. Planning off `site.name` therefore queried
+# the wrong PyPI project and emitted an upgrade command for a package that does
+# not exist -- while looking entirely plausible in the output.
+
+
+async def test_the_pypi_lookup_uses_the_distribution_not_the_tool_name():
+    asked: list[str] = []
+
+    async def pypi(name):
+        asked.append(name)
+        return "1.9.0"
+
+    site = _site(name="idb", package="fb-idb", source="pipx", version="1.5.2")
+    update = _by_name(await _plan([site], pypi=pypi), "idb")
+
+    assert asked == ["fb-idb"], "queried PyPI for the wrong project"
+    assert update.command == ["pipx", "upgrade", "fb-idb"]
+
+
+async def test_a_cask_is_upgraded_with_the_cask_flag():
+    """There is no `adb` formula; brew ships the binary in a cask, so
+    `brew upgrade adb` fails outright."""
+    async def brew():
+        return {"android-platform-tools": "36.0.0"}
+
+    site = _site(name="adb", package="android-platform-tools", brew_cask=True,
+                 source="brew", version="1.0.41")
+    update = _by_name(await _plan([site], brew=brew), "adb")
+
+    assert update.action == "upgrade_available"
+    assert update.command == ["brew", "upgrade", "--cask", "android-platform-tools"]
+
+
+async def test_a_formula_is_upgraded_without_the_cask_flag():
+    async def brew():
+        return {"libimobiledevice": "1.5.0"}
+
+    site = _site(name="libimobiledevice", source="brew", version="1.4.0")
+    update = _by_name(await _plan([site], brew=brew), "libimobiledevice")
+    assert update.command == ["brew", "upgrade", "libimobiledevice"]
+
+
+async def test_a_site_without_an_identity_is_unknown_not_current():
+    """Planning it as `current` would report a tool as up to date on the
+    strength of a lookup that never happened."""
+    site = _site(package=None)
+    update = _by_name(await _plan([site]), "pymobiledevice3")
+    assert update.action == "unknown"
+    assert not update.actionable
+    assert "no package identity" in update.reason
+    assert update.command == []
+
+
+async def test_brew_outdated_reads_casks_as_well_as_formulae(fake_brew_run):
+    """Reading only `formulae` reported an outdated cask as up to date."""
+    from server.device.tool_updates import brew_outdated
+
+    payload = json.dumps({
+        "formulae": [{"name": "libimobiledevice", "current_version": "1.5.0"}],
+        # Casks report `name` as a list of tokens, not a string.
+        "casks": [{"name": ["android-platform-tools"], "current_version": "36.0.0"}],
+    })
+    fake_brew_run(0, payload)
+    assert await brew_outdated() == {
+        "libimobiledevice": "1.5.0",
+        "android-platform-tools": "36.0.0",
+    }
+
+
+async def test_provenance_asks_brew_about_the_formula_name():
+    """`brew info adb` is not a thing. Asking under the tool's nickname returned
+    no provenance, which reads downstream as 'not recorded'."""
+    import server.device.tool_versions as tv
+    from server.device import tool_versions
+
+    asked: list[str] = []
+
+    async def fake_provenance(formula):
+        asked.append(formula)
+        return True, []
+
+    original = tv.brew_provenance
+    tv.brew_provenance = fake_provenance
+    try:
+        await tool_versions._attach_brew_provenance(
+            [_site(name="adb", package="android-platform-tools", source="brew")])
+    finally:
+        tv.brew_provenance = original
+
+    assert asked == ["android-platform-tools"]
+
+
+# --------------------------------------------------------------------------
+# `--tools` is an instruction, so its failures have to be visible
+# --------------------------------------------------------------------------
+
+
+def test_a_failed_upgrade_makes_update_exit_nonzero(monkeypatch, capsys):
+    """Printing "failed" while the process exits 0 tells a script the opposite
+    of what happened."""
+    from server.device import tool_updates
+    from server.lifecycle import updater
+
+    async def fake_sites():
+        return [_site()]
+
+    async def fake_plan(_sites, **_kw):
+        return [tool_updates.ToolUpdate(
+            name="pymobiledevice3", role="cli", action="upgrade_available",
+            current="9.15.1", latest="11.3.1", source="pipx",
+            command=["pipx", "upgrade", "pymobiledevice3"], reason="newer",
+        )]
+
+    monkeypatch.setattr("server.device.tool_versions.collect_sites", fake_sites)
+    monkeypatch.setattr("server.device.tool_updates.plan_updates", fake_plan)
+    monkeypatch.setattr(
+        updater.subprocess, "run",
+        lambda *a, **k: __import__("types").SimpleNamespace(returncode=1))
+
+    assert updater._report_tool_updates(apply=True) is False
+    assert "1 tool upgrade(s) failed" in capsys.readouterr().out
+
+
+def test_a_raised_upgrade_failure_also_counts(monkeypatch, capsys):
+    from server.device import tool_updates
+    from server.lifecycle import updater
+
+    async def fake_sites():
+        return [_site()]
+
+    async def fake_plan(_sites, **_kw):
+        return [tool_updates.ToolUpdate(
+            name="pymobiledevice3", role="cli", action="upgrade_available",
+            current="9.15.1", latest="11.3.1", source="pipx",
+            command=["pipx", "upgrade", "pymobiledevice3"], reason="newer",
+        )]
+
+    monkeypatch.setattr("server.device.tool_versions.collect_sites", fake_sites)
+    monkeypatch.setattr("server.device.tool_updates.plan_updates", fake_plan)
+
+    def boom(*_a, **_k):
+        raise PermissionError("pipx not executable")
+
+    monkeypatch.setattr(updater.subprocess, "run", boom)
+    assert updater._report_tool_updates(apply=True) is False
+
+
+def test_reporting_alone_is_never_a_failure(monkeypatch):
+    """A stale tool is information. Only `--tools` turns it into an instruction
+    that can fail."""
+    from server.device import tool_updates
+    from server.lifecycle import updater
+
+    async def fake_sites():
+        return [_site()]
+
+    async def fake_plan(_sites, **_kw):
+        return [tool_updates.ToolUpdate(
+            name="pymobiledevice3", role="cli", action="upgrade_available",
+            current="9.15.1", latest="11.3.1", source="pipx",
+            command=["pipx", "upgrade", "pymobiledevice3"], reason="newer",
+        )]
+
+    monkeypatch.setattr("server.device.tool_versions.collect_sites", fake_sites)
+    monkeypatch.setattr("server.device.tool_updates.plan_updates", fake_plan)
+    assert updater._report_tool_updates(apply=False) is True
+
+
+def test_doctor_reports_external_tools_when_no_device_tools_are_found(monkeypatch):
+    """The branch where it matters most: a missing device controller often *is*
+    a missing or stale external tool. Skipping the report there also made the
+    README's description of `quern doctor` false."""
+    import inspect
+
+    from server import main
+
+    source = inspect.getsource(main._cmd_doctor)
+    empty_branch = source.split("if not tools:")[1].split("sys.exit(0)")[0]
+    assert "_report_external_tools" in empty_branch


### PR DESCRIPTION
> **Stacked on #106.** Base is `deps/floors-and-eager-upgrades`, so this diff
> shows only its own changes. Merge #106 first.

## The gap

`quern update` kept its own venv current and said nothing about anything else.
That is not a small gap — `pymobiledevice3` is **two installs** on a typical
machine, and the eager venv upgrade in #106 *widened* the split rather than
closing it:

```
pymobiledevice3 (library)  11.3.1  venv   ← moved by the eager upgrade
pymobiledevice3 (cli)       9.15.1  pipx   ← serves tunneld; untouched
```

`tool_versions` answered *what is installed*. This adds `tool_updates`, which
decides *what to do about it* — a different question with a different shape.

## Three findings that set the design

**The floor is not the driver.** Every floor quern declares is a `>=` and none
is load-bearing, so a floor-driven updater sits silent while tools age
indefinitely. Latest drives the offer; a floor only escalates it into a
requirement.

`CLI_FLOORS` therefore ships **empty**, and a test keeps it that way. That is
the finding, not an omission: no CLI version boundary has ever been tested
against quern, and inventing one here would repeat exactly what #106 was written
to stop. Adding an entry has to be a deliberate act with a comment saying what
breaks below it and where that was measured.

**How a tool updates is a property of its `source`, not its name.** `adb` is
left alone because it is `android-sdk` and `node` because it is `fnm` — there is
no name list. The same tool installed from brew on another machine is offered
normally, and a test pins that. An earlier sketch keyed the exclusions off names
and would have been wrong on the next machine.

**Arriving as a dependency is a reason to leave a tool alone** — upgrading it
directly can be undone by whatever pulled it in. Unless it is below a floor,
where staying put is not an option either.

## A correctness bug fixed on the way

`brew_provenance` was fetched for **`libimobiledevice` alone, hardcoded**,
because that was the only brew install on the machine it was written on.
`mitmproxy`, `adb` and `pymobiledevice3` are all brew-installable, so on a
machine that installed them that way, `requested` / `required_by` were absent —
and `requested is False` is exactly what suppresses an unsafe upgrade offer. The
*safety* check was silently missing for every brew tool but one.

Now fetched for every brew site, concurrently (each costs a `brew info` plus a
`brew uses`), with `return_exceptions=True` so one unreadable formula cannot
cost the provenance of the others.

## A failed lookup is not a clean bill of health

`brew_outdated` returns `None` for "could not ask" and `{}` for "asked, nothing
outdated". The first version collapsed them, which reports **every formula as
current on a machine with no brew installed**.

Worth flagging for review: mutation testing showed my first tests for this were
inadequate — they injected a fake `brew` returning `None`, so they exercised the
planner and never `brew_outdated` itself. A regression to `{}` on failure passed
all 37 tests. Five tests were added against the real function.

## Surfaces

| command | behaviour |
|---|---|
| `quern update` | reports stale tools with exact commands, on **every** run — including the already-up-to-date path, since external tools age independently of quern |
| `quern update --tools` | applies them |
| `quern doctor` | shows **every** install site including healthy ones, with each brew formula's dependents |
| `quern doctor --fix` | unchanged scope (venv only), but now *says* it will not upgrade external tools |

Reporting is the default throughout: a `pipx` or `brew` upgrade changes state
for every consumer on the machine, so doing it as a side effect of updating
quern is not a decision to make on the caller's behalf.

`format_report` is deliberately separate from `format_offer`. The offer answers
"what should I run" and hides everything healthy; the report answers "why does
this machine differ from that one", where hiding the healthy entries is the
failure — two machines comparing only their problems agree they have none while
running three-major-apart copies.

The `--fix` disclaimer exists because `--fix: nothing to do` printed directly
above a tool marked `↑` reads as "and nothing to do about that either".

## Verification

- **1776 passed**, ruff clean.
- Live on this machine: correctly identifies the one stale tool, excludes `adb`
  and `node` by source, and shows `libimobiledevice`'s dependents
  (`ideviceinstaller`, `ios-webkit-debug-proxy`) on a tool needing no action.
- Mutation-tested: failed lookup collapsing to "up to date", `brew_outdated`
  returning `{}` on failure, dependency exemption removed, reporting silently
  applying, and the up-to-date path skipping the check — each caught.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `quern update` reports external-tool updates even when Quern is current.
  - `quern update --tools` applies eligible upgrades, including Homebrew casks.
  - `quern doctor` reports external tools without available device tools, including versions, provenance, and recommended commands.

- **Bug Fixes**
  - Corrected update commands and package mappings for externally managed tools.
  - Updates now report dependency, setup, build, and restart failures accurately.

- **Documentation**
  - Clarified update channels, virtual-environment reconciliation, `doctor --fix` behavior, and external-tool diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->