### PR TITLE
Report tunneld and local-capture extension health in doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,24 @@ both while one runs a 9.15.1 binary and the other an 11.3.1 one.
 tools, and says so when it finds some it cannot help with, rather than printing
 "nothing to do" above a tool it just flagged as behind.
 
+Doctor also reports **service health**, which is a different question from whether a
+tool is installed:
+
+- **tunneld** — a failed device pairing can leave the daemon alive but not serving. It
+  holds no listener and never exits, so `KeepAlive` never fires and launchd reports it
+  healthy indefinitely. Doctor separates that *wedged* state from a merely *stopped*
+  one by pairing the HTTP probe with the launchd job state, and prints the `bootout` +
+  `bootstrap` recovery. It never runs it — recovery is tracked in issue #73.
+- **local capture extension** — the mitmproxy macOS system extension is approved once
+  by a human and then upgraded underneath that approval by ordinary dependency updates.
+  When the version macOS runs falls behind the version the installed wheel ships, local
+  capture reports itself enabled while capturing nothing. Doctor compares the two, and
+  `--fix` re-runs the shipped app so macOS can activate the newer one (you still have
+  to approve it in System Settings).
+
+Neither check needs a password: `launchctl print` on a system job and
+`systemextensionsctl list` are both readable unprivileged.
+
 Setting the channel only writes `~/.quern/config.json` — nothing changes until the next `quern update`. Git-clone installs follow the `release/stable` / `release/beta` pointer branches; tarball installs follow GitHub Releases, filtered on the prerelease flag. Full details, including the maintainer release procedure, are in [`docs/release-channels.md`](docs/release-channels.md).
 
 ## What Quern Does
@@ -298,7 +316,7 @@ quern start -f               # Foreground
 quern stop                   # Graceful shutdown
 quern restart                # Stop + start
 quern status                 # Show PID, URL, uptime, tool availability
-quern doctor                 # Read-only diagnostics: device tools, venv, external tool versions
+quern doctor                 # Read-only diagnostics: device tools, venv, tool versions, service health
 quern doctor --fix           # ...and reconcile the venv with pyproject.toml (venv only)
 quern version                # Print the installed version
 quern update                 # Update to the latest release on your channel and rebuild

--- a/server/device/tunneld.py
+++ b/server/device/tunneld.py
@@ -21,6 +21,7 @@ import subprocess
 import tempfile
 import textwrap
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
 import httpx
@@ -140,6 +141,143 @@ async def resolve_tunnel_udid(coredevice_uuid: str) -> str | None:
             Path(tmp_path).unlink(missing_ok=True)
 
     return _tunnel_udid_cache.get(coredevice_uuid)
+
+
+
+@dataclass
+class TunneldHealth:
+    """What state the tunneld daemon is in, and what would resolve it."""
+
+    status: str
+    """healthy | wedged | stopped | not_installed | no_binary | stale_plist |
+    binary_drift."""
+
+    detail: str
+    serving: bool = False
+    launchd_state: str | None = None
+    pid: int | None = None
+    program: str | None = None
+    remedy: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.status == "healthy"
+
+
+def launchd_job() -> dict[str, str]:
+    """What launchd knows about the tunneld job, without needing sudo.
+
+    `launchctl print` on a system-domain job is readable unprivileged -- verified
+    on macOS 26 -- which is what lets this run inside read-only diagnostics
+    without a password prompt. Only the handful of scalar fields are parsed;
+    the output is a large nested dump and anything deeper would be brittle.
+    """
+    try:
+        result = subprocess.run(
+            ["launchctl", "print", f"system/{TUNNELD_LABEL}"],
+            capture_output=True, text=True, timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return {}
+    if result.returncode != 0:
+        return {}
+
+    wanted = ("state", "pid", "program", "last exit code")
+    fields: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        stripped = line.strip()
+        if "=" not in stripped:
+            continue
+        key, _, value = stripped.partition("=")
+        key, value = key.strip(), value.strip()
+        # Only top-level scalars: nested blocks repeat `state = active` for
+        # every endpoint, which would otherwise overwrite the job's own state.
+        if key in wanted and key not in fields:
+            fields[key] = value
+    return fields
+
+
+async def tunneld_health() -> TunneldHealth:
+    """Whether tunneld is actually serving, and if not, why.
+
+    The distinction that matters is **wedged versus stopped**, because they look
+    identical from the HTTP side and need opposite responses. A failed device
+    pairing can leave the daemon alive and not serving: it holds no listener and
+    never exits, so `KeepAlive` never fires and launchd reports it healthy
+    indefinitely (#73). "HTTP down while launchd says running" is the signature
+    that separates that from a daemon which is simply not started.
+
+    This reports and does not remediate. Recovery is `bootout` + `bootstrap`,
+    never `kickstart -k` -- that sends SIGKILL and hung launchctl on macOS 15,
+    as `install_daemon` already notes.
+    """
+    binary = find_pymobiledevice3_binary()
+    if binary is None:
+        return TunneldHealth(
+            status="no_binary",
+            detail="pymobiledevice3 binary not found, so tunneld cannot run",
+            remedy="pipx install pymobiledevice3",
+        )
+
+    if not PLIST_PATH.exists():
+        return TunneldHealth(
+            status="not_installed",
+            detail="LaunchDaemon is not installed",
+            remedy="./quern tunneld install",
+        )
+
+    serving = await is_tunneld_running()
+    job = launchd_job()
+    state = job.get("state")
+    pid = int(job["pid"]) if job.get("pid", "").isdigit() else None
+    program = job.get("program")
+
+    if not serving:
+        if state == "running":
+            return TunneldHealth(
+                status="wedged", serving=False, launchd_state=state, pid=pid,
+                program=program,
+                detail=(
+                    f"alive (pid {pid}) but not serving on {TUNNELD_URL} — "
+                    "launchd sees a healthy job and will never restart it"
+                ),
+                remedy=(
+                    "sudo launchctl bootout system/" + TUNNELD_LABEL
+                    + " && sudo launchctl bootstrap system " + str(PLIST_PATH)
+                    + "  (not kickstart -k: it hangs launchctl)"
+                ),
+            )
+        return TunneldHealth(
+            status="stopped", serving=False, launchd_state=state, pid=pid,
+            program=program,
+            detail=f"installed but not running (launchd state: {state or 'unknown'})",
+            remedy="./quern tunneld install",
+        )
+
+    if not installed_plist_is_current():
+        return TunneldHealth(
+            status="stale_plist", serving=True, launchd_state=state, pid=pid,
+            program=program,
+            detail=f"serving, but the installed plist is outdated ({installed_plist_log_path()})",
+            remedy="./quern tunneld install",
+        )
+
+    # The daemon runs whatever the plist froze in, which is not necessarily the
+    # binary quern would resolve today -- a second pipx install, or a per-user
+    # one shadowing the shared path, drifts silently and is invisible from the
+    # HTTP side because the old one keeps serving perfectly well.
+    if program and Path(program) != binary:
+        return TunneldHealth(
+            status="binary_drift", serving=True, launchd_state=state, pid=pid,
+            program=program,
+            detail=f"serving from {program}, but quern resolves {binary}",
+            remedy="./quern tunneld install  (re-freezes the plist onto the resolved binary)",
+        )
+
+    return TunneldHealth(
+        status="healthy", serving=True, launchd_state=state, pid=pid, program=program,
+        detail=f"serving on {TUNNELD_URL} (pid {pid})",
+    )
 
 
 def generate_plist(binary_path: Path) -> str:

--- a/server/main.py
+++ b/server/main.py
@@ -1064,7 +1064,73 @@ def _cmd_doctor(args: argparse.Namespace) -> None:
 
     _report_python_deps(getattr(args, "fix", False))
     _report_external_tools(getattr(args, "fix", False))
+    _report_service_health(getattr(args, "fix", False))
     sys.exit(0)
+
+
+_HEALTH_MARKERS = {"healthy": "\u2713", "unsupported": "\u2013"}
+
+
+def _report_service_health(fix: bool = False) -> None:
+    """Whether tunneld and local capture are actually working, not just present.
+
+    Both fail in the same shape: the thing quern checks stays green while the
+    thing that matters stops working. `check_tools()` reports tunneld from an
+    HTTP probe that cannot separate "wedged" from "never started", and nothing
+    looked at the mitmproxy system extension at all -- so local capture reports
+    itself enabled while macOS runs an extension the installed wheel replaced.
+
+    tunneld is reported and never repaired here, deliberately. Recovery is
+    `bootout` + `bootstrap` and belongs to #73, which has a live wedged instance
+    being preserved for testing; a `--fix` that silently restarted it would
+    destroy the only real reproduction anyone has.
+    """
+    import asyncio
+
+    print()
+    print("Service health:")
+
+    try:
+        from server.device.tunneld import tunneld_health
+
+        health = asyncio.run(tunneld_health())
+    except Exception as exc:
+        print(f"  ? tunneld — could not be checked ({exc})")
+    else:
+        marker = _HEALTH_MARKERS.get(health.status, "\u2717")
+        print(f"  {marker} tunneld — {health.detail}")
+        if health.remedy:
+            print(f"      {health.remedy}")
+        if health.status == "wedged":
+            print("      not repaired automatically: see issue #73")
+
+    try:
+        from server.proxy.extension import extension_health
+
+        ext = extension_health()
+    except Exception as exc:
+        print(f"  ? local capture extension — could not be checked ({exc})")
+        return
+
+    marker = _HEALTH_MARKERS.get(ext.status, "\u2717")
+    print(f"  {marker} local capture extension — {ext.detail}")
+
+    if not ext.fixable:
+        if ext.remedy:
+            print(f"      {ext.remedy}")
+        return
+
+    if not fix:
+        print(f"      {ext.remedy}")
+        return
+
+    from server.proxy.extension import reinstall
+
+    ok, message = reinstall()
+    # "handed off to macOS", not "fixed": approval is a human step, so claiming
+    # success here would be reporting a repair that has not happened yet.
+    outcome = "\u2192" if ok else "\u2717"
+    print(f"      {outcome} {message}")
 
 
 def _report_external_tools(fix: bool = False) -> None:

--- a/server/proxy/extension.py
+++ b/server/proxy/extension.py
@@ -1,0 +1,224 @@
+"""Health of the mitmproxy macOS system extension used by local capture.
+
+Local capture routes a chosen process's traffic through mitmproxy without
+touching the system proxy, and it does that with a network system extension --
+`org.mitmproxy.macos-redirector.network-extension`, shipped as a tarred app
+inside the `mitmproxy_macos` wheel and activated by macOS on first use.
+
+The failure this exists to catch is quiet. The extension is approved once, by a
+human, in System Settings; the wheel that ships it is then upgraded underneath
+that approval by any ordinary dependency update. `mitmproxy-rs` moved to 0.12.11
+during the upgrade that prompted this module. When the shipped bundle version
+moves past the activated one, macOS keeps running the old extension and local
+capture goes on reporting itself as enabled while capturing nothing.
+
+Nothing else in quern looks at this: `proxy_status` reports the mitmdump process
+and the configured process list, both of which stay perfectly healthy while the
+extension underneath them is stale.
+"""
+
+from __future__ import annotations
+
+import plistlib
+import re
+import subprocess
+import sys
+import tarfile
+from dataclasses import dataclass
+from pathlib import Path
+
+BUNDLE_ID = "org.mitmproxy.macos-redirector.network-extension"
+APP_TAR_NAME = "Mitmproxy Redirector.app.tar"
+_EXTENSION_PLIST = (
+    "Mitmproxy Redirector.app/Contents/Library/SystemExtensions/"
+    f"{BUNDLE_ID}.systemextension/Contents/Info.plist"
+)
+
+# One row of `systemextensionsctl list`, which is tab-separated but pads
+# irregularly. Anchored on the bundle id so the surrounding columns can move.
+_ROW = re.compile(
+    r"(?P<bundle>[\w.\-]+)\s+\((?P<short>[^/)]+)/(?P<build>[^)]+)\)"
+    r".*?\[(?P<state>[^\]]+)\]"
+)
+
+
+@dataclass
+class ExtensionHealth:
+    """What state the redirector extension is in."""
+
+    status: str
+    """healthy | stale | not_activated | not_shipped | unsupported | unknown."""
+
+    detail: str
+    shipped: str | None = None
+    activated: str | None = None
+    activated_state: str | None = None
+    remedy: str | None = None
+
+    @property
+    def fixable(self) -> bool:
+        return self.status in ("stale", "not_activated")
+
+
+def _tar_path() -> Path | None:
+    """Where the shipped app tar lives, or None if mitmproxy_macos is absent."""
+    try:
+        import mitmproxy_macos
+    except Exception:
+        return None
+    location = getattr(mitmproxy_macos, "__file__", None)
+    if not location:
+        return None
+    candidate = Path(location).parent / APP_TAR_NAME
+    return candidate if candidate.is_file() else None
+
+
+def shipped_version() -> str | None:
+    """The extension version inside the installed wheel, as `short/build`.
+
+    Read straight out of the tar rather than from an extracted copy: extracting
+    is what activation does, and a health check must not have side effects.
+    """
+    tar_path = _tar_path()
+    if tar_path is None:
+        return None
+    try:
+        with tarfile.open(tar_path) as archive:
+            member = archive.extractfile(_EXTENSION_PLIST)
+            if member is None:
+                return None
+            info = plistlib.loads(member.read())
+    except (OSError, tarfile.TarError, plistlib.InvalidFileException, KeyError):
+        return None
+    short = info.get("CFBundleShortVersionString")
+    build = info.get("CFBundleVersion")
+    if not short or not build:
+        return None
+    return f"{short}/{build}"
+
+
+def activated_extension() -> tuple[str, str] | None:
+    """The activated `(version, state)` for the redirector, or None if absent.
+
+    `systemextensionsctl list` needs no privileges, which is what lets this run
+    inside read-only diagnostics without a sudo prompt.
+    """
+    try:
+        result = subprocess.run(
+            ["systemextensionsctl", "list"],
+            capture_output=True, text=True, timeout=20,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    for line in result.stdout.splitlines():
+        if BUNDLE_ID not in line:
+            continue
+        match = _ROW.search(line)
+        if match and match.group("bundle") == BUNDLE_ID:
+            return f"{match.group('short')}/{match.group('build')}", match.group("state")
+    return None
+
+
+def extension_health() -> ExtensionHealth:
+    """Whether the activated extension matches the one currently shipped."""
+    if sys.platform != "darwin":
+        return ExtensionHealth(
+            status="unsupported",
+            detail="local capture's system extension is macOS-only",
+        )
+
+    shipped = shipped_version()
+    if shipped is None:
+        return ExtensionHealth(
+            status="not_shipped",
+            detail="mitmproxy_macos is not installed, so local capture cannot run",
+            remedy="reinstall quern's dependencies: quern doctor --fix",
+        )
+
+    found = activated_extension()
+    if found is None:
+        return ExtensionHealth(
+            status="not_activated", shipped=shipped,
+            detail="not registered with macOS; local capture has never been approved",
+            remedy="approve it in System Settings > General > Login Items & Extensions",
+        )
+
+    activated, state = found
+    if activated != shipped:
+        return ExtensionHealth(
+            status="stale", shipped=shipped, activated=activated, activated_state=state,
+            detail=(
+                f"macOS is running {activated} but the installed wheel ships "
+                f"{shipped}; local capture reports enabled while capturing nothing"
+            ),
+            remedy="quern doctor --fix re-runs the shipped app to activate it",
+        )
+
+    if "activated" not in state or "enabled" not in state:
+        return ExtensionHealth(
+            status="not_activated", shipped=shipped, activated=activated,
+            activated_state=state,
+            detail=f"registered but not active (state: {state})",
+            remedy="enable it in System Settings > General > Login Items & Extensions",
+        )
+
+    return ExtensionHealth(
+        status="healthy", shipped=shipped, activated=activated, activated_state=state,
+        detail=f"{activated} activated and enabled",
+    )
+
+
+# Where the redirector app is unpacked. A stable location rather than a temp
+# directory: macOS keeps referring to the app bundle that registered an
+# extension, and unpacking to somewhere that gets cleaned up leaves the
+# activated extension pointing at nothing.
+INSTALL_DIR = Path.home() / ".quern" / "mitmproxy-redirector"
+
+
+def reinstall() -> tuple[bool, str]:
+    """Unpack the shipped redirector and run it so macOS activates it.
+
+    There is no Python API for this. `mitmproxy_macos` is a data-only package --
+    its `__init__.py` is empty -- and activation happens inside
+    `mitmproxy_rs.local.LocalRedirector` when capture starts. Running the app
+    directly is what mitmproxy itself relies on.
+
+    This cannot complete unattended: macOS shows an approval prompt in System
+    Settings and waits for a human. So the honest return is "handed off", not
+    "installed", and the caller must say so rather than reporting success.
+    """
+    tar_path = _tar_path()
+    if tar_path is None:
+        return False, "mitmproxy_macos is not installed; nothing to unpack"
+
+    try:
+        INSTALL_DIR.mkdir(parents=True, exist_ok=True)
+        with tarfile.open(tar_path) as archive:
+            # filter="data" refuses absolute paths, traversal and device nodes.
+            # The archive is trusted, but this runs against whatever version of
+            # the wheel happens to be installed, which is not a thing to assume.
+            archive.extractall(INSTALL_DIR, filter="data")
+    except (OSError, tarfile.TarError, ValueError) as exc:
+        return False, f"could not unpack the redirector: {exc}"
+
+    app = INSTALL_DIR / "Mitmproxy Redirector.app"
+    if not app.is_dir():
+        return False, f"unpacked, but {app.name} is not where it was expected"
+
+    try:
+        result = subprocess.run(
+            ["open", "-a", str(app)], capture_output=True, text=True, timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return False, f"could not launch the redirector: {exc}"
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        return False, f"launching the redirector failed: {detail}"
+
+    return True, (
+        f"launched {app.name}. macOS will ask you to approve the extension in "
+        "System Settings > General > Login Items & Extensions — it is not active "
+        "until you do. Re-run `quern doctor` afterwards to confirm."
+    )

--- a/server/proxy/extension.py
+++ b/server/proxy/extension.py
@@ -200,6 +200,18 @@ def reinstall() -> tuple[bool, str]:
             # The archive is trusted, but this runs against whatever version of
             # the wheel happens to be installed, which is not a thing to assume.
             archive.extractall(INSTALL_DIR, filter="data")
+    except TypeError as exc:
+        # `extractall(filter=...)` arrived in 3.12 and was backported only as far
+        # as 3.11.4, while requires-python allows >=3.11 -- so 3.11.0 to 3.11.3
+        # raise TypeError here. Refuse rather than retrying without the filter:
+        # the filter is the control that rejects absolute paths, traversal and
+        # device nodes, and dropping it to make an unattended repair succeed is
+        # the wrong trade. CI installs the newest 3.11.x, so nothing here would
+        # have caught this.
+        return False, (
+            f"cannot unpack the redirector safely on this interpreter ({exc}); "
+            "Python 3.11.4 or newer is required for filtered tar extraction"
+        )
     except (OSError, tarfile.TarError, ValueError) as exc:
         return False, f"could not unpack the redirector: {exc}"
 

--- a/tests/test_service_health.py
+++ b/tests/test_service_health.py
@@ -1,0 +1,521 @@
+"""Health checks for tunneld and the mitmproxy local-capture extension.
+
+Both services fail in the same shape, which is why they are tested together:
+the thing quern checks stays green while the thing that matters stops working.
+
+- `check_tools()` reports tunneld from an HTTP probe. A wedged daemon and one
+  that was never started both answer nothing, so the boolean cannot separate
+  "restart this" from "install this" (#73).
+- Nothing looked at the mitmproxy system extension at all. It is approved once
+  by a human and then upgraded underneath that approval by any dependency
+  update -- `mitmproxy-rs` moved to 0.12.11 during the upgrade that prompted
+  this -- after which local capture reports itself enabled while capturing
+  nothing.
+
+Neither check may prompt for a password: `launchctl print` on a system job and
+`systemextensionsctl list` are both readable unprivileged, and that is load
+bearing for a read-only `doctor`.
+"""
+
+from __future__ import annotations
+
+import plistlib
+import subprocess
+import tarfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from server.proxy import extension as ext_mod
+
+# --------------------------------------------------------------------------
+# launchctl parsing
+# --------------------------------------------------------------------------
+
+LAUNCHCTL_RUNNING = """\
+system/com.quern.tunneld = {
+\tactive count = 1
+\tpath = /Library/LaunchDaemons/com.quern.tunneld.plist
+\tstate = running
+\tprogram = /opt/pipx/venvs/pymobiledevice3/bin/pymobiledevice3
+\truns = 1
+\tpid = 825
+\tlast exit code = (never exited)
+\tendpoints = {
+\t\t"com.quern.tunneld" = {
+\t\t\tstate = active
+\t\t}
+\t}
+}
+"""
+
+
+@pytest.fixture
+def launchctl(monkeypatch):
+    """Make `launchctl print` return canned output."""
+    def install(stdout: str, returncode: int = 0):
+        def fake_run(cmd, **_kw):
+            assert cmd[:2] == ["launchctl", "print"], cmd
+            return SimpleNamespace(returncode=returncode, stdout=stdout, stderr="")
+
+        monkeypatch.setattr("server.device.tunneld.subprocess.run", fake_run)
+
+    return install
+
+
+def test_launchd_job_reads_the_scalar_fields(launchctl):
+    from server.device.tunneld import launchd_job
+
+    launchctl(LAUNCHCTL_RUNNING)
+    job = launchd_job()
+    assert job["state"] == "running"
+    assert job["pid"] == "825"
+    assert job["program"].endswith("pymobiledevice3")
+
+
+def test_nested_endpoint_state_does_not_overwrite_the_job_state(launchctl):
+    """`launchctl print` repeats `state = active` for every endpoint. Taking the
+    last match would report the job as active whatever it is really doing, and
+    the wedge signature depends entirely on this field."""
+    from server.device.tunneld import launchd_job
+
+    launchctl(LAUNCHCTL_RUNNING)
+    assert launchd_job()["state"] == "running"
+
+
+def test_launchd_job_is_empty_when_the_job_is_unknown(launchctl):
+    from server.device.tunneld import launchd_job
+
+    launchctl("Could not find service", returncode=113)
+    assert launchd_job() == {}
+
+
+def test_launchd_job_survives_launchctl_being_absent(monkeypatch):
+    def boom(*_a, **_k):
+        raise OSError("no launchctl")
+
+    monkeypatch.setattr("server.device.tunneld.subprocess.run", boom)
+    from server.device.tunneld import launchd_job
+
+    assert launchd_job() == {}
+
+
+# --------------------------------------------------------------------------
+# tunneld health
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tunneld_env(monkeypatch, tmp_path):
+    """Control every input tunneld_health consults."""
+    plist = tmp_path / "com.quern.tunneld.plist"
+    plist.write_text("<plist/>")
+    binary = tmp_path / "pymobiledevice3"
+    binary.write_text("#!/bin/sh\n")
+
+    state = {"serving": True, "job": {}, "plist_current": True,
+             "plist": plist, "binary": binary}
+
+    async def fake_running():
+        return state["serving"]
+
+    monkeypatch.setattr("server.device.tunneld.is_tunneld_running", fake_running)
+    monkeypatch.setattr("server.device.tunneld.launchd_job", lambda: state["job"])
+    monkeypatch.setattr(
+        "server.device.tunneld.installed_plist_is_current", lambda: state["plist_current"])
+    monkeypatch.setattr(
+        "server.device.tunneld.installed_plist_log_path", lambda: Path("/old/log"))
+    monkeypatch.setattr(
+        "server.device.tunneld.find_pymobiledevice3_binary", lambda: state["binary"])
+    monkeypatch.setattr("server.device.tunneld.PLIST_PATH", plist)
+    return state
+
+
+async def test_wedged_is_http_down_while_launchd_says_running(tunneld_env):
+    """The #73 signature. A daemon that holds no listener and never exits is
+    invisible to KeepAlive, so launchd reports it healthy forever."""
+    from server.device.tunneld import tunneld_health
+
+    tunneld_env["serving"] = False
+    tunneld_env["job"] = {"state": "running", "pid": "825"}
+
+    health = await tunneld_health()
+    assert health.status == "wedged"
+    assert health.pid == 825
+    assert not health.ok
+
+
+async def test_stopped_is_http_down_with_launchd_not_running(tunneld_env):
+    """Same HTTP symptom as wedged, opposite remedy — which is the entire
+    reason the launchd state is consulted at all."""
+    from server.device.tunneld import tunneld_health
+
+    tunneld_env["serving"] = False
+    tunneld_env["job"] = {}
+
+    health = await tunneld_health()
+    assert health.status == "stopped"
+
+
+async def test_the_wedged_remedy_avoids_kickstart(tunneld_env):
+    """`kickstart -k` sends SIGKILL and hung launchctl on macOS 15; the codebase
+    already says so in install_daemon. It must never be the advice."""
+    from server.device.tunneld import tunneld_health
+
+    tunneld_env["serving"] = False
+    tunneld_env["job"] = {"state": "running", "pid": "1"}
+
+    health = await tunneld_health()
+    assert "bootout" in health.remedy
+    assert "bootstrap" in health.remedy
+    assert "kickstart" not in health.remedy.split("(")[0]
+
+
+async def test_missing_binary_is_reported_before_anything_else(tunneld_env):
+    from server.device.tunneld import tunneld_health
+
+    tunneld_env["binary"] = None
+    health = await tunneld_health()
+    assert health.status == "no_binary"
+    assert "pipx install" in health.remedy
+
+
+async def test_missing_plist_reads_as_not_installed(tunneld_env, monkeypatch, tmp_path):
+    from server.device.tunneld import tunneld_health
+
+    monkeypatch.setattr("server.device.tunneld.PLIST_PATH", tmp_path / "absent.plist")
+    health = await tunneld_health()
+    assert health.status == "not_installed"
+
+
+async def test_a_serving_daemon_on_a_stale_plist_is_flagged(tunneld_env):
+    from server.device.tunneld import tunneld_health
+
+    tunneld_env["plist_current"] = False
+    tunneld_env["job"] = {"state": "running", "pid": "5"}
+    health = await tunneld_health()
+    assert health.status == "stale_plist"
+
+
+async def test_binary_drift_is_caught_while_serving(tunneld_env):
+    """The daemon runs whatever the plist froze in. A second pipx install
+    shadowing it drifts silently -- the old binary keeps serving perfectly, so
+    the HTTP probe stays green."""
+    from server.device.tunneld import tunneld_health
+
+    tunneld_env["job"] = {"state": "running", "pid": "5", "program": "/other/pymobiledevice3"}
+    health = await tunneld_health()
+    assert health.status == "binary_drift"
+    assert "/other/pymobiledevice3" in health.detail
+
+
+async def test_healthy_when_everything_lines_up(tunneld_env):
+    from server.device.tunneld import tunneld_health
+
+    tunneld_env["job"] = {
+        "state": "running", "pid": "825", "program": str(tunneld_env["binary"]),
+    }
+    health = await tunneld_health()
+    assert health.status == "healthy"
+    assert health.ok
+
+
+# --------------------------------------------------------------------------
+# The mitmproxy system extension
+# --------------------------------------------------------------------------
+
+# Real `systemextensionsctl list` output. Built by joining rather than written
+# as one literal so the tab-separated row stays under the line limit without
+# being reflowed into something the parser would never actually see.
+_SYSEXT_ROW = "\t".join([
+    "*", "*", "S8XHQB96PW",
+    f"{ext_mod.BUNDLE_ID} (2.0/1)", "network-extension", "[activated enabled]",
+])
+SYSEXT_LIST = "\n".join([
+    "2 extension(s)",
+    "--- com.apple.system_extension.network_extension",
+    "enabled\tactive\tteamID\tbundleID (version)\tname\t[state]",
+    _SYSEXT_ROW,
+]) + "\n"
+
+
+@pytest.fixture
+def sysext(monkeypatch):
+    def install(stdout: str, returncode: int = 0):
+        def fake_run(cmd, **_kw):
+            assert cmd[0] == "systemextensionsctl", cmd
+            return SimpleNamespace(returncode=returncode, stdout=stdout, stderr="")
+
+        monkeypatch.setattr(ext_mod.subprocess, "run", fake_run)
+
+    monkeypatch.setattr(ext_mod.sys, "platform", "darwin")
+    return install
+
+
+@pytest.fixture
+def shipped_tar(monkeypatch, tmp_path):
+    """A real tar with a real Info.plist, so the extraction path is exercised."""
+    def install(short: str, build: str):
+        plist_dir = tmp_path / "build" / Path(ext_mod._EXTENSION_PLIST).parent
+        plist_dir.mkdir(parents=True, exist_ok=True)
+        (plist_dir / "Info.plist").write_bytes(plistlib.dumps({
+            "CFBundleIdentifier": ext_mod.BUNDLE_ID,
+            "CFBundleShortVersionString": short,
+            "CFBundleVersion": build,
+        }))
+        tar_path = tmp_path / ext_mod.APP_TAR_NAME
+        with tarfile.open(tar_path, "w") as archive:
+            archive.add(tmp_path / "build" / "Mitmproxy Redirector.app",
+                        arcname="Mitmproxy Redirector.app")
+        monkeypatch.setattr(ext_mod, "_tar_path", lambda: tar_path)
+        return tar_path
+
+    return install
+
+
+def test_shipped_version_is_read_out_of_the_tar(shipped_tar):
+    shipped_tar("2.0", "1")
+    assert ext_mod.shipped_version() == "2.0/1"
+
+
+def test_reading_the_shipped_version_does_not_unpack_anything(shipped_tar, tmp_path):
+    """A health check must not have side effects; unpacking is what activation
+    does."""
+    shipped_tar("2.0", "1")
+    before = set(tmp_path.rglob("*"))
+    ext_mod.shipped_version()
+    assert set(tmp_path.rglob("*")) == before
+
+
+def test_activated_extension_is_parsed_without_privileges(sysext):
+    sysext(SYSEXT_LIST)
+    assert ext_mod.activated_extension() == ("2.0/1", "activated enabled")
+
+
+def test_no_matching_row_reads_as_not_activated(sysext, shipped_tar):
+    sysext("0 extension(s)\n")
+    shipped_tar("2.0", "1")
+    health = ext_mod.extension_health()
+    assert health.status == "not_activated"
+    assert "System Settings" in health.remedy
+
+
+def test_a_newer_shipped_version_is_stale(sysext, shipped_tar):
+    """The failure this module exists for: approved once, then upgraded
+    underneath the approval."""
+    sysext(SYSEXT_LIST)
+    shipped_tar("2.1", "3")
+
+    health = ext_mod.extension_health()
+    assert health.status == "stale"
+    assert health.activated == "2.0/1"
+    assert health.shipped == "2.1/3"
+    assert "capturing nothing" in health.detail
+    assert health.fixable
+
+
+def test_matching_versions_are_healthy(sysext, shipped_tar):
+    sysext(SYSEXT_LIST)
+    shipped_tar("2.0", "1")
+    health = ext_mod.extension_health()
+    assert health.status == "healthy"
+    assert not health.fixable
+
+
+def test_registered_but_disabled_is_not_healthy(sysext, shipped_tar):
+    sysext(SYSEXT_LIST.replace("[activated enabled]", "[activated waiting for user]"))
+    shipped_tar("2.0", "1")
+    health = ext_mod.extension_health()
+    assert health.status == "not_activated"
+
+
+def test_a_missing_wheel_is_reported_not_guessed(monkeypatch, sysext):
+    sysext(SYSEXT_LIST)
+    monkeypatch.setattr(ext_mod, "_tar_path", lambda: None)
+    health = ext_mod.extension_health()
+    assert health.status == "not_shipped"
+
+
+def test_non_macos_is_unsupported_rather_than_broken(monkeypatch):
+    monkeypatch.setattr(ext_mod.sys, "platform", "linux")
+    health = ext_mod.extension_health()
+    assert health.status == "unsupported"
+    assert not health.fixable
+
+
+def test_systemextensionsctl_failing_is_not_read_as_absent(sysext, shipped_tar):
+    """A non-zero exit means the question could not be asked.
+
+    The output is deliberately *not* empty: a failing command that still prints
+    a row is the case that distinguishes checking the exit code from merely
+    finding nothing to parse. An earlier version of this test passed an empty
+    string, so it went on passing with the exit-code check deleted.
+    """
+    sysext(SYSEXT_LIST, returncode=1)
+    shipped_tar("2.0", "1")
+    assert ext_mod.activated_extension() is None
+
+
+# --------------------------------------------------------------------------
+# Reinstall
+# --------------------------------------------------------------------------
+
+
+def test_reinstall_unpacks_and_launches_the_app(shipped_tar, monkeypatch, tmp_path):
+    shipped_tar("2.1", "3")
+    monkeypatch.setattr(ext_mod, "INSTALL_DIR", tmp_path / "installed")
+
+    opened = []
+
+    def fake_run(cmd, **_kw):
+        opened.append(cmd)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(ext_mod.subprocess, "run", fake_run)
+
+    ok, message = ext_mod.reinstall()
+    assert ok
+    assert opened[0][0] == "open"
+    assert (tmp_path / "installed" / "Mitmproxy Redirector.app").is_dir()
+    assert "System Settings" in message
+
+
+def test_reinstall_does_not_claim_the_extension_is_active(shipped_tar, monkeypatch, tmp_path):
+    """Approval is a human step in System Settings. Reporting success would be
+    claiming a repair that has not happened."""
+    shipped_tar("2.1", "3")
+    monkeypatch.setattr(ext_mod, "INSTALL_DIR", tmp_path / "installed")
+    monkeypatch.setattr(
+        ext_mod.subprocess, "run",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout="", stderr=""))
+
+    _ok, message = ext_mod.reinstall()
+    assert "System Settings" in message
+    assert "approve" in message.lower()
+
+
+def test_reinstall_reports_a_failed_launch(shipped_tar, monkeypatch, tmp_path):
+    shipped_tar("2.1", "3")
+    monkeypatch.setattr(ext_mod, "INSTALL_DIR", tmp_path / "installed")
+    monkeypatch.setattr(
+        ext_mod.subprocess, "run",
+        lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="nope"))
+
+    ok, message = ext_mod.reinstall()
+    assert not ok
+    assert "nope" in message
+
+
+def test_reinstall_without_the_wheel_fails_cleanly(monkeypatch):
+    monkeypatch.setattr(ext_mod, "_tar_path", lambda: None)
+    ok, message = ext_mod.reinstall()
+    assert not ok
+    assert "not installed" in message
+
+
+# --------------------------------------------------------------------------
+# What doctor does with all this
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def wedged_tunneld(monkeypatch):
+    """A wedged daemon and a stale extension, both reported through doctor."""
+    from server.device.tunneld import TunneldHealth
+
+    async def health():
+        return TunneldHealth(
+            status="wedged", serving=False, launchd_state="running", pid=825,
+            detail="alive (pid 825) but not serving",
+            remedy="sudo launchctl bootout system/com.quern.tunneld && ...",
+        )
+
+    monkeypatch.setattr("server.device.tunneld.tunneld_health", health)
+    monkeypatch.setattr(ext_mod, "extension_health", lambda: ext_mod.ExtensionHealth(
+        status="stale", shipped="2.1/3", activated="2.0/1",
+        detail="macOS is running 2.0/1 but the wheel ships 2.1/3",
+        remedy="quern doctor --fix re-runs the shipped app",
+    ))
+
+    reinstalled: list[bool] = []
+    monkeypatch.setattr(
+        ext_mod, "reinstall",
+        lambda: (reinstalled.append(True), (True, "launched it; approve in System Settings"))[1])
+    return reinstalled
+
+
+def test_doctor_never_restarts_a_wedged_tunneld(wedged_tunneld, monkeypatch, capsys):
+    """#73 keeps a live wedged instance deliberately, so detection schemes can
+    be tested against a real one. A --fix that silently restarted it would
+    destroy the only real reproduction anyone has."""
+    ran: list = []
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: ran.append(a))
+
+    from server.main import _report_service_health
+
+    _report_service_health(fix=True)
+    out = capsys.readouterr().out
+    assert "wedged" in out or "not serving" in out
+    assert "issue #73" in out
+    assert ran == [], "doctor must not run launchctl against tunneld"
+
+
+def test_doctor_shows_the_wedge_remedy_without_running_it(wedged_tunneld, capsys):
+    from server.main import _report_service_health
+
+    _report_service_health(fix=False)
+    out = capsys.readouterr().out
+    assert "bootout" in out
+    assert "not repaired automatically" in out
+
+
+def test_fix_reinstalls_a_stale_extension(wedged_tunneld, capsys):
+    from server.main import _report_service_health
+
+    _report_service_health(fix=True)
+    assert wedged_tunneld == [True], "--fix should have re-run the shipped app"
+    assert "approve in System Settings" in capsys.readouterr().out
+
+
+def test_without_fix_the_extension_is_only_reported(wedged_tunneld, capsys):
+    from server.main import _report_service_health
+
+    _report_service_health(fix=False)
+    assert wedged_tunneld == [], "reporting must not launch anything"
+    assert "re-runs the shipped app" in capsys.readouterr().out
+
+
+def test_a_healthy_extension_is_never_reinstalled(monkeypatch, capsys):
+    from server.device.tunneld import TunneldHealth
+
+    async def health():
+        return TunneldHealth(status="healthy", serving=True, detail="serving")
+
+    monkeypatch.setattr("server.device.tunneld.tunneld_health", health)
+    monkeypatch.setattr(ext_mod, "extension_health", lambda: ext_mod.ExtensionHealth(
+        status="healthy", shipped="2.0/1", activated="2.0/1", detail="2.0/1 activated"))
+
+    called: list = []
+    monkeypatch.setattr(ext_mod, "reinstall", lambda: called.append(True) or (True, ""))
+
+    from server.main import _report_service_health
+
+    _report_service_health(fix=True)
+    assert called == []
+
+
+def test_a_broken_check_does_not_break_doctor(monkeypatch, capsys):
+    async def boom():
+        raise RuntimeError("launchctl exploded")
+
+    monkeypatch.setattr("server.device.tunneld.tunneld_health", boom)
+    monkeypatch.setattr(ext_mod, "extension_health", lambda: (_ for _ in ()).throw(
+        RuntimeError("systemextensionsctl exploded")))
+
+    from server.main import _report_service_health
+
+    _report_service_health(fix=False)
+    out = capsys.readouterr().out
+    assert "could not be checked" in out
+    assert out.count("could not be checked") == 2, "each check must fail independently"

--- a/tests/test_service_health.py
+++ b/tests/test_service_health.py
@@ -519,3 +519,36 @@ def test_a_broken_check_does_not_break_doctor(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "could not be checked" in out
     assert out.count("could not be checked") == 2, "each check must fail independently"
+
+
+def test_reinstall_refuses_rather_than_unpacking_unfiltered(shipped_tar, monkeypatch, tmp_path):
+    """`extractall(filter=...)` arrived in 3.12 and was backported only to
+    3.11.4, but requires-python allows >=3.11 -- so 3.11.0 to 3.11.3 raise
+    TypeError here. It escaped `reinstall()` and aborted `quern doctor --fix`.
+
+    The filter is what rejects absolute paths, traversal and device nodes, so
+    the fix must not be to retry without it. CI installs the newest 3.11.x and
+    would never have caught this.
+    """
+    shipped_tar("2.1", "3")
+    monkeypatch.setattr(ext_mod, "INSTALL_DIR", tmp_path / "installed")
+
+    calls: list[dict] = []
+    real_extractall = tarfile.TarFile.extractall
+
+    def no_filter_support(self, *args, **kwargs):
+        calls.append(kwargs)
+        if "filter" in kwargs:
+            raise TypeError("extractall() got an unexpected keyword argument 'filter'")
+        return real_extractall(self, *args, **kwargs)
+
+    monkeypatch.setattr(tarfile.TarFile, "extractall", no_filter_support)
+
+    opened = []
+    monkeypatch.setattr(ext_mod.subprocess, "run", lambda *a, **k: opened.append(a))
+
+    ok, message = ext_mod.reinstall()
+    assert ok is False
+    assert "3.11.4" in message
+    assert len(calls) == 1, "must not retry extraction without the filter"
+    assert opened == [], "nothing should be launched after a refused unpack"


### PR DESCRIPTION
> **Stacked on #107** (which is stacked on #106). Base is
> `feat/external-tool-updates`, so this diff shows only its own changes. Merge
> #106 → #107 → this.

## The shared failure shape

Both services fail the same way, which is why they are one PR: **the thing quern
checks stays green while the thing that matters stops working.**

## tunneld

Reported from an HTTP probe surfaced as one boolean. That *sees* a wedge — #73
confirms doctor showed `✗` on the live wedged instance — but cannot separate it
from a daemon that was never started. Identical symptom, opposite remedy.

A failed device pairing leaves the daemon alive and not serving: it holds no
listener and never exits, so `KeepAlive` never fires and launchd reports it
healthy indefinitely. `tunneld_health()` pairs the probe with the launchd job
state, which is the signature that tells those apart:

| status | meaning |
|---|---|
| `wedged` | HTTP down, launchd says `running` — the #73 signature |
| `stopped` | HTTP down, launchd not running |
| `stale_plist` | serving, but the installed plist is outdated |
| `binary_drift` | serving from the binary the plist froze in, while quern now resolves another |
| `no_binary` / `not_installed` | prerequisites missing |

`binary_drift` is not in #73 and is invisible over HTTP, because the old binary
keeps answering perfectly well. Related to the per-user vs shared pipx path
raised under that issue's "Related".

## The mitmproxy local-capture extension

No check existed **at all**. The extension is approved once by a human in System
Settings and then upgraded underneath that approval by any ordinary dependency
update — `mitmproxy-rs` moved to 0.12.11 during the upgrade in #106. When the
shipped bundle version passes the activated one, macOS keeps running the old
extension and **local capture reports itself enabled while capturing nothing**.

Nothing else looks at this: `proxy_status` reports the mitmdump process and the
configured process list, both of which stay healthy throughout.

Verified by hand before writing the code:

```
shipped   (venv tar): org.mitmproxy.macos-redirector.network-extension  2.0/1
activated (macOS)   : org.mitmproxy.macos-redirector.network-extension (2.0/1)  [activated enabled]
```

## Both checks are unprivileged

`launchctl print` on a system-domain job and `systemextensionsctl list` are both
readable without sudo (verified on macOS 26), which is what lets read-only
diagnostics use them with no password prompt.

Reading the shipped version parses the `Info.plist` **out of the wheel's tar
without unpacking** — unpacking is what activation does, and a health check must
not have side effects. A test asserts nothing appears on disk.

## What `--fix` does and does not do

**tunneld is reported and never repaired.** Recovery is `bootout` + `bootstrap`
and belongs to #73, which has a live wedged instance being deliberately
preserved for testing; a `--fix` that silently restarted it would destroy the
only real reproduction anyone has. A test asserts doctor runs **no `launchctl`
at all**.

**`--fix` does re-run the shipped redirector app** for a stale extension, and
reports that as *handed off*, not fixed — approval is a human step in System
Settings, so claiming success would be claiming a repair that has not happened.

## Reviewer note: what is not verified

`reinstall()` has **never driven a real macOS activation prompt.** I could not
produce a stale extension without disrupting a working setup, so that path is
unit-tested only. Detection I verified by hand against `systemextensionsctl`
first. The blast radius is one `open` call on an app bundle extracted with
`filter="data"`, and it is opt-in behind `--fix`.

## Related: a correction filed on #73

That issue states *"Quern's own code already avoids `kickstart -k`."* It does
not — `install_daemon` (262) and `uninstall_daemon` (334) use `bootout`, but
`_restart_daemon` (411), reached by `./quern tunneld restart`, uses exactly
`kickstart -k`, the command the comment four hundred lines away warns *"hung
launchctl on macOS 15"*. Filed as a comment on #73, since wiring remediation to
`_restart_daemon` would inherit the hang while looking compliant. Not changed
here — that is #73's to fix.

## Verification

- **1808 passed**, ruff clean.
- Live: both report healthy on this machine, and `--fix` correctly did nothing —
  the install directory was never created.
- Mutation-tested: nested `state = active` overwriting the job state, `wedged`
  collapsing into `stopped`, a stale extension reading as healthy, a failing
  `systemextensionsctl` reading as "not registered", `--fix` restarting tunneld,
  and reporting silently reinstalling — each caught. One initially survived
  because the test passed empty stdout; it now uses a failing command that still
  prints a row.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added service-health diagnostics to `quern doctor` for tunneld and the local capture extension.
  * Reports service status, installation issues, stale configurations, binary mismatches, and available remediation steps.
  * Supports optional repair of fixable capture-extension issues with `quern doctor --fix`; manual macOS approval may still be required.
  * Identifies unresponsive tunneld instances without restarting them automatically.

* **Documentation**
  * Updated the CLI reference with the expanded service-health checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->