### PR TITLE
test(updater): stop reading the developer's channel, and cover beta (#115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`test_updater.py` no longer depends on the developer's update channel** (#115) — five of its twelve tests failed for anyone who had run `quern set-channel beta`. The mocked command tables are keyed on the literal `origin/release/stable`, while the code under test calls the real `_get_release_branch()`, which reads `~/.quern/config.json`; on the beta channel every key missed, and the dispatcher's deliberate default — a silent successful no-op, so a missed mock surfaces as a wrong answer rather than an exception — turned that into five failures pointing at the updater instead of at the machine. An autouse fixture now pins the channel, so the result no longer varies with who runs the suite. This tracks the channel *setting*, not the installed version: `set-channel` writes the config before any beta code exists, so the tests could break on a checkout that had not moved.
+
+
 
 ## [0.15.0-beta.1] - 2026-09-06
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -13,6 +13,27 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def pinned_channel(monkeypatch):
+    """Keep these tests off whatever channel the developer happens to be on.
+
+    `_get_release_branch()` reads `update_channel` from `~/.quern/config.json`,
+    so without this the command tables below -- which are keyed on the literal
+    `origin/release/stable` -- miss every entry once someone has run
+    `quern set-channel beta`, and the result of the suite depends on who runs
+    it (#115). The dispatcher defaults a missed key to a successful no-op, by
+    design, so the symptom is a wrong answer rather than an error, and it
+    points at the updater rather than at the machine.
+
+    Note this tracks the *setting*, not the installed version: the channel is
+    written by `set-channel` before any beta code exists, so the tests can
+    break on a checkout that has not moved.
+
+    The two tests that are about the mapping itself override this.
+    """
+    monkeypatch.setattr("server.config.get_update_channel", lambda: "stable")
+
+
 def _make_run(returncode: int = 0, stdout: str = "", stderr: str = ""):
     """Build a MagicMock subprocess CompletedProcess-ish object."""
     result = MagicMock()
@@ -95,6 +116,38 @@ def test_check_via_git_compares_to_release_branch_not_current_branch():
     assert len(rev_list_calls) == 1
     assert rev_list_calls[0].args[0] == [
         "git", "rev-list", "HEAD..origin/release/stable", "--count",
+    ]
+
+
+def test_check_via_git_follows_the_configured_channel(monkeypatch):
+    """The beta channel had no coverage at all: every table was keyed on
+    `release/stable`, so the one behaviour the channel setting controls went
+    untested while quietly breaking the suite for anyone who had opted in."""
+    from server.lifecycle import updater
+
+    monkeypatch.setattr("server.config.get_update_channel", lambda: "beta")
+    responses = {
+        ("git", "fetch", "origin"): _make_run(0),
+        ("git", "rev-parse", "--abbrev-ref", "HEAD"): _make_run(
+            0, stdout="release/beta\n",
+        ),
+        ("git", "rev-list", "HEAD..origin/release/beta", "--count"): _make_run(
+            0, stdout="4\n",
+        ),
+    }
+    with patch(
+        "server.lifecycle.updater.subprocess.run",
+        side_effect=_make_subprocess_dispatcher(responses),
+    ) as run_mock:
+        result = updater._check_via_git(Path("/fake"))
+
+    assert result == (True, "release/beta", 4)
+    rev_list_calls = [
+        c for c in run_mock.call_args_list
+        if c.args[0][:2] == ["git", "rev-list"]
+    ]
+    assert rev_list_calls[0].args[0] == [
+        "git", "rev-list", "HEAD..origin/release/beta", "--count",
     ]
 
 


### PR DESCRIPTION
Closes #115.

Five of `test_updater.py`'s twelve tests failed for anyone who had run `quern set-channel beta`. The mocked command tables are keyed on the literal `origin/release/stable`, while the code under test calls the real `_get_release_branch()`, which reads `~/.quern/config.json`. On the beta channel every key missed.

## Why it read as a product bug

The dispatcher's default is deliberate, and documented as such:

> Default to a successful no-op so unmocked git invocations don't crash the test — they'd surface as the wrong answer rather than an exception, which is what we want when diagnosing a missed mock.

That is sound for its intended case. Here it converted an environmental mismatch into five failures whose text points at the updater rather than at the machine — which is exactly how this got mistaken for a real defect on `fix/tunneld-restart-and-fallback`, where I deselected the file to get a clean run.

## The fix

An autouse fixture pins the channel, so the suite no longer varies with who runs it. The two tests that are *about* the mapping already monkeypatched it for themselves and still override deliberately.

Per the scoping correction on the issue, this tracks the channel **setting**, not the installed version — `set-channel` writes the config and changes nothing else until the next update, so the tests could fail on a checkout that had not moved, while a checkout of the beta tag with the channel unset passed.

## And the coverage whose absence hid it

Every table named `release/stable`, so the one behaviour the channel setting actually controls had **no test at all**. `_check_via_git` is now exercised on beta, asserting it asks about `origin/release/beta`. That is arguably the more valuable half: the bug was possible because the beta path was untested, not merely because a literal was hardcoded.

## Verification

| config | before | after |
|---|---|---|
| Isolated `HOME`, `update_channel: beta` | 5 failed, 7 passed | **13 passed** |
| Isolated `HOME`, channel unset | 12 passed | **13 passed** |
| This machine's real config (beta) | 5 failed | **13 passed** |
| Full suite | needed `--deselect tests/test_updater.py` | **1902 passed**, no deselection |

Mutation-checked by flipping the fixture to `autouse=False`, which reproduces the original five failures exactly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Pinned update-channel behavior in tests to avoid results varying with local configuration.
  - Added coverage for beta-channel update checks, including the expected release branch and commit count.

- **Documentation**
  - Added an Unreleased changelog entry describing the test reliability improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->