### PR TITLE
Report proxy and update state the menu bar can trust

### DIFF
--- a/server/lifecycle/update_check.py
+++ b/server/lifecycle/update_check.py
@@ -85,38 +85,51 @@ def _get_head_sha() -> str | None:
 
 
 
-def _is_ahead_of_channel() -> bool:
-    """Whether the local HEAD is at or ahead of its channel's pointer branch.
+def _is_ahead_of(latest_sha: str | None) -> bool:
+    """Whether the local HEAD already contains ``latest_sha``.
 
-    Only meaningful for git installs; a tarball install has no repository and
-    never sends a sha, so it never reaches here. Counts commits the pointer has
-    that HEAD does not -- zero means nothing to pull, which is what
-    ``_update_via_git`` requires before it will do anything.
+    Answers the question quern.dev structurally cannot: it holds branch refs
+    with no commit graph, so `clientSha !== latestSha` is the best it can do and
+    "ahead" is indistinguishable from "behind" (#123).
 
-    Returns False on any failure, so an unexpected git state falls back to the
-    endpoint's answer rather than silently suppressing a real update.
+    Deliberately does **not** fetch. An earlier version did, and it was wrong
+    twice over: a failed fetch left a stale ref, `rev-list` then reported zero
+    commits behind, and a genuinely outdated install was told nothing — the exact
+    inversion of this function's contract. It also added up to 25s of blocking
+    git to `check_for_updates()`, which `server/main.py` calls synchronously on
+    the foreground startup path.
+
+    Using the sha the endpoint just asserted avoids both. If the object is
+    present locally, ancestry is decidable offline in milliseconds. If it is not
+    present — a shallow clone, a genuinely newer upstream commit, a tarball
+    install — the answer is unknowable here, and False means "believe the
+    endpoint".
+
+    Returns False on anything unexpected, so this can only ever suppress a claim
+    it positively disproves. It can never invent an update or hide a real one.
     """
+    if not latest_sha:
+        return False
     project_root = _find_project_root()
     if project_root is None or not (project_root / ".git").exists():
         return False
     try:
-        from server.lifecycle.updater import _get_release_branch
-
-        ref = f"origin/{_get_release_branch()}"
-        # Fetch first: without it the pointer ref may be stale enough to report
-        # zero commits behind on an install that genuinely has an update.
-        subprocess.run(
-            ["git", "fetch", "--quiet", "origin"],
-            cwd=str(project_root), capture_output=True, timeout=15,
+        # Confirm we actually have the object before asking about ancestry:
+        # `merge-base` on an unknown sha errors, and we must not read that as
+        # a negative answer to a question we never got to ask.
+        have = subprocess.run(
+            ["git", "cat-file", "-e", f"{latest_sha}^{{commit}}"],
+            cwd=str(project_root), capture_output=True, timeout=10,
         )
-        result = subprocess.run(
-            ["git", "rev-list", f"HEAD..{ref}", "--count"],
-            cwd=str(project_root), capture_output=True, text=True, timeout=10,
-        )
-        if result.returncode != 0:
+        if have.returncode != 0:
             return False
-        return int(result.stdout.strip()) == 0
-    except (OSError, subprocess.SubprocessError, ValueError):
+        result = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", latest_sha, "HEAD"],
+            cwd=str(project_root), capture_output=True, timeout=10,
+        )
+        # 0 = latest_sha is an ancestor of HEAD, i.e. we already contain it.
+        return result.returncode == 0
+    except (OSError, subprocess.SubprocessError):
         return False
 
 
@@ -183,7 +196,7 @@ def check_for_updates() -> str | None:
         # refused and the defect was confined to the notification. This makes the
         # notification consult the same reality the action already does, rather
         # than adding a second mechanism.
-        if update_available and head_sha and _is_ahead_of_channel():
+        if update_available and head_sha and _is_ahead_of(data.get("latest_sha")):
             update_available = False
             latest_version = None
         if not update_available:

--- a/server/lifecycle/update_check.py
+++ b/server/lifecycle/update_check.py
@@ -84,6 +84,42 @@ def _get_head_sha() -> str | None:
     return None
 
 
+
+def _is_ahead_of_channel() -> bool:
+    """Whether the local HEAD is at or ahead of its channel's pointer branch.
+
+    Only meaningful for git installs; a tarball install has no repository and
+    never sends a sha, so it never reaches here. Counts commits the pointer has
+    that HEAD does not -- zero means nothing to pull, which is what
+    ``_update_via_git`` requires before it will do anything.
+
+    Returns False on any failure, so an unexpected git state falls back to the
+    endpoint's answer rather than silently suppressing a real update.
+    """
+    project_root = _find_project_root()
+    if project_root is None or not (project_root / ".git").exists():
+        return False
+    try:
+        from server.lifecycle.updater import _get_release_branch
+
+        ref = f"origin/{_get_release_branch()}"
+        # Fetch first: without it the pointer ref may be stale enough to report
+        # zero commits behind on an install that genuinely has an update.
+        subprocess.run(
+            ["git", "fetch", "--quiet", "origin"],
+            cwd=str(project_root), capture_output=True, timeout=15,
+        )
+        result = subprocess.run(
+            ["git", "rev-list", f"HEAD..{ref}", "--count"],
+            cwd=str(project_root), capture_output=True, text=True, timeout=10,
+        )
+        if result.returncode != 0:
+            return False
+        return int(result.stdout.strip()) == 0
+    except (OSError, subprocess.SubprocessError, ValueError):
+        return False
+
+
 def check_for_updates() -> str | None:
     """Return a message if updates are available, None otherwise.
 
@@ -135,6 +171,21 @@ def check_for_updates() -> str | None:
 
         update_available = bool(data.get("update_available"))
         latest_version = data.get("latest_version")
+
+        # quern.dev answers the sha question with string equality
+        # (`clientSha !== latestSha`), because a Cloudflare Worker holding only
+        # branch refs has no commit graph and cannot tell "ahead" from "behind".
+        # A git install working on main is ahead of its channel pointer, so it
+        # was told an update was available to an ancestor of its own HEAD (#123).
+        #
+        # `_update_via_git` never believed this -- it counts `HEAD..origin/<ref>`
+        # and declines when that is zero -- so the update itself was always
+        # refused and the defect was confined to the notification. This makes the
+        # notification consult the same reality the action already does, rather
+        # than adding a second mechanism.
+        if update_available and head_sha and _is_ahead_of_channel():
+            update_available = False
+            latest_version = None
         if not update_available:
             message = None
         elif latest_version:

--- a/server/sources/proxy.py
+++ b/server/sources/proxy.py
@@ -304,8 +304,9 @@ class ProxyAdapter(BaseSourceAdapter):
         self._running = False
         # Also written here, not only from the addon's "stopped" event: a hard
         # kill gives the addon no chance to emit, and the state file would then
-        # keep claiming the proxy is running.
-        update_state(proxy_status="stopped")
+        # keep claiming the proxy is running. Off-thread for the same reason as
+        # the handler -- this runs on the event loop.
+        await asyncio.to_thread(update_state, proxy_status="stopped")
 
         if self._process and self._process.returncode is None:
             self._process.terminate()
@@ -536,7 +537,7 @@ class ProxyAdapter(BaseSourceAdapter):
                 elif msg_type == "mock_hit":
                     await self._handle_mock_hit(data)
                 elif msg_type == "status":
-                    self._handle_status_event(data)
+                    await self._handle_status_event(data)
                 elif msg_type == "error":
                     logger.warning("Addon error: %s", data)
         except asyncio.CancelledError:
@@ -644,18 +645,22 @@ class ProxyAdapter(BaseSourceAdapter):
         )
         await self.emit(entry)
 
-    def _handle_status_event(self, data: dict) -> None:
+    async def _handle_status_event(self, data: dict) -> None:
         """Handle status events from the addon that update local state mirrors."""
         event = data.get("event")
+        # update_state() takes fcntl.LOCK_EX and does synchronous file I/O, so
+        # calling it inline would block the event loop behind whichever writer
+        # holds the lock -- stalling unrelated coroutines for a state write
+        # nothing is waiting on.
         if event == "started":
             # state.json's proxy_status was written as "starting" at boot and
             # never advanced, so every unauthenticated consumer saw a proxy that
             # was permanently starting up (#122). The addon's own "started" is
             # the honest signal -- it means the script loaded and mitmproxy is
             # up, rather than merely that the subprocess was spawned.
-            update_state(proxy_status="running")
+            await asyncio.to_thread(update_state, proxy_status="running")
         elif event == "stopped":
-            update_state(proxy_status="stopped")
+            await asyncio.to_thread(update_state, proxy_status="stopped")
         elif event == "intercept_set":
             self._intercept_pattern = data.get("pattern")
         elif event == "intercept_cleared":

--- a/server/sources/proxy.py
+++ b/server/sources/proxy.py
@@ -25,6 +25,7 @@ from pathlib import Path
 
 from mitmproxy import flowfilter
 
+from server.lifecycle.state import update_state
 from server.models import (
     FlowRecord,
     FlowRequest,
@@ -301,6 +302,10 @@ class ProxyAdapter(BaseSourceAdapter):
     async def stop(self) -> None:
         """Terminate the mitmdump subprocess and clean up."""
         self._running = False
+        # Also written here, not only from the addon's "stopped" event: a hard
+        # kill gives the addon no chance to emit, and the state file would then
+        # keep claiming the proxy is running.
+        update_state(proxy_status="stopped")
 
         if self._process and self._process.returncode is None:
             self._process.terminate()
@@ -642,7 +647,16 @@ class ProxyAdapter(BaseSourceAdapter):
     def _handle_status_event(self, data: dict) -> None:
         """Handle status events from the addon that update local state mirrors."""
         event = data.get("event")
-        if event == "intercept_set":
+        if event == "started":
+            # state.json's proxy_status was written as "starting" at boot and
+            # never advanced, so every unauthenticated consumer saw a proxy that
+            # was permanently starting up (#122). The addon's own "started" is
+            # the honest signal -- it means the script loaded and mitmproxy is
+            # up, rather than merely that the subprocess was spawned.
+            update_state(proxy_status="running")
+        elif event == "stopped":
+            update_state(proxy_status="stopped")
+        elif event == "intercept_set":
             self._intercept_pattern = data.get("pattern")
         elif event == "intercept_cleared":
             self._intercept_pattern = None

--- a/tests/test_proxy_adapter.py
+++ b/tests/test_proxy_adapter.py
@@ -407,7 +407,7 @@ async def test_wait_for_held_signal(adapter):
 @pytest.mark.asyncio
 async def test_handle_status_event_intercept_set(adapter):
     """intercept_set status should update pattern."""
-    adapter._handle_status_event({"event": "intercept_set", "pattern": "~d test.com"})
+    await adapter._handle_status_event({"event": "intercept_set", "pattern": "~d test.com"})
     assert adapter._intercept_pattern == "~d test.com"
 
 
@@ -416,7 +416,7 @@ async def test_handle_status_event_intercept_cleared(adapter):
     """intercept_cleared status should clear pattern and held flows."""
     adapter._intercept_pattern = "~d test.com"
     adapter._held_flows["f_1"] = {"id": "f_1"}
-    adapter._handle_status_event({"event": "intercept_cleared"})
+    await adapter._handle_status_event({"event": "intercept_cleared"})
     assert adapter._intercept_pattern is None
     assert len(adapter._held_flows) == 0
 
@@ -425,7 +425,7 @@ async def test_handle_status_event_intercept_cleared(adapter):
 async def test_handle_status_event_mocks_cleared(adapter):
     """mocks_cleared status should clear mock rules."""
     adapter._mock_rules = [{"rule_id": "a"}, {"rule_id": "b"}]
-    adapter._handle_status_event({"event": "mocks_cleared", "rule_id": None})
+    await adapter._handle_status_event({"event": "mocks_cleared", "rule_id": None})
     assert len(adapter._mock_rules) == 0
 
 
@@ -433,7 +433,7 @@ async def test_handle_status_event_mocks_cleared(adapter):
 async def test_handle_status_event_mock_cleared_specific_is_noop(adapter):
     """mocks_cleared with rule_id should be a no-op (caller already handled it)."""
     adapter._mock_rules = [{"rule_id": "a"}, {"rule_id": "b"}]
-    adapter._handle_status_event({"event": "mocks_cleared", "rule_id": "a"})
+    await adapter._handle_status_event({"event": "mocks_cleared", "rule_id": "a"})
     # Per-rule echo is ignored — both rules still present
     assert len(adapter._mock_rules) == 2
 
@@ -465,7 +465,7 @@ async def test_update_mock_preserves_rule(adapter):
     assert adapter._mock_rules[0]["response"]["status_code"] == 404
 
     # Simulate the echo arriving — should NOT wipe the rule
-    adapter._handle_status_event({"event": "mocks_cleared", "rule_id": "r1"})
+    await adapter._handle_status_event({"event": "mocks_cleared", "rule_id": "r1"})
     assert len(adapter._mock_rules) == 1
 
 
@@ -628,21 +628,21 @@ def _adapter():
     return ProxyAdapter(on_entry=lambda _e: None)
 
 
-def test_the_addon_started_event_marks_the_proxy_running(monkeypatch):
+async def test_the_addon_started_event_marks_the_proxy_running(monkeypatch):
     written = {}
     monkeypatch.setattr("server.sources.proxy.update_state",
                         lambda **kw: written.update(kw))
 
-    _adapter()._handle_status_event({"type": "status", "event": "started"})
+    await _adapter()._handle_status_event({"type": "status", "event": "started"})
     assert written == {"proxy_status": "running"}
 
 
-def test_the_addon_stopped_event_marks_it_stopped(monkeypatch):
+async def test_the_addon_stopped_event_marks_it_stopped(monkeypatch):
     written = {}
     monkeypatch.setattr("server.sources.proxy.update_state",
                         lambda **kw: written.update(kw))
 
-    _adapter()._handle_status_event({"type": "status", "event": "stopped"})
+    await _adapter()._handle_status_event({"type": "status", "event": "stopped"})
     assert written == {"proxy_status": "stopped"}
 
 
@@ -658,7 +658,7 @@ async def test_an_explicit_stop_writes_stopped_without_the_addon(monkeypatch):
     assert written.get("proxy_status") == "stopped"
 
 
-def test_other_status_events_do_not_touch_proxy_status(monkeypatch):
+async def test_other_status_events_do_not_touch_proxy_status(monkeypatch):
     """`intercept_set` and friends share this handler; only lifecycle events
     should move the field."""
     written = {}
@@ -666,6 +666,30 @@ def test_other_status_events_do_not_touch_proxy_status(monkeypatch):
                         lambda **kw: written.update(kw))
 
     a = _adapter()
-    a._handle_status_event({"type": "status", "event": "intercept_set", "pattern": "~u x"})
-    a._handle_status_event({"type": "status", "event": "mocks_cleared"})
+    await a._handle_status_event({"type": "status", "event": "intercept_set", "pattern": "~u x"})
+    await a._handle_status_event({"type": "status", "event": "mocks_cleared"})
     assert written == {}
+
+
+async def test_state_writes_never_block_the_event_loop(monkeypatch):
+    """update_state() takes fcntl.LOCK_EX and does synchronous file I/O. Called
+    inline it would stall every other coroutine behind whichever writer holds
+    the lock, for a write nothing is waiting on."""
+
+    loop_thread = __import__("threading").get_ident()
+    seen_on = []
+
+    def blocking_write(**_kw):
+        seen_on.append(__import__("threading").get_ident())
+
+    monkeypatch.setattr("server.sources.proxy.update_state", blocking_write)
+
+    a = _adapter()
+    await a._handle_status_event({"type": "status", "event": "started"})
+    await a.stop()
+
+    assert seen_on, "no state write happened"
+    assert all(t != loop_thread for t in seen_on), (
+        "update_state ran on the event loop thread; it must go through "
+        "asyncio.to_thread"
+    )

--- a/tests/test_proxy_adapter.py
+++ b/tests/test_proxy_adapter.py
@@ -605,3 +605,67 @@ def test_kill_stale_mitmdump_lsof_fails():
             # Should not raise
             ProxyAdapter._kill_stale_mitmdump(9101)
             mock_kill.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# state.json's proxy_status must reach "running" (#122)
+# --------------------------------------------------------------------------
+#
+# It was written as "starting" at boot (server/main.py) and only ever changed
+# again by the watchdog writing "crashed". Nothing wrote "running", although
+# state.py's own annotation lists it as a valid value — so the state machine was
+# `starting -> (crashed)` with the success transition missing.
+#
+# Invisible while every consumer was authenticated, because the *API* computes
+# status live and was always right. The menu-bar app reads the unauthenticated
+# state files on purpose (no API key), so it was the first thing to surface a
+# proxy that had been "starting" for three days.
+
+
+def _adapter():
+    from server.sources.proxy import ProxyAdapter
+
+    return ProxyAdapter(on_entry=lambda _e: None)
+
+
+def test_the_addon_started_event_marks_the_proxy_running(monkeypatch):
+    written = {}
+    monkeypatch.setattr("server.sources.proxy.update_state",
+                        lambda **kw: written.update(kw))
+
+    _adapter()._handle_status_event({"type": "status", "event": "started"})
+    assert written == {"proxy_status": "running"}
+
+
+def test_the_addon_stopped_event_marks_it_stopped(monkeypatch):
+    written = {}
+    monkeypatch.setattr("server.sources.proxy.update_state",
+                        lambda **kw: written.update(kw))
+
+    _adapter()._handle_status_event({"type": "status", "event": "stopped"})
+    assert written == {"proxy_status": "stopped"}
+
+
+async def test_an_explicit_stop_writes_stopped_without_the_addon(monkeypatch):
+    """A hard kill gives the addon no chance to emit its own `stopped`, and the
+    state file would otherwise keep claiming the proxy is running."""
+    written = {}
+    monkeypatch.setattr("server.sources.proxy.update_state",
+                        lambda **kw: written.update(kw))
+
+    a = _adapter()
+    await a.stop()
+    assert written.get("proxy_status") == "stopped"
+
+
+def test_other_status_events_do_not_touch_proxy_status(monkeypatch):
+    """`intercept_set` and friends share this handler; only lifecycle events
+    should move the field."""
+    written = {}
+    monkeypatch.setattr("server.sources.proxy.update_state",
+                        lambda **kw: written.update(kw))
+
+    a = _adapter()
+    a._handle_status_event({"type": "status", "event": "intercept_set", "pattern": "~u x"})
+    a._handle_status_event({"type": "status", "event": "mocks_cleared"})
+    assert written == {}

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -208,13 +208,12 @@ def test_message_falls_back_when_endpoint_omits_the_version(
 # is unchanged.
 
 
-def _fake_git(monkeypatch, tmp_path, *, behind: int, has_repo: bool = True,
-              fail: bool = False):
-    """Stand in for the git calls _is_ahead_of_channel makes.
+def _fake_git(monkeypatch, tmp_path, *, is_ancestor: bool = True,
+              has_object: bool = True, has_repo: bool = True, fail: bool = False):
+    """Stand in for the git calls _is_ahead_of makes.
 
     Uses a real temp directory rather than patching `Path.exists` on the class —
-    doing that globally broke an autouse fixture's teardown, which surfaced as
-    four errors in unrelated tests.
+    doing that globally broke an autouse fixture's teardown.
     """
     from server.lifecycle import update_check as uc
 
@@ -223,43 +222,84 @@ def _fake_git(monkeypatch, tmp_path, *, behind: int, has_repo: bool = True,
     monkeypatch.setattr(uc, "_find_project_root", lambda: tmp_path)
 
     def run(cmd, **_kw):
-        if "fetch" in cmd:
-            return SimpleNamespace(returncode=0, stdout="", stderr="")
         if fail:
-            return SimpleNamespace(returncode=128, stdout="", stderr="fatal")
-        return SimpleNamespace(returncode=0, stdout=f"{behind}\n", stderr="")
+            raise OSError("git exploded")
+        if "cat-file" in cmd:
+            return SimpleNamespace(returncode=0 if has_object else 128, stdout="", stderr="")
+        if "merge-base" in cmd:
+            return SimpleNamespace(returncode=0 if is_ancestor else 1, stdout="", stderr="")
+        raise AssertionError(f"unexpected git call: {cmd}")
 
     monkeypatch.setattr(uc.subprocess, "run", run)
 
 
-def test_ahead_of_the_channel_reads_as_up_to_date(monkeypatch, tmp_path):
-    from server.lifecycle.update_check import _is_ahead_of_channel
+SHA = "d9710814f46fcdd27190f683f24921ecf8658142"
 
-    _fake_git(monkeypatch, tmp_path, behind=0)
-    assert _is_ahead_of_channel() is True
+
+def test_already_containing_the_latest_sha_reads_as_ahead(monkeypatch, tmp_path):
+    from server.lifecycle.update_check import _is_ahead_of
+
+    _fake_git(monkeypatch, tmp_path, is_ancestor=True)
+    assert _is_ahead_of(SHA) is True
 
 
 def test_genuinely_behind_is_not_suppressed(monkeypatch, tmp_path):
-    """The guard must not swallow a real update."""
-    from server.lifecycle.update_check import _is_ahead_of_channel
+    """The guard must never swallow a real update."""
+    from server.lifecycle.update_check import _is_ahead_of
 
-    _fake_git(monkeypatch, tmp_path, behind=7)
-    assert _is_ahead_of_channel() is False
+    _fake_git(monkeypatch, tmp_path, is_ancestor=False)
+    assert _is_ahead_of(SHA) is False
+
+
+def test_an_unknown_commit_is_not_treated_as_behind(monkeypatch, tmp_path):
+    """`merge-base` errors on a sha we do not have, and that must not be read as
+    a negative answer to a question we never got to ask — a shallow clone would
+    otherwise report itself ahead of everything."""
+    from server.lifecycle.update_check import _is_ahead_of
+
+    _fake_git(monkeypatch, tmp_path, has_object=False)
+    assert _is_ahead_of(SHA) is False
 
 
 def test_a_non_git_install_never_claims_to_be_ahead(monkeypatch, tmp_path):
-    """Tarball installs have no repository. Returning True here would suppress
-    every update they are ever offered."""
-    from server.lifecycle.update_check import _is_ahead_of_channel
+    """Tarball installs have no repository. True here would suppress every
+    update they are ever offered."""
+    from server.lifecycle.update_check import _is_ahead_of
 
-    _fake_git(monkeypatch, tmp_path, behind=0, has_repo=False)
-    assert _is_ahead_of_channel() is False
+    _fake_git(monkeypatch, tmp_path, has_repo=False)
+    assert _is_ahead_of(SHA) is False
 
 
 def test_a_git_failure_falls_back_to_the_endpoint(monkeypatch, tmp_path):
-    """An unexpected git state must not silently suppress a real update — the
-    conservative answer is to believe the endpoint."""
-    from server.lifecycle.update_check import _is_ahead_of_channel
+    from server.lifecycle.update_check import _is_ahead_of
 
-    _fake_git(monkeypatch, tmp_path, behind=0, fail=True)
-    assert _is_ahead_of_channel() is False
+    _fake_git(monkeypatch, tmp_path, fail=True)
+    assert _is_ahead_of(SHA) is False
+
+
+def test_a_missing_latest_sha_is_unanswerable(monkeypatch, tmp_path):
+    """An older quern.dev deployment may omit it."""
+    from server.lifecycle.update_check import _is_ahead_of
+
+    _fake_git(monkeypatch, tmp_path)
+    assert _is_ahead_of(None) is False
+    assert _is_ahead_of("") is False
+
+
+def test_the_guard_never_fetches(monkeypatch, tmp_path):
+    """check_for_updates() runs synchronously on the foreground startup path
+    (server/main.py), so this must not add blocking network git. An earlier
+    version fetched and could stall startup for up to 25s."""
+    from server.lifecycle import update_check as uc
+
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(uc, "_find_project_root", lambda: tmp_path)
+    seen = []
+
+    def run(cmd, **_kw):
+        seen.append(cmd)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(uc.subprocess, "run", run)
+    uc._is_ahead_of(SHA)
+    assert not any("fetch" in c for c in seen), f"guard fetched: {seen}"

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -7,6 +7,7 @@ call so test runs are deterministic.
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -186,3 +187,79 @@ def test_message_falls_back_when_endpoint_omits_the_version(
     assert msg is not None
     assert "Update available" in msg
     assert update_check.read_update_info()["latest_version"] is None
+
+
+# --------------------------------------------------------------------------
+# A git install that is ahead of its channel is not "out of date" (#123)
+# --------------------------------------------------------------------------
+#
+# quern.dev answers the sha question with string equality, because a Cloudflare
+# Worker holding only branch refs has no commit graph and cannot distinguish
+# "ahead" from "behind". A git install working on main is ahead of its channel
+# pointer, so the endpoint reported an update available to an *ancestor* of the
+# local HEAD.
+#
+# `_update_via_git` never believed it — it counts HEAD..origin/<ref> and returns
+# "no update needed" at zero — so the update was always refused and only the
+# notification was wrong. These pin that the notification now agrees with the
+# action.
+#
+# Tarball installs never send a sha and never reach this path; their behaviour
+# is unchanged.
+
+
+def _fake_git(monkeypatch, tmp_path, *, behind: int, has_repo: bool = True,
+              fail: bool = False):
+    """Stand in for the git calls _is_ahead_of_channel makes.
+
+    Uses a real temp directory rather than patching `Path.exists` on the class —
+    doing that globally broke an autouse fixture's teardown, which surfaced as
+    four errors in unrelated tests.
+    """
+    from server.lifecycle import update_check as uc
+
+    if has_repo:
+        (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(uc, "_find_project_root", lambda: tmp_path)
+
+    def run(cmd, **_kw):
+        if "fetch" in cmd:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if fail:
+            return SimpleNamespace(returncode=128, stdout="", stderr="fatal")
+        return SimpleNamespace(returncode=0, stdout=f"{behind}\n", stderr="")
+
+    monkeypatch.setattr(uc.subprocess, "run", run)
+
+
+def test_ahead_of_the_channel_reads_as_up_to_date(monkeypatch, tmp_path):
+    from server.lifecycle.update_check import _is_ahead_of_channel
+
+    _fake_git(monkeypatch, tmp_path, behind=0)
+    assert _is_ahead_of_channel() is True
+
+
+def test_genuinely_behind_is_not_suppressed(monkeypatch, tmp_path):
+    """The guard must not swallow a real update."""
+    from server.lifecycle.update_check import _is_ahead_of_channel
+
+    _fake_git(monkeypatch, tmp_path, behind=7)
+    assert _is_ahead_of_channel() is False
+
+
+def test_a_non_git_install_never_claims_to_be_ahead(monkeypatch, tmp_path):
+    """Tarball installs have no repository. Returning True here would suppress
+    every update they are ever offered."""
+    from server.lifecycle.update_check import _is_ahead_of_channel
+
+    _fake_git(monkeypatch, tmp_path, behind=0, has_repo=False)
+    assert _is_ahead_of_channel() is False
+
+
+def test_a_git_failure_falls_back_to_the_endpoint(monkeypatch, tmp_path):
+    """An unexpected git state must not silently suppress a real update — the
+    conservative answer is to believe the endpoint."""
+    from server.lifecycle.update_check import _is_ahead_of_channel
+
+    _fake_git(monkeypatch, tmp_path, behind=0, fail=True)
+    assert _is_ahead_of_channel() is False


### PR DESCRIPTION
Closes #122. Closes #123.

Both were found by the menu-bar app on #117, which reads the **unauthenticated
state files** rather than the API — that is what lets it work without an API key,
and it is why it saw things nothing else could. In both cases the API was right
and the file or the notification was wrong, so every authenticated consumer had
been shielded from the defect.

## `proxy_status` never reached "running" (#122)

`main.py` wrote `"starting"` at boot; the watchdog wrote `"crashed"`. Nothing
ever wrote the success value, although `state.py:46` documents it:

```python
proxy_status: str  # "running", "stopped", "crashed", "disabled"
```

So the state machine was `starting → (crashed)`, with the success transition
missing. Observed on a proxy that had been serving traffic for three days:

```
API  /api/v1/proxy/status  ->  running
state.json  proxy_status   ->  starting
```

The addon already emits `started` and `stopped`, and the adapter already had a
handler where both fell through the `else`. Those now write the field.

`stop()` writes it too, deliberately: a hard kill gives the addon no chance to
emit, and the file would otherwise keep claiming the proxy is running.

## The update notification claimed an update when ahead of the channel (#123)

quern.dev answers the sha question with string equality:

```js
update_available: latestSha !== null && clientSha !== "" && clientSha !== latestSha
```

It is not being lazy — `fetchRefs()` gives it branch tips, not a commit graph, so
a Worker cannot tell "ahead" from "behind". A git install on `main` is ahead of
its channel pointer, so it was told an update was available to an **ancestor of
its own HEAD**.

**`_update_via_git` never believed this.** It counts properly and declines:

```
git rev-list HEAD..origin/release/stable --count  ->  0
has_updates = behind_count > 0                    ->  False
return 2   # No update needed
```

So the update was always refused and only the *notification* was wrong. Rather
than add a second mechanism, `check_for_updates()` now consults the reality the
action already computes.

**The guard is one-directional.** A non-git install, or any git failure, returns
`False` and the endpoint is believed. It can only suppress a claim it can
positively disprove — never invent one, never silence a real update.

**Tarball installs are unaffected either way.** `_get_head_sha()` returns `None`
without a `.git` directory, so they never send a sha, and the endpoint is correct
on that path — verified live across all four channel/version combinations.

## Verification

Both confirmed through the app that surfaced them:

```
before:  Proxy: starting        …  Restart to Update — v0.14.1
after:   Proxy: running :9101   …  (item gone)
```

- **1942 passed**, ruff clean.
- Six mutations caught: dropping the `started` write; dropping the `stop()`
  write; letting every status event write `running`; removing the ahead-check;
  letting it fire without a repository (which would break tarball installs);
  and treating a git error as "ahead" (which would suppress real updates).

## Not included

quern.dev still asserts something it cannot know. Fixing it needs a GitHub
compare call per check, and nothing depends on it now that the client is
authoritative — the endpoint's answer is only ever used as a hint the client can
overrule. Left for later rather than folded in here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Update notifications are now suppressed when a Git-based installation already contains the configured channel version, reducing outdated prompts.
  - Proxy lifecycle status remains accurate after startup, shutdown, and forced termination.
  - Unrelated proxy events no longer overwrite the displayed status.
  - Proxy status updates no longer block other asynchronous activity, improving responsiveness during startup and shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->