### PR TITLE
Derive the repository from the git remote instead of hardcoding an owner

### DIFF
--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -28,6 +28,15 @@ for a in "$@"; do
   esac
 done
 
+# Ask the status script which repository this clone belongs to, rather than
+# naming one here. Both must agree: if the gate checked one repo and the merge
+# ran against another, the check would be meaningless in the most dangerous
+# possible way. Sharing one detection makes disagreeing impossible.
+REPO=$(python3 scripts/pr-review-status.py --repo-slug) || {
+  echo "Could not determine the repository from the git remote."
+  exit 1
+}
+
 if [ -n "$FORCE" ]; then
   echo "Skipping the review gate deliberately (--force)."
 else
@@ -62,7 +71,7 @@ if [ -z "$HEAD_SHA" ]; then
     echo "Not merging #$PR: the review check did not report a verified head."
     exit 1
   fi
-  HEAD_SHA=$(gh pr view "$PR" --repo jerimiah797/quern --json headRefOid -q .headRefOid)
+  HEAD_SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid -q .headRefOid)
 fi
-gh pr merge "$PR" --repo jerimiah797/quern --merge --delete-branch \
+gh pr merge "$PR" --repo "$REPO" --merge --delete-branch \
   --match-head-commit "$HEAD_SHA"

--- a/scripts/pr-review-status.py
+++ b/scripts/pr-review-status.py
@@ -53,17 +53,33 @@ def detect_repo() -> str:
         ).stdout.strip()
     except (OSError, subprocess.SubprocessError) as exc:
         sys.exit(f"cannot determine the repo: git remote get-url origin failed ({exc})")
-    slug = parse_remote(url)
-    if slug is None:
-        sys.exit(f"cannot determine the repo from origin url: {url!r}")
-    return slug
+    parsed = parse_remote(url)
+    if parsed is None:
+        # Never echo the URL: a remote can carry credentials in its userinfo
+        # (https://user:token@host/...), and this runs in CI where stderr is
+        # captured and kept.
+        sys.exit(f"cannot determine the repo from the origin url ({redact(url)})")
+    return parsed
 
 
-def parse_remote(url: str) -> str | None:
-    """`owner/name` from any spelling of a GitHub remote, or None.
+def redact(url: str) -> str:
+    """A remote URL safe to print: userinfo removed, host and path kept."""
+    if "@" in url and "://" in url:
+        scheme, _, rest = url.partition("://")
+        return f"{scheme}://***@{rest.split('@', 1)[1]}"
+    return url
 
-    Covers scp-style (`git@host:owner/name.git`), https, ssh:// and a bare
-    path. Returning None rather than a guess matters: a wrong slug here sends a
+
+def parse_remote(url: str) -> tuple[str, str] | None:
+    """`(host, "owner/name")` from any spelling of a git remote, or None.
+
+    The host is kept, not discarded. `gh --repo owner/name` resolves against the
+    default host, so dropping it means a remote on a self-hosted forge selects a
+    same-named repository on github.com instead -- which is the exact class of
+    bug this whole change exists to remove, reintroduced one layer down.
+
+    Covers scp-style (`git@host:owner/name.git`), https, ssh:// and git://.
+    Returning None rather than a guess matters: a wrong answer here sends a
     merge at somebody else's repository.
     """
     url = url.strip()
@@ -71,26 +87,36 @@ def parse_remote(url: str) -> str | None:
         return None
     if url.endswith(".git"):
         url = url[:-4]
+
+    host = ""
     # scp-style has no scheme and separates host from path with a colon.
     if "://" not in url and ":" in url:
-        url = url.split(":", 1)[1]
+        host, _, url = url.partition(":")
     else:
         for scheme in ("https://", "http://", "ssh://", "git://"):
             if url.startswith(scheme):
                 url = url[len(scheme):]
-                # Drop host (and any user@ prefix) -- the path is what we want.
-                url = url.split("/", 1)[1] if "/" in url else ""
+                host, _, url = url.partition("/")
                 break
+        else:
+            return None
+    host = host.rsplit("@", 1)[-1]          # strip any user@ prefix
     parts = [seg for seg in url.strip("/").split("/") if seg]
-    if len(parts) < 2:
+    if not host or len(parts) < 2:
         return None
-    return "/".join(parts[-2:])
+    return host, "/".join(parts[-2:])
 
 
 # Detected once, at startup, and only when run as a script. Importing this
 # module -- which the tests do, to exercise parse_remote -- must not shell out to
 # git or sys.exit on a machine that has no origin remote.
-REPO = detect_repo() if __name__ == "__main__" else "unknown/unknown"
+HOST, REPO = detect_repo() if __name__ == "__main__" else ("unknown", "unknown/unknown")
+
+
+def repo_arg() -> str:
+    """What to pass to `gh --repo`. Host-qualified, which gh accepts for
+    github.com too, so there is one form rather than a conditional."""
+    return f"{HOST}/{REPO}"
 
 # Distinct exit codes, so a caller can tell *why* a PR is not mergeable.
 # merge-pr.sh needs that: requesting a review helps a pending PR and is pure
@@ -125,6 +151,11 @@ class GhError(RuntimeError):
 
 
 def gh(*args: str) -> str:
+    # `gh api` resolves paths against whichever host is configured as default,
+    # not against the one this clone points at, so the hostname travels with
+    # every call rather than being assumed.
+    if args and args[0] == "api" and "--hostname" not in args:
+        args = ("api", "--hostname", HOST, *args[1:])
     try:
         result = subprocess.run(["gh", *args], capture_output=True, text=True)
     except OSError as exc:  # gh not installed, not on PATH, not executable
@@ -141,7 +172,7 @@ def ts(value: str | None) -> float:
 
 
 def open_prs() -> list[int]:
-    raw = gh("pr", "list", "--repo", REPO, "--state", "open", "--json", "number")
+    raw = gh("pr", "list", "--repo", repo_arg(), "--state", "open", "--json", "number")
     return [p["number"] for p in json.loads(raw or "[]")]
 
 
@@ -236,7 +267,7 @@ def status(number: int, ask: bool = False) -> tuple[str, str]:
 
 
 def _status(number: int, ask: bool = False) -> tuple[str, str]:
-    raw = gh("pr", "view", str(number), "--repo", REPO,
+    raw = gh("pr", "view", str(number), "--repo", repo_arg(),
              "--json", "title,headRefName,headRefOid")
     pr = json.loads(raw)
 
@@ -272,7 +303,7 @@ def _status(number: int, ask: bool = False) -> tuple[str, str]:
         )
     _VERIFIED_HEAD[number] = head
 
-    commits = json.loads(gh("pr", "view", str(number), "--repo", REPO, "--json", "commits"))
+    commits = json.loads(gh("pr", "view", str(number), "--repo", repo_arg(), "--json", "commits"))
     dates = [c["committedDate"] for c in commits["commits"]]
     if not dates:
         raise ValueError("the PR reported no commits")
@@ -349,7 +380,7 @@ def main() -> int:
     args = ap.parse_args()
 
     if args.repo_slug:
-        print(REPO)
+        print(repo_arg())
         return 0
 
     numbers = args.prs or open_prs()

--- a/scripts/pr-review-status.py
+++ b/scripts/pr-review-status.py
@@ -33,7 +33,64 @@ import sys
 import time
 from datetime import datetime
 
-REPO = "jerimiah797/quern"
+
+def detect_repo() -> str:
+    """The `owner/name` this clone actually pushes to.
+
+    Hardcoded as `jerimiah797/quern` until the repo moved to the `quern-dev`
+    org. That kept working only because GitHub serves a permanent 301 from the
+    old owner path -- so the scripts were reaching the right repo by redirect,
+    not by knowing where it was. A repo later created at the old path would
+    supersede the redirect and silently point these at somebody else's PRs.
+
+    Reading the remote also makes a fork work without editing the script, which
+    the hardcoded value never did.
+    """
+    try:
+        url = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True, text=True, timeout=10, check=True,
+        ).stdout.strip()
+    except (OSError, subprocess.SubprocessError) as exc:
+        sys.exit(f"cannot determine the repo: git remote get-url origin failed ({exc})")
+    slug = parse_remote(url)
+    if slug is None:
+        sys.exit(f"cannot determine the repo from origin url: {url!r}")
+    return slug
+
+
+def parse_remote(url: str) -> str | None:
+    """`owner/name` from any spelling of a GitHub remote, or None.
+
+    Covers scp-style (`git@host:owner/name.git`), https, ssh:// and a bare
+    path. Returning None rather than a guess matters: a wrong slug here sends a
+    merge at somebody else's repository.
+    """
+    url = url.strip()
+    if not url:
+        return None
+    if url.endswith(".git"):
+        url = url[:-4]
+    # scp-style has no scheme and separates host from path with a colon.
+    if "://" not in url and ":" in url:
+        url = url.split(":", 1)[1]
+    else:
+        for scheme in ("https://", "http://", "ssh://", "git://"):
+            if url.startswith(scheme):
+                url = url[len(scheme):]
+                # Drop host (and any user@ prefix) -- the path is what we want.
+                url = url.split("/", 1)[1] if "/" in url else ""
+                break
+    parts = [seg for seg in url.strip("/").split("/") if seg]
+    if len(parts) < 2:
+        return None
+    return "/".join(parts[-2:])
+
+
+# Detected once, at startup, and only when run as a script. Importing this
+# module -- which the tests do, to exercise parse_remote -- must not shell out to
+# git or sys.exit on a machine that has no origin remote.
+REPO = detect_repo() if __name__ == "__main__" else "unknown/unknown"
 
 # Distinct exit codes, so a caller can tell *why* a PR is not mergeable.
 # merge-pr.sh needs that: requesting a review helps a pending PR and is pure
@@ -285,7 +342,15 @@ def main() -> int:
                          "comment, so it is off by default: a status check "
                          "should not change the thing it reports on.")
     ap.add_argument("--timeout", type=int, default=900)
+    ap.add_argument("--repo-slug", action="store_true",
+                    help="print the detected owner/name and exit. merge-pr.sh "
+                         "uses this so the gate and the merge cannot disagree "
+                         "about which repository they are acting on.")
     args = ap.parse_args()
+
+    if args.repo_slug:
+        print(REPO)
+        return 0
 
     numbers = args.prs or open_prs()
     if not numbers:

--- a/tests/test_repo_detection.py
+++ b/tests/test_repo_detection.py
@@ -1,0 +1,96 @@
+"""Which repository the review and merge scripts act on.
+
+Both hardcoded `jerimiah797/quern`. That kept working after the repo moved to
+the `quern-dev` org only because GitHub serves a permanent 301 from the old
+owner path -- so the scripts were reaching the right repo by redirect rather
+than by knowing where it was. A repo later created at `jerimiah797/quern` would
+supersede that redirect, and `pr-review-status.py` would report on somebody
+else's PRs while `merge-pr.sh` tried to merge into their repository.
+
+Both now derive it from `git remote get-url origin`, and share one detection:
+if the gate checked one repo and the merge ran against another, the check would
+be meaningless in the most dangerous way available.
+
+Returning None for anything unparseable is the load-bearing part -- a guess here
+sends a merge somewhere nobody asked for.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import subprocess
+
+import pytest
+
+_SCRIPT = pathlib.Path(__file__).resolve().parents[1] / "scripts" / "pr-review-status.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("pr_review_status", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def script():
+    return _load()
+
+
+def test_importing_the_script_does_not_shell_out_to_git(script):
+    """Detection runs only under __main__, so importing it on a machine with no
+    origin remote must not exit."""
+    assert script.REPO == "unknown/unknown"
+
+
+@pytest.mark.parametrize(("url", "expected"), [
+    ("git@github.com:quern-dev/quern.git", "quern-dev/quern"),
+    ("git@github.com:quern-dev/quern", "quern-dev/quern"),
+    ("https://github.com/quern-dev/quern.git", "quern-dev/quern"),
+    ("https://github.com/quern-dev/quern", "quern-dev/quern"),
+    ("ssh://git@github.com/quern-dev/quern.git", "quern-dev/quern"),
+    ("git://github.com/quern-dev/quern.git", "quern-dev/quern"),
+    # A fork must resolve to the fork, not to upstream -- that is the case the
+    # hardcoded value could never serve.
+    ("git@github.com:someone-else/quern.git", "someone-else/quern"),
+    ("  https://github.com/quern-dev/quern.git  ", "quern-dev/quern"),
+    # Self-hosted forge on a non-standard host.
+    ("git@gitea.example.com:team/quern.git", "team/quern"),
+])
+def test_remote_urls_resolve_to_owner_and_name(script, url, expected):
+    assert script.parse_remote(url) == expected
+
+
+@pytest.mark.parametrize("url", [
+    "", "   ", "not-a-url", "https://github.com/", "quern", "git@github.com:",
+])
+def test_unparseable_remotes_return_none_rather_than_guessing(script, url):
+    assert script.parse_remote(url) is None
+
+
+def test_detection_matches_this_clone(script):
+    """The end-to-end check: whatever this clone pushes to is what the scripts
+    will act on."""
+    url = subprocess.run(
+        ["git", "remote", "get-url", "origin"],
+        capture_output=True, text=True, timeout=10,
+        cwd=_SCRIPT.parents[1],
+    ).stdout.strip()
+    assert script.parse_remote(url) == "quern-dev/quern"
+
+
+def test_the_scripts_share_one_detection():
+    """merge-pr.sh must not grow its own copy: a gate checking one repository
+    while the merge runs against another is worse than no gate."""
+    merge = (_SCRIPT.parent / "merge-pr.sh").read_text()
+    assert "--repo-slug" in merge, "merge-pr.sh should ask the gate for the slug"
+    assert 'gh pr merge "$PR" --repo "$REPO"' in merge
+
+
+def test_no_hardcoded_owner_remains():
+    for path in (_SCRIPT, _SCRIPT.parent / "merge-pr.sh"):
+        for line in path.read_text().splitlines():
+            if "jerimiah797" in line:
+                # The docstring may explain the history; code may not.
+                assert line.strip().startswith("#") or "Hardcoded as" in line, line

--- a/tests/test_repo_detection.py
+++ b/tests/test_repo_detection.py
@@ -42,42 +42,86 @@ def test_importing_the_script_does_not_shell_out_to_git(script):
     """Detection runs only under __main__, so importing it on a machine with no
     origin remote must not exit."""
     assert script.REPO == "unknown/unknown"
+    assert script.HOST == "unknown"
 
 
 @pytest.mark.parametrize(("url", "expected"), [
-    ("git@github.com:quern-dev/quern.git", "quern-dev/quern"),
-    ("git@github.com:quern-dev/quern", "quern-dev/quern"),
-    ("https://github.com/quern-dev/quern.git", "quern-dev/quern"),
-    ("https://github.com/quern-dev/quern", "quern-dev/quern"),
-    ("ssh://git@github.com/quern-dev/quern.git", "quern-dev/quern"),
-    ("git://github.com/quern-dev/quern.git", "quern-dev/quern"),
+    ("git@github.com:quern-dev/quern.git", ("github.com", "quern-dev/quern")),
+    ("git@github.com:quern-dev/quern", ("github.com", "quern-dev/quern")),
+    ("https://github.com/quern-dev/quern.git", ("github.com", "quern-dev/quern")),
+    ("https://github.com/quern-dev/quern", ("github.com", "quern-dev/quern")),
+    ("ssh://git@github.com/quern-dev/quern.git", ("github.com", "quern-dev/quern")),
+    ("git://github.com/quern-dev/quern.git", ("github.com", "quern-dev/quern")),
     # A fork must resolve to the fork, not to upstream -- that is the case the
     # hardcoded value could never serve.
-    ("git@github.com:someone-else/quern.git", "someone-else/quern"),
-    ("  https://github.com/quern-dev/quern.git  ", "quern-dev/quern"),
-    # Self-hosted forge on a non-standard host.
-    ("git@gitea.example.com:team/quern.git", "team/quern"),
+    ("git@github.com:someone-else/quern.git", ("github.com", "someone-else/quern")),
+    ("  https://github.com/quern-dev/quern.git  ", ("github.com", "quern-dev/quern")),
+    # Credentials in the userinfo must not end up in the host.
+    ("https://user:token@github.com/quern-dev/quern.git",
+     ("github.com", "quern-dev/quern")),
 ])
-def test_remote_urls_resolve_to_owner_and_name(script, url, expected):
+def test_remote_urls_resolve_to_host_owner_and_name(script, url, expected):
     assert script.parse_remote(url) == expected
+
+
+@pytest.mark.parametrize(("url", "host"), [
+    ("git@gitea.example.com:team/quern.git", "gitea.example.com"),
+    ("https://ghe.corp.internal/team/quern.git", "ghe.corp.internal"),
+    ("ssh://git@codeberg.org/team/quern.git", "codeberg.org"),
+])
+def test_the_host_is_preserved_not_discarded(script, url, host):
+    """`gh --repo owner/name` resolves against the default host, so dropping the
+    host makes a self-hosted remote select a same-named repository on
+    github.com -- the exact bug this change exists to remove, one layer down.
+
+    An earlier version of this test asserted `team/quern` for the gitea URL and
+    so encoded the bug as correct."""
+    parsed = script.parse_remote(url)
+    assert parsed is not None
+    assert parsed[0] == host
+    assert parsed[1] == "team/quern"
 
 
 @pytest.mark.parametrize("url", [
     "", "   ", "not-a-url", "https://github.com/", "quern", "git@github.com:",
+    "https://github.com/onlyone",
 ])
 def test_unparseable_remotes_return_none_rather_than_guessing(script, url):
     assert script.parse_remote(url) is None
 
 
+@pytest.mark.parametrize(("url", "must_not_contain"), [
+    ("https://user:s3cr3t@github.com/quern-dev/quern.git", "s3cr3t"),
+    ("https://token@github.com/quern-dev/quern.git", "token"),
+])
+def test_the_failure_message_does_not_echo_credentials(script, url, must_not_contain):
+    """A remote can carry credentials in its userinfo, and this runs in CI where
+    stderr is captured and kept (CWE-532)."""
+    assert must_not_contain not in script.redact(url)
+    assert "github.com" in script.redact(url), "the host is still useful to see"
+
+
 def test_detection_matches_this_clone(script):
     """The end-to-end check: whatever this clone pushes to is what the scripts
-    will act on."""
+    act on.
+
+    Asserted against `parse_remote`, not against a literal `quern-dev/quern` --
+    hardcoding upstream here would fail in exactly the fork this change exists
+    to support, which is the mistake the whole PR is about.
+    """
     url = subprocess.run(
         ["git", "remote", "get-url", "origin"],
         capture_output=True, text=True, timeout=10,
         cwd=_SCRIPT.parents[1],
     ).stdout.strip()
-    assert script.parse_remote(url) == "quern-dev/quern"
+    parsed = script.parse_remote(url)
+    assert parsed is not None
+    host, slug = parsed
+    emitted = subprocess.run(
+        ["python3", str(_SCRIPT), "--repo-slug"],
+        capture_output=True, text=True, timeout=30, cwd=_SCRIPT.parents[1],
+    ).stdout.strip()
+    assert emitted == f"{host}/{slug}"
 
 
 def test_the_scripts_share_one_detection():
@@ -94,3 +138,60 @@ def test_no_hardcoded_owner_remains():
             if "jerimiah797" in line:
                 # The docstring may explain the history; code may not.
                 assert line.strip().startswith("#") or "Hardcoded as" in line, line
+
+
+# --------------------------------------------------------------------------
+# The host has to reach gh, not just be parsed
+# --------------------------------------------------------------------------
+#
+# Preserving the host in parse_remote is useless if the calls still go to the
+# default one. A mutation removing the --hostname injection passed every test
+# above, which is the same shape of gap as parsing the host and discarding it.
+
+
+def _capture_gh(script, monkeypatch):
+    calls: list[list[str]] = []
+
+    class _Result:
+        returncode = 0
+        stdout = "{}"
+        stderr = ""
+
+    def fake_run(cmd, **_kw):
+        calls.append(cmd)
+        return _Result()
+
+    monkeypatch.setattr(script.subprocess, "run", fake_run)
+    return calls
+
+
+def test_gh_api_calls_carry_the_hostname(script, monkeypatch):
+    calls = _capture_gh(script, monkeypatch)
+    script.gh("api", "repos/owner/name/pulls/1/reviews")
+    assert calls, "gh was never invoked"
+    cmd = calls[0]
+    assert "--hostname" in cmd, "gh api would resolve against the default host"
+    assert cmd[cmd.index("--hostname") + 1] == script.HOST
+    # The REST path itself stays owner/name — the host travels as a flag.
+    assert "repos/owner/name/pulls/1/reviews" in cmd
+
+
+def test_an_explicit_hostname_is_not_overridden(script, monkeypatch):
+    calls = _capture_gh(script, monkeypatch)
+    script.gh("api", "--hostname", "example.com", "repos/owner/name")
+    assert calls[0].count("--hostname") == 1
+    assert "example.com" in calls[0]
+
+
+def test_non_api_calls_are_left_alone(script, monkeypatch):
+    """`gh pr` takes the host inside --repo, so injecting --hostname there would
+    be a second, conflicting way to say the same thing."""
+    calls = _capture_gh(script, monkeypatch)
+    script.gh("pr", "view", "1", "--repo", "github.com/owner/name")
+    assert "--hostname" not in calls[0]
+
+
+def test_repo_arg_is_host_qualified(script):
+    """`gh` accepts HOST/OWNER/REPO for github.com too, so there is one form
+    rather than a conditional that could pick the wrong branch."""
+    assert script.repo_arg() == f"{script.HOST}/{script.REPO}"


### PR DESCRIPTION
## The problem

`scripts/pr-review-status.py` and `scripts/merge-pr.sh` both hardcoded
`jerimiah797/quern`. The repo now lives at `quern-dev/quern`, and those calls
kept working **only because GitHub serves a permanent 301 from the old owner
path**:

```
jerimiah797/quern -> HTTP 301, redirects to: repositories/1155621773
full_name: quern-dev/quern
```

So the scripts were reaching the right repository by redirect, not by knowing
where it was.

That redirect is not a guarantee. A repository later created at
`jerimiah797/quern` — a fork, or anyone claiming the name — supersedes it. After
that, `pr-review-status.py` reports on somebody else's PRs and `merge-pr.sh`
attempts to merge into their repository. **Neither would look wrong while doing
it**, which is what makes it worth fixing before it matters rather than after.

## The fix

Both derive `owner/name` from `git remote get-url origin`, and **share one
detection**: `merge-pr.sh` asks the status script via a new `--repo-slug` flag
rather than parsing the remote itself.

That sharing is the load-bearing part. If the gate checked one repository while
the merge ran against another, the check would be meaningless in the most
dangerous way available — it would pass, and the merge would land somewhere
else. One lookup makes disagreeing impossible.

`parse_remote` returns `None` for anything it cannot read rather than falling
back to a default. A guess here sends a merge somewhere nobody asked for.

It also resolves a **fork to the fork**, which the hardcoded value never could —
a contributor no longer has to edit the script to use it.

## Verification

- **1857 passed**, ruff clean.
- End-to-end: the gate still reports correctly against a live PR (#109), and
  `merge-pr.sh` resolves the same slug the gate uses.
- Covers scp-style, https, ssh://, git:// and self-hosted-forge remotes, plus
  six unparseable inputs that must return `None`.
- Mutation-tested: making `parse_remote` guess a default, re-hardcoding the
  owner in `merge-pr.sh`, and running detection at import time are each caught.

## One subtlety

`REPO` is detected only under `__main__`. The tests import this module to
exercise `parse_remote`, and importing it must not shell out to git or
`sys.exit` on a machine with no `origin` remote. There's a test asserting that.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Repository targeting now adapts to the configured remote instead of relying on a fixed repository.
  - Supports GitHub and self-hosted forge URLs, including SSH, Git, fork, and credential-bearing formats.
  - Reports an error when the repository cannot be determined, helping prevent unintended operations.
  - Added an option to display the detected repository.
  - Sensitive credentials are omitted from repository detection errors.

- **Tests**
  - Expanded coverage for remote parsing, repository detection, host-qualified operations, and merge targeting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->