### PR TITLE
Bump to 0.15.0-beta.1, and guard the two places that declare it

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "quern-debug-mcp",
-  "version": "0.14.1",
-  "description": "MCP server for Quern — thin wrapper over HTTP API",
+  "version": "0.15.0-beta.1",
+  "description": "MCP server for Quern \u2014 thin wrapper over HTTP API",
   "type": "module",
   "main": "dist/launcher.cjs",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quern-debug-server"
-version = "0.14.1"
+version = "0.15.0-beta.1"
 description = "Debug log capture and AI context server"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -51,8 +51,37 @@ def test_the_server_reports_the_declared_version():
     assert get_version() == _pyproject_version()
 
 
+# A SemVer numeric identifier: no leading zeroes. `\d+` would accept `01.2.3`
+# and `1.2.3-beta.01`, which npm rejects as invalid SemVer -- so the guard
+# against a typo in this field would itself have admitted one.
+_NUM = r"(?:0|[1-9]\d*)"
+_SEMVER = re.compile(rf"{_NUM}\.{_NUM}\.{_NUM}(?:-[a-z]+\.{_NUM})?$")
+
+
 def test_the_version_is_a_release_shape():
-    """Guards a typo in the one field a release is cut from. Accepts
-    `1.2.3` and prerelease suffixes like `1.2.3-beta.1`."""
+    """Guards a typo in the one field a release is cut from."""
     version = _pyproject_version()
-    assert re.fullmatch(r"\d+\.\d+\.\d+(?:-[a-z]+\.\d+)?", version), version
+    assert _SEMVER.fullmatch(version), version
+
+
+@pytest.mark.parametrize("version", [
+    "0.15.0", "1.2.3", "0.15.0-beta.1", "10.0.0-rc.12", "0.0.1",
+])
+def test_valid_versions_are_accepted(version):
+    assert _SEMVER.fullmatch(version)
+
+
+@pytest.mark.parametrize("version", [
+    "01.2.3",           # leading zero in major
+    "1.02.3",           # in minor
+    "1.2.03",           # in patch
+    "1.2.3-beta.01",    # in the prerelease number
+    "1.2",              # too few parts
+    "1.2.3.4",          # too many
+    "v1.2.3",           # tag prefix, not a version
+    "1.2.3-beta",       # prerelease without a number
+    "",
+])
+def test_invalid_versions_are_rejected(version):
+    """npm requires valid SemVer, and both files ship as packages."""
+    assert not _SEMVER.fullmatch(version), version

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -1,0 +1,58 @@
+"""The project version is declared twice; nothing checked they agreed.
+
+`server/__init__.py:get_version()` reads pyproject.toml and describes it as the
+"single source of truth", which is true for the Python server and not true for
+the project: `mcp/package.json` carries its own copy, published to npm and
+reported by the MCP wrapper.
+
+Nothing compared them, so a release could ship a server announcing one version
+on /health while the MCP wrapper announced another -- the kind of drift that is
+invisible until two machines disagree and neither can say why.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+PYPROJECT = ROOT / "pyproject.toml"
+PACKAGE_JSON = ROOT / "mcp" / "package.json"
+
+
+def _pyproject_version() -> str:
+    for line in PYPROJECT.read_text().splitlines():
+        if line.startswith("version"):
+            return line.split('"')[1]
+    raise AssertionError("no version line in pyproject.toml")
+
+
+@pytest.mark.parametrize("path", [PYPROJECT, PACKAGE_JSON])
+def test_version_sources_exist(path):
+    """Fail loudly rather than silently passing on a missing file."""
+    assert path.exists(), f"{path} is missing — this guard cannot run."
+
+
+def test_the_two_declared_versions_agree():
+    npm = json.loads(PACKAGE_JSON.read_text())["version"]
+    assert npm == _pyproject_version(), (
+        "pyproject.toml and mcp/package.json disagree. Both ship in a release; "
+        "the server reports one on /health and the MCP wrapper publishes the "
+        "other."
+    )
+
+
+def test_the_server_reports_the_declared_version():
+    from server import get_version
+
+    assert get_version() == _pyproject_version()
+
+
+def test_the_version_is_a_release_shape():
+    """Guards a typo in the one field a release is cut from. Accepts
+    `1.2.3` and prerelease suffixes like `1.2.3-beta.1`."""
+    version = _pyproject_version()
+    assert re.fullmatch(r"\d+\.\d+\.\d+(?:-[a-z]+\.\d+)?", version), version

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -51,11 +51,18 @@ def test_the_server_reports_the_declared_version():
     assert get_version() == _pyproject_version()
 
 
-# A SemVer numeric identifier: no leading zeroes. `\d+` would accept `01.2.3`
-# and `1.2.3-beta.01`, which npm rejects as invalid SemVer -- so the guard
-# against a typo in this field would itself have admitted one.
-_NUM = r"(?:0|[1-9]\d*)"
-_SEMVER = re.compile(rf"{_NUM}\.{_NUM}\.{_NUM}(?:-[a-z]+\.{_NUM})?$")
+# The published SemVer 2.0.0 grammar, verbatim from semver.org, rather than a
+# hand-rolled approximation. Two earlier attempts here were each wrong in a
+# different direction: `\d+` per part accepted `01.2.3`, and tightening it to
+# `-[a-z]+\.\d+` then rejected `1.2.3-beta`, `1.2.3-0` and build metadata --
+# all valid, so a legitimate release would have failed CI. The point of this
+# guard is to catch a typo, not to invent a dialect.
+_SEMVER = re.compile(
+    r"(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)"
+    r"(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+    r"(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+    r"(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+)
 
 
 def test_the_version_is_a_release_shape():
@@ -65,21 +72,27 @@ def test_the_version_is_a_release_shape():
 
 
 @pytest.mark.parametrize("version", [
-    "0.15.0", "1.2.3", "0.15.0-beta.1", "10.0.0-rc.12", "0.0.1",
+    "0.15.0", "1.2.3", "0.0.1", "10.20.30",
+    "0.15.0-beta.1", "10.0.0-rc.12",
+    # Valid forms an earlier version of this guard rejected, any of which would
+    # have failed CI on a legitimate release.
+    "1.2.3-beta", "1.2.3-0", "1.2.3-alpha.1.2", "1.2.3-alpha-1",
+    "1.2.3+build.1", "1.2.3-beta.1+exp.sha.5114f85",
 ])
 def test_valid_versions_are_accepted(version):
-    assert _SEMVER.fullmatch(version)
+    assert _SEMVER.fullmatch(version), version
 
 
 @pytest.mark.parametrize("version", [
     "01.2.3",           # leading zero in major
     "1.02.3",           # in minor
     "1.2.03",           # in patch
-    "1.2.3-beta.01",    # in the prerelease number
+    "1.2.3-beta.01",    # in a numeric prerelease identifier
+    "1.2.3-01",         # same, as the only identifier
     "1.2",              # too few parts
     "1.2.3.4",          # too many
     "v1.2.3",           # tag prefix, not a version
-    "1.2.3-beta",       # prerelease without a number
+    "1.2.3-",           # empty prerelease
     "",
 ])
 def test_invalid_versions_are_rejected(version):


### PR DESCRIPTION
Cuts the beta for the work merged since `v0.14.1` — **29 PRs, 117 commits**.

## Why minor, not patch

The bulk of it adds capability rather than fixing behaviour:

- **Web content on iOS simulators** (#90–#97, #101, #103, #104) — reading and
  tapping inside `WKWebView`, `SFSafariViewController` and
  `ASWebAuthenticationSession`; screen-settle detection instead of sleeping;
  clearing and verifying text entry.
- **Accessibility bridge recovery** (#89) — self-heals the wedge XCUITest leaves.
- **External tool inventory, updates and service health** (#105–#108) — versions
  and provenance per install *site*, upgrade offers driven by latest rather than
  by a floor, and health checks for tunneld and the mitmproxy system extension.
- **Merge/review tooling** (#86–#88, #110).

MCP tool count moved 107 → 109.

## The guard

The version is declared twice — `pyproject.toml` and `mcp/package.json` — and
nothing compared them. `get_version()` reads the former and calls it the single
source of truth, which is true for the Python server and not for the project:
the npm package carries its own copy.

A release could therefore ship a server announcing one version on `/health`
while the MCP wrapper announced another. Invisible until two machines disagree
and neither can say why — the same failure shape as the tool-version drift
#67 was opened for.

The guard also pins the version's *shape*, since a release is cut from that one
field and a typo there is caught by nothing else.

## Verification

- **1872 passed**, ruff clean.
- Mutation: reverting `mcp/package.json` to `0.14.1` fails the sync test.
- `get_version()` returns `0.15.0-beta.1` end to end.

## Not blocking, but worth knowing

Five issues remain open: #73 (tunneld remediation, has a live repro preserved on
another machine), #74 (sim-bridge retry ambiguity — mitigated, root fix
outstanding), #84, #78, #102. None are regressions from this work, and a beta is
where the remaining ones get exercised. #67 is closed with a writeup of where the
implementation diverged from its proposal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release**
  * Updated the project and package version to **0.15.0-beta.1**, marking the latest beta release.

* **Tests**
  * Expanded version validation to support the complete Semantic Versioning 2.0.0 format, including prerelease identifiers and build metadata.
  * Added coverage for valid and invalid version formats, including leading-zero prerelease numbers and empty prerelease components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->