### PR TITLE
Record the device name and the update channel in the state sidecars

### DIFF
--- a/server/__main__.py
+++ b/server/__main__.py
@@ -440,7 +440,6 @@ def _cmd_set_channel(args: list[str]) -> int:
         VALID_UPDATE_CHANNELS,
         channel_to_release_branch,
         get_update_channel,
-        set_update_channel,
     )
 
     if not args:
@@ -451,17 +450,17 @@ def _cmd_set_channel(args: list[str]) -> int:
         return 0
 
     target = args[0]
+    # switch_channel persists the preference and drops the cached check as one
+    # locked operation, so the next check is asked afresh instead of waiting
+    # out the 24h rate limit, and a check already in flight cannot put the old
+    # channel's answer back afterwards.
+    from server.lifecycle.update_check import switch_channel
+
     try:
-        set_update_channel(target)
+        switch_channel(target)
     except ValueError as e:
         print(f"Error: {e}")
         return 1
-
-    # The cached check was answered against the old channel; drop it so the
-    # next one is asked afresh rather than waiting out the 24h rate limit.
-    from server.lifecycle.update_check import invalidate_update_check
-
-    invalidate_update_check()
 
     branch = channel_to_release_branch(target)
     print(f"Update channel set to: {target} (tracks origin/{branch})")

--- a/server/__main__.py
+++ b/server/__main__.py
@@ -457,6 +457,12 @@ def _cmd_set_channel(args: list[str]) -> int:
         print(f"Error: {e}")
         return 1
 
+    # The cached check was answered against the old channel; drop it so the
+    # next one is asked afresh rather than waiting out the 24h rate limit.
+    from server.lifecycle.update_check import invalidate_update_check
+
+    invalidate_update_check()
+
     branch = channel_to_release_branch(target)
     print(f"Update channel set to: {target} (tracks origin/{branch})")
     print("Run `quern update` to apply changes from this channel.")

--- a/server/api/device.py
+++ b/server/api/device.py
@@ -307,6 +307,11 @@ async def erase_device(request: Request, body: ShutdownDeviceRequest):
 async def set_active_device(request: Request, body: ShutdownDeviceRequest):
     """Set the active device by UDID."""
     controller = _get_controller(request)
+    # Warm the device caches first. This is the one route that names a device
+    # the server may never have enumerated, so without it the type falls back
+    # to "simulator" -- routing a physical device to idb instead of WDA -- and
+    # the active-device sidecar is written with no human-readable name.
+    await controller._ensure_device_type_cached(body.udid)
     controller._active_udid = body.udid
     return {"active_udid": body.udid}
 

--- a/server/api/system.py
+++ b/server/api/system.py
@@ -22,9 +22,8 @@ from server.config import (
     VALID_UPDATE_CHANNELS,
     channel_to_release_branch,
     get_update_channel,
-    set_update_channel,
 )
-from server.lifecycle.update_check import invalidate_update_check, read_update_info
+from server.lifecycle.update_check import read_update_info, switch_channel
 
 logger = logging.getLogger("quern-debug-server.system")
 
@@ -120,14 +119,14 @@ async def put_channel(body: SetUpdateChannelRequest) -> UpdateChannelResponse:
     /update`` once the user is ready (and, for dev clones, has
     explicitly switched their branch).
     """
-    # Both of these are synchronous filesystem work -- a config write and two
-    # unlinks -- so they go off the event loop rather than stalling the handler
-    # if the disk does.
+    # switch_channel does the config write and the cache invalidation under one
+    # lock, so a check running concurrently cannot land its old-channel result
+    # after the invalidation. Off the event loop because it is blocking
+    # filesystem work that waits on that lock.
     try:
-        await asyncio.to_thread(set_update_channel, body.channel)
+        await asyncio.to_thread(switch_channel, body.channel)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
-    await asyncio.to_thread(invalidate_update_check)
     return UpdateChannelResponse(
         channel=body.channel,
         release_branch=channel_to_release_branch(body.channel),

--- a/server/api/system.py
+++ b/server/api/system.py
@@ -23,7 +23,7 @@ from server.config import (
     get_update_channel,
     set_update_channel,
 )
-from server.lifecycle.update_check import read_update_info
+from server.lifecycle.update_check import invalidate_update_check, read_update_info
 
 logger = logging.getLogger("quern-debug-server.system")
 
@@ -123,6 +123,7 @@ async def put_channel(body: SetUpdateChannelRequest) -> UpdateChannelResponse:
         set_update_channel(body.channel)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    invalidate_update_check()
     return UpdateChannelResponse(
         channel=body.channel,
         release_branch=channel_to_release_branch(body.channel),

--- a/server/api/system.py
+++ b/server/api/system.py
@@ -8,6 +8,7 @@ update, mentions it, and can call ``POST /update`` if the user agrees.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import subprocess
@@ -119,11 +120,14 @@ async def put_channel(body: SetUpdateChannelRequest) -> UpdateChannelResponse:
     /update`` once the user is ready (and, for dev clones, has
     explicitly switched their branch).
     """
+    # Both of these are synchronous filesystem work -- a config write and two
+    # unlinks -- so they go off the event loop rather than stalling the handler
+    # if the disk does.
     try:
-        set_update_channel(body.channel)
+        await asyncio.to_thread(set_update_channel, body.channel)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
-    invalidate_update_check()
+    await asyncio.to_thread(invalidate_update_check)
     return UpdateChannelResponse(
         channel=body.channel,
         release_branch=channel_to_release_branch(body.channel),

--- a/server/device/controller.py
+++ b/server/device/controller.py
@@ -39,6 +39,11 @@ class DeviceController(DeviceControllerUI):
         self.sim_bridge = SimBridgeBackend(self.sim_bridge_manager)
         self._sim_bridge_ok = False
         self.__active_udid: str | None = None
+        # What was last persisted, so an assignment that changes nothing can
+        # skip the write entirely. Separate from __active_udid, which is
+        # assigned before the comparison runs. See the setter.
+        self.__active_name_key: str | None = None
+        self.__active_name: str | None = None
         self._pool = None  # Set by main.py after pool is created; None = no pool
 
         # Restore active device from its sidecar file (lives separately
@@ -85,12 +90,30 @@ class DeviceController(DeviceControllerUI):
 
     @_active_udid.setter
     def _active_udid(self, value: str | None) -> None:
-        self.__active_udid = value
         # Best-effort name: the cache is filled by list_devices(), which
         # every resolve path runs before landing here, but the pool and the
         # set-active-device API can assign a UDID directly. A miss writes no
         # name and readers fall back to the UDID -- the previous behaviour.
-        write_active_udid(value, self._device_name_cache.get(value) if value else None)
+        name = self._device_name_cache.get(value) if value else None
+        self.__active_udid = value
+
+        # Write only on an actual change. resolve_udid() assigns this on every
+        # call that names a device, which is most tool calls, so the sidecar
+        # was being rewritten -- taking LOCK_EX on the event loop each time --
+        # to store the value it already held. The active device changes rarely,
+        # so this takes the I/O off the hot path altogether rather than moving
+        # it to a thread, which a property setter cannot await anyway and which
+        # would make two rapid switches race to land out of order.
+        #
+        # The name is part of the comparison, not just the UDID: the name cache
+        # is warmed by list_devices() and can arrive after the first
+        # assignment, and that later fill is exactly when the sidecar needs
+        # rewriting.
+        if value == self.__active_name_key and name == self.__active_name:
+            return
+        self.__active_name_key = value
+        self.__active_name = name
+        write_active_udid(value, name)
 
     async def check_tools(self) -> dict[str, bool]:
         """Check availability of CLI tools."""

--- a/server/device/controller.py
+++ b/server/device/controller.py
@@ -72,6 +72,10 @@ class DeviceController(DeviceControllerUI):
         self._device_info_cache: dict[str, DeviceInfo] = {}
         # Device type cache: udid -> DeviceType (populated by list_devices)
         self._device_type_cache: dict[str, DeviceType] = {}
+        # Device name cache: udid -> human-readable name (populated by
+        # list_devices). Only consumer is the active-device sidecar, so that
+        # readers outside the server can show a name instead of a UDID.
+        self._device_name_cache: dict[str, str] = {}
         # CoreDevice UUID -> libimobiledevice UDID mapping (populated by list_devices)
         self._usbmux_udid_map: dict[str, str] = {}
 
@@ -82,7 +86,11 @@ class DeviceController(DeviceControllerUI):
     @_active_udid.setter
     def _active_udid(self, value: str | None) -> None:
         self.__active_udid = value
-        write_active_udid(value)
+        # Best-effort name: the cache is filled by list_devices(), which
+        # every resolve path runs before landing here, but the pool and the
+        # set-active-device API can assign a UDID directly. A miss writes no
+        # name and readers fall back to the UDID -- the previous behaviour.
+        write_active_udid(value, self._device_name_cache.get(value) if value else None)
 
     async def check_tools(self) -> dict[str, bool]:
         """Check availability of CLI tools."""
@@ -282,6 +290,11 @@ class DeviceController(DeviceControllerUI):
                 self.wda_client._device_names[d.udid] = d.name
         for d in android_devices:
             self._device_type_cache[d.udid] = d.device_type
+        # One pass over every backend rather than four: the name is wanted
+        # for all device kinds and nothing else here varies by kind.
+        for d in sim_devices + physical_devices + usbmux_devices + android_devices:
+            if d.name:
+                self._device_name_cache[d.udid] = d.name
 
         # Build CoreDevice UUID -> libimobiledevice UDID mapping
         # by correlating device names between devicectl and usbmux

--- a/server/lifecycle/state.py
+++ b/server/lifecycle/state.py
@@ -172,9 +172,16 @@ def write_active_udid(udid: str | None, name: str | None = None) -> None:
             payload["name"] = name
     else:
         payload = {}
-    fd = ACTIVE_DEVICE_FILE.open("w")
+    # "a+" rather than "w", then truncate under the lock. "w" empties the file
+    # on open, before the lock is taken, so a concurrent read_active_device()
+    # holding LOCK_SH could see an empty file and report no active device --
+    # for as long as this writer waited for LOCK_EX. Same pattern update_state
+    # already uses below.
+    fd = ACTIVE_DEVICE_FILE.open("a+")
     try:
         fcntl.flock(fd, fcntl.LOCK_EX)
+        fd.seek(0)
+        fd.truncate()
         fd.write(json.dumps(payload, indent=2))
         fd.flush()
     finally:

--- a/server/lifecycle/state.py
+++ b/server/lifecycle/state.py
@@ -126,14 +126,52 @@ def read_active_udid() -> str | None:
         return None
 
 
-def write_active_udid(udid: str | None) -> None:
+def read_active_device() -> dict:
+    """Read the whole active-device sidecar, not just the UDID.
+
+    Returns {} when the file is missing, empty or malformed, so callers
+    can treat every failure the same way.
+    """
+    if not ACTIVE_DEVICE_FILE.exists():
+        return {}
+    try:
+        fd = ACTIVE_DEVICE_FILE.open("r")
+        try:
+            fcntl.flock(fd, fcntl.LOCK_SH)
+            content = fd.read()
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            fd.close()
+        if not content.strip():
+            return {}
+        data = json.loads(content)
+        return data if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning("Failed to read active-device.json: %s", e)
+        return {}
+
+
+def write_active_udid(udid: str | None, name: str | None = None) -> None:
     """Persist the active-device UDID to its sidecar file.
 
     Pass None (or empty string) to clear. Survives `quern stop` —
     `remove_state()` deletes state.json but does not touch this file.
+
+    `name` is the human-readable device name, written alongside so that
+    readers outside the server -- the menu-bar app is the one that
+    prompted this -- can show "iPhone 17 Pro" instead of a 36-character
+    UDID. It is optional and best-effort: the name comes from a cache
+    the caller may not have warmed yet, and a device is still perfectly
+    usable without one. Readers must therefore treat it as absent-able
+    and fall back to the UDID rather than showing an empty label.
     """
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-    payload = {"udid": udid} if udid else {}
+    if udid:
+        payload: dict[str, str] = {"udid": udid}
+        if name:
+            payload["name"] = name
+    else:
+        payload = {}
     fd = ACTIVE_DEVICE_FILE.open("w")
     try:
         fcntl.flock(fd, fcntl.LOCK_EX)

--- a/server/lifecycle/update_check.py
+++ b/server/lifecycle/update_check.py
@@ -17,12 +17,14 @@ re-hitting the endpoint. Opt out by setting ``"update_check": false`` in
 from __future__ import annotations
 
 import asyncio
+import fcntl
 import json
 import logging
 import subprocess
 import time
 import urllib.error
 import urllib.request
+from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -31,6 +33,10 @@ from server.config import CONFIG_DIR, read_user_config
 logger = logging.getLogger("quern-debug-server.update-check")
 
 LAST_CHECK_FILE = CONFIG_DIR / "last-update-check"
+# Serialises "commit a check result" against "switch channel and invalidate".
+# A separate file rather than the cache itself, because invalidation deletes
+# the cache and a lock held on a deleted inode guards nothing.
+CHANNEL_LOCK_FILE = CONFIG_DIR / "channel.lock"
 UPDATE_INFO_FILE = CONFIG_DIR / "update-info.json"
 CHECK_INTERVAL = 86400  # 24 hours
 ENDPOINT = "https://quern.dev/api/check-update"
@@ -222,24 +228,29 @@ def check_for_updates() -> str | None:
         # whose worst case is a stale notification until the next run, and the
         # switch already cleared the rate-limit stamp so the next run is
         # immediate.
-        if get_update_channel() != channel:
-            return None
+        # Held across the comparison *and* the write. Checking without the
+        # lock only narrowed the window; a switch landing between the two
+        # still recreated the invalidated result.
+        with _channel_lock():
+            if get_update_channel() != channel:
+                return None
 
-        # Persist structured result for the system API + MCP. Older
-        # deployments of quern.dev returned only update_available, so
-        # latest_version may still be absent.
-        _write_update_info({
-            "checked_at": datetime.now(UTC).isoformat(),
-            "current_version": version,
-            "latest_version": latest_version,
-            "update_available": update_available,
-            "message": message,
-            # The answer above is only meaningful for the channel it was asked
-            # about -- quern.dev compares against that channel's pointer branch
-            # -- so record which one, and let readers detect a result cached
-            # before a channel switch instead of trusting it for 24 hours.
-            "channel": channel,
-        })
+            # Persist structured result for the system API + MCP. Older
+            # deployments of quern.dev returned only update_available, so
+            # latest_version may still be absent.
+            _write_update_info({
+                "checked_at": datetime.now(UTC).isoformat(),
+                "current_version": version,
+                "latest_version": latest_version,
+                "update_available": update_available,
+                "message": message,
+                # The answer above is only meaningful for the channel it was
+                # asked about -- quern.dev compares against that channel's
+                # pointer branch -- so record which one, and let readers detect
+                # a result cached before a channel switch instead of trusting
+                # it for 24 hours.
+                "channel": channel,
+            })
         return message
 
     except Exception:
@@ -258,6 +269,60 @@ def _write_update_info(info: dict) -> None:
         logger.debug("Failed to persist update info: %s", e)
 
 
+@contextmanager
+def _channel_lock():
+    """Hold the channel lock, or proceed without it if it cannot be taken.
+
+    Best-effort by design. This coordinates a background hint; failing to
+    create a lock file must not stop a user from switching channels.
+    """
+    fd = None
+    try:
+        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        fd = CHANNEL_LOCK_FILE.open("a+")
+        fcntl.flock(fd, fcntl.LOCK_EX)
+    except OSError as e:
+        logger.debug("Channel lock unavailable, proceeding without it: %s", e)
+        if fd is not None:
+            fd.close()
+            fd = None
+    try:
+        yield
+    finally:
+        if fd is not None:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            fd.close()
+
+
+def switch_channel(channel: str) -> None:
+    """Persist the channel and discard the cached check as one operation.
+
+    The two halves must not be separable. A check reads the channel, spends up
+    to TIMEOUT seconds in the network call, then commits its result; if a
+    switch lands between that commit's channel comparison and its write, the
+    old channel's verdict is recreated after the invalidation meant to remove
+    it. Sharing a lock with the commit makes the interleaving impossible: the
+    switch either completes first, so the check sees the new channel and
+    discards, or lands second and deletes what the check just wrote.
+
+    Raises ValueError for an unknown channel, before anything is invalidated.
+    """
+    from server.config import set_update_channel
+
+    with _channel_lock():
+        set_update_channel(channel)
+        _invalidate_locked()
+
+
+def _invalidate_locked() -> None:
+    """Delete the cache files. Caller holds the channel lock."""
+    for path in (LAST_CHECK_FILE, UPDATE_INFO_FILE):
+        try:
+            path.unlink(missing_ok=True)
+        except OSError as e:
+            logger.debug("Failed to clear %s: %s", path.name, e)
+
+
 def invalidate_update_check() -> None:
     """Discard the cached update check so the next one runs immediately.
 
@@ -269,12 +334,12 @@ def invalidate_update_check() -> None:
 
     Best-effort: this only makes a check happen sooner, so a failed unlink is
     not worth propagating.
+
+    Prefer switch_channel() when the reason is a channel change, so the write
+    and the invalidation cannot be separated by a concurrent check.
     """
-    for path in (LAST_CHECK_FILE, UPDATE_INFO_FILE):
-        try:
-            path.unlink(missing_ok=True)
-        except OSError as e:
-            logger.debug("Failed to clear %s: %s", path.name, e)
+    with _channel_lock():
+        _invalidate_locked()
 
 
 def read_update_info() -> dict | None:

--- a/server/lifecycle/update_check.py
+++ b/server/lifecycle/update_check.py
@@ -209,6 +209,22 @@ def check_for_updates() -> str | None:
             )
         else:
             message = 'Update available \u2014 run "quern update" to get the latest version'
+        # The network call above can block for up to TIMEOUT seconds, which is
+        # long enough for the user to switch channels underneath it. That
+        # switch deletes both cache files precisely because this answer no
+        # longer applies -- so writing it now would undo the invalidation and
+        # leave read_update_info() reporting the old channel's verdict as
+        # current. Re-read and discard rather than resurrect.
+        #
+        # This narrows the window to the gap between the comparison and the
+        # write, instead of the whole request. An interprocess lock would close
+        # it completely, but the update check is a best-effort background hint
+        # whose worst case is a stale notification until the next run, and the
+        # switch already cleared the rate-limit stamp so the next run is
+        # immediate.
+        if get_update_channel() != channel:
+            return None
+
         # Persist structured result for the system API + MCP. Older
         # deployments of quern.dev returned only update_available, so
         # latest_version may still be absent.

--- a/server/lifecycle/update_check.py
+++ b/server/lifecycle/update_check.py
@@ -169,12 +169,13 @@ def check_for_updates() -> str | None:
         # to anyone on beta.
         from server.config import get_update_channel
 
+        channel = get_update_channel()
         params = []
         if head_sha:
             params.append(f"sha={head_sha}")
         if version:
             params.append(f"version={version}")
-        params.append(f"channel={get_update_channel()}")
+        params.append(f"channel={channel}")
 
         # Hit the endpoint
         url = f"{ENDPOINT}?{'&'.join(params)}"
@@ -217,6 +218,11 @@ def check_for_updates() -> str | None:
             "latest_version": latest_version,
             "update_available": update_available,
             "message": message,
+            # The answer above is only meaningful for the channel it was asked
+            # about -- quern.dev compares against that channel's pointer branch
+            # -- so record which one, and let readers detect a result cached
+            # before a channel switch instead of trusting it for 24 hours.
+            "channel": channel,
         })
         return message
 
@@ -234,6 +240,25 @@ def _write_update_info(info: dict) -> None:
         UPDATE_INFO_FILE.write_text(json.dumps(info, indent=2))
     except OSError as e:
         logger.debug("Failed to persist update info: %s", e)
+
+
+def invalidate_update_check() -> None:
+    """Discard the cached update check so the next one runs immediately.
+
+    Called when the update channel changes. The cached answer was computed
+    against the old channel's pointer branch, and the rate-limit stamp would
+    otherwise suppress a fresh check for up to 24 hours -- so a user who
+    switched to beta could keep being told they were up to date against
+    stable, or be offered a "newer" version they had just switched away from.
+
+    Best-effort: this only makes a check happen sooner, so a failed unlink is
+    not worth propagating.
+    """
+    for path in (LAST_CHECK_FILE, UPDATE_INFO_FILE):
+        try:
+            path.unlink(missing_ok=True)
+        except OSError as e:
+            logger.debug("Failed to clear %s: %s", path.name, e)
 
 
 def read_update_info() -> dict | None:

--- a/tests/test_device_controller.py
+++ b/tests/test_device_controller.py
@@ -30,6 +30,53 @@ def _device(
 
 
 # ---------------------------------------------------------------------------
+# Active-device sidecar — the name written beside the UDID
+# ---------------------------------------------------------------------------
+
+
+class TestActiveDeviceName:
+    async def test_name_is_persisted_beside_the_udid(self):
+        """Readers outside the server -- the menu-bar app -- show the active
+        device, and a 36-character UDID is not something a person recognises."""
+        from server.lifecycle.state import read_active_device
+
+        ctrl = DeviceController()
+        ctrl.simctl.list_devices = AsyncMock(
+            return_value=[_device(udid="AAAA-1111", name="iPhone 16 Pro")]
+        )
+        ctrl.devicectl.list_devices = AsyncMock(return_value=[])
+        ctrl.usbmux.list_devices = AsyncMock(return_value=[])
+        ctrl.adb.list_devices = AsyncMock(return_value=[])
+        ctrl.usbmux.get_usb_udid_map = AsyncMock(return_value={})
+
+        await ctrl.resolve_udid("AAAA-1111")
+
+        assert read_active_device() == {"udid": "AAAA-1111", "name": "iPhone 16 Pro"}
+
+    async def test_an_unknown_device_still_persists_its_udid(self):
+        """The name is best-effort. A UDID assigned with no enumeration behind
+        it -- the pool takes this path -- must still be recorded, with readers
+        falling back to the UDID rather than losing the active device."""
+        from server.lifecycle.state import read_active_device
+
+        ctrl = DeviceController()
+        ctrl._active_udid = "ZZZZ-9999"
+
+        assert read_active_device() == {"udid": "ZZZZ-9999"}
+
+    async def test_switching_devices_replaces_the_name(self):
+        """A stale name on a new UDID would mislabel the device outright."""
+        from server.lifecycle.state import read_active_device
+
+        ctrl = DeviceController()
+        ctrl._device_name_cache = {"AAAA-1111": "iPhone 16 Pro"}
+        ctrl._active_udid = "AAAA-1111"
+        ctrl._active_udid = "BBBB-2222"
+
+        assert read_active_device() == {"udid": "BBBB-2222"}
+
+
+# ---------------------------------------------------------------------------
 # resolve_udid
 # ---------------------------------------------------------------------------
 

--- a/tests/test_device_controller.py
+++ b/tests/test_device_controller.py
@@ -64,6 +64,50 @@ class TestActiveDeviceName:
 
         assert read_active_device() == {"udid": "ZZZZ-9999"}
 
+    async def test_reassigning_the_same_device_does_not_rewrite_the_sidecar(self):
+        """resolve_udid() assigns the active device on every call that names
+        one, which is most tool calls. Rewriting the file each time took
+        LOCK_EX on the event loop to store the value it already held."""
+        from server.lifecycle import state
+
+        ctrl = DeviceController()
+        ctrl._device_name_cache = {"AAAA-1111": "iPhone 16 Pro"}
+
+        writes = 0
+        real = state.write_active_udid
+
+        def counting(udid, name=None):
+            nonlocal writes
+            writes += 1
+            return real(udid, name)
+
+        with patch.object(
+            __import__("server.device.controller", fromlist=["x"]),
+            "write_active_udid", counting,
+        ):
+            ctrl._active_udid = "AAAA-1111"
+            assert writes == 1
+            for _ in range(10):
+                ctrl._active_udid = "AAAA-1111"
+            assert writes == 1, "unchanged reassignment still wrote"
+            ctrl._active_udid = "BBBB-2222"
+            assert writes == 2
+
+    async def test_a_name_arriving_later_is_written(self):
+        """The name cache is warmed by list_devices() and can fill in after the
+        UDID was already set. That later fill is exactly when the sidecar needs
+        rewriting, so the guard compares the name too, not just the UDID."""
+        from server.lifecycle.state import read_active_device
+
+        ctrl = DeviceController()
+        ctrl._active_udid = "AAAA-1111"
+        assert read_active_device() == {"udid": "AAAA-1111"}
+
+        ctrl._device_name_cache["AAAA-1111"] = "iPhone 16 Pro"
+        ctrl._active_udid = "AAAA-1111"
+
+        assert read_active_device() == {"udid": "AAAA-1111", "name": "iPhone 16 Pro"}
+
     async def test_switching_devices_replaces_the_name(self):
         """A stale name on a new UDID would mislabel the device outright."""
         from server.lifecycle.state import read_active_device

--- a/tests/test_lifecycle_state.py
+++ b/tests/test_lifecycle_state.py
@@ -8,6 +8,7 @@ import pytest
 
 from server.lifecycle.state import (
     is_server_healthy,
+    read_active_device,
     read_active_udid,
     read_state,
     remove_state,
@@ -65,6 +66,43 @@ def test_active_udid_clear(tmp_state_dir):
 def test_active_udid_missing_file(tmp_state_dir):
     """read_active_udid returns None when the sidecar doesn't exist."""
     assert read_active_udid() is None
+
+
+def test_active_device_name_round_trip(tmp_state_dir):
+    """The name is written alongside the UDID so readers outside the server
+    can show it instead of a 36-character identifier."""
+    write_active_udid("ABC-123-DEF", "iPhone 17 Pro")
+    assert read_active_device() == {"udid": "ABC-123-DEF", "name": "iPhone 17 Pro"}
+    assert read_active_udid() == "ABC-123-DEF"
+
+
+def test_active_device_name_omitted_when_unknown(tmp_state_dir):
+    """The name is best-effort. When the caller has none, the key is absent
+    rather than written empty -- readers key off absence to fall back to the
+    UDID, and an empty string would render as a blank label instead."""
+    write_active_udid("ABC-123-DEF")
+    assert read_active_device() == {"udid": "ABC-123-DEF"}
+    write_active_udid("ABC-123-DEF", "")
+    assert read_active_device() == {"udid": "ABC-123-DEF"}
+
+
+def test_active_device_name_cleared_with_udid(tmp_state_dir):
+    """Clearing the device must not leave the previous device's name behind."""
+    write_active_udid("ABC-123-DEF", "iPhone 17 Pro")
+    write_active_udid(None)
+    assert read_active_device() == {}
+    assert read_active_udid() is None
+
+
+def test_read_active_device_missing_and_malformed(tmp_state_dir):
+    """Every failure mode collapses to {} so callers need one branch."""
+    assert read_active_device() == {}
+    (tmp_state_dir / "active-device.json").write_text("")
+    assert read_active_device() == {}
+    (tmp_state_dir / "active-device.json").write_text("not json")
+    assert read_active_device() == {}
+    (tmp_state_dir / "active-device.json").write_text("[1, 2]")
+    assert read_active_device() == {}
 
 
 def test_active_udid_survives_remove_state(tmp_state_dir):

--- a/tests/test_lifecycle_state.py
+++ b/tests/test_lifecycle_state.py
@@ -105,6 +105,32 @@ def test_read_active_device_missing_and_malformed(tmp_state_dir):
     assert read_active_device() == {}
 
 
+def test_a_blocked_writer_never_empties_the_sidecar(tmp_state_dir, monkeypatch):
+    """Opening with "w" truncates before the lock is taken, so a reader holding
+    LOCK_SH could observe an empty file and report no active device for as long
+    as the writer waited. The file must still hold the old value at the moment
+    the writer blocks."""
+    import fcntl as _fcntl
+
+    write_active_udid("OLD-UDID", "Old Phone")
+
+    seen: dict[str, dict] = {}
+    real_flock = _fcntl.flock
+
+    def spy(fd, op):
+        # Read the file as a competing process would, at the instant this
+        # writer asks for its exclusive lock.
+        if op == _fcntl.LOCK_EX and "at_lock" not in seen:
+            seen["at_lock"] = read_active_device()
+        return real_flock(fd, op)
+
+    monkeypatch.setattr("server.lifecycle.state.fcntl.flock", spy)
+    write_active_udid("NEW-UDID", "New Phone")
+
+    assert seen["at_lock"] == {"udid": "OLD-UDID", "name": "Old Phone"}
+    assert read_active_device() == {"udid": "NEW-UDID", "name": "New Phone"}
+
+
 def test_active_udid_survives_remove_state(tmp_state_dir):
     """The bug regression test: remove_state() must NOT touch the
     active-device sidecar. Active device is user preference and survives

--- a/tests/test_system_api.py
+++ b/tests/test_system_api.py
@@ -168,6 +168,7 @@ def isolated_config(tmp_path, monkeypatch):
     monkeypatch.setattr(update_check, "CONFIG_DIR", tmp_path)
     monkeypatch.setattr(update_check, "LAST_CHECK_FILE", tmp_path / "last-update-check")
     monkeypatch.setattr(update_check, "UPDATE_INFO_FILE", tmp_path / "update-info.json")
+    monkeypatch.setattr(update_check, "CHANNEL_LOCK_FILE", tmp_path / "channel.lock")
     return tmp_path
 
 

--- a/tests/test_system_api.py
+++ b/tests/test_system_api.py
@@ -151,11 +151,23 @@ async def test_update_trigger_reports_skipped_on_oserror(
 @pytest.fixture
 def isolated_config(tmp_path, monkeypatch):
     """Redirect ~/.quern/config.json to a temp dir so tests don't mutate
-    the real user config."""
+    the real user config.
+
+    The update-check files are redirected too, and not defensively: setting the
+    channel invalidates the cached check, and update_check binds its paths at
+    import time from the real CONFIG_DIR, so patching server.config alone left
+    PUT /channel deleting update-info.json and last-update-check out of the
+    developer's actual home directory.
+    """
     monkeypatch.setattr("server.config.CONFIG_DIR", tmp_path)
     monkeypatch.setattr(
         "server.config.USER_CONFIG_FILE", tmp_path / "config.json",
     )
+    from server.lifecycle import update_check
+
+    monkeypatch.setattr(update_check, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(update_check, "LAST_CHECK_FILE", tmp_path / "last-update-check")
+    monkeypatch.setattr(update_check, "UPDATE_INFO_FILE", tmp_path / "update-info.json")
     return tmp_path
 
 
@@ -194,6 +206,57 @@ async def test_put_channel_persists_and_returns_new_state(
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.get("/api/v1/system/channel", headers=auth_headers)
         assert resp.json()["channel"] == "beta"
+
+
+@pytest.mark.asyncio
+async def test_put_channel_discards_the_previous_channels_verdict(
+    app, auth_headers, isolated_config,
+):
+    """The cached check was measured against the old channel's pointer branch,
+    and the rate-limit stamp would pin it for 24 hours -- so a user moving to
+    beta would keep being told how they stood against stable.
+
+    This also pins the fixture down. These paths are bound at import from the
+    real CONFIG_DIR, so a redirect that misses them makes this assertion pass
+    by deleting the developer's own files.
+    """
+    (isolated_config / "update-info.json").write_text(
+        '{"update_available": true, "channel": "stable"}'
+    )
+    (isolated_config / "last-update-check").touch()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.put(
+            "/api/v1/system/channel",
+            headers=auth_headers,
+            json={"channel": "beta"},
+        )
+        assert resp.status_code == 200
+
+    assert not (isolated_config / "update-info.json").exists()
+    assert not (isolated_config / "last-update-check").exists()
+
+
+@pytest.mark.asyncio
+async def test_a_rejected_channel_leaves_the_cached_check_alone(
+    app, auth_headers, isolated_config,
+):
+    """Nothing changed, so there is nothing to invalidate. Throwing away a
+    valid check because of a typo would cost a real update notification."""
+    info = isolated_config / "update-info.json"
+    info.write_text('{"update_available": true, "channel": "stable"}')
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.put(
+            "/api/v1/system/channel",
+            headers=auth_headers,
+            json={"channel": "nightly"},
+        )
+        assert resp.status_code == 400
+
+    assert info.exists()
 
 
 @pytest.mark.asyncio

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -7,6 +7,7 @@ call so test runs are deterministic.
 from __future__ import annotations
 
 import json
+import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -18,12 +19,15 @@ def isolated_update_files(tmp_path, monkeypatch):
     """Redirect CONFIG_DIR / LAST_CHECK_FILE / UPDATE_INFO_FILE to tmp_path.
 
     The update check writes files in CONFIG_DIR; without redirection the
-    test would mutate the real ~/.quern.
+    test would mutate the real ~/.quern. CHANNEL_LOCK_FILE is included for a
+    second reason as well as tidiness: left pointing at the real path, a test
+    would contend for the same lock as the developer's running server.
     """
     from server.lifecycle import update_check
     monkeypatch.setattr(update_check, "CONFIG_DIR", tmp_path)
     monkeypatch.setattr(update_check, "LAST_CHECK_FILE", tmp_path / "last-update-check")
     monkeypatch.setattr(update_check, "UPDATE_INFO_FILE", tmp_path / "update-info.json")
+    monkeypatch.setattr(update_check, "CHANNEL_LOCK_FILE", tmp_path / "channel.lock")
     return tmp_path
 
 
@@ -200,6 +204,84 @@ def test_an_unchanged_channel_still_writes_the_result(
     persisted = json.loads((isolated_update_files / "update-info.json").read_text())
     assert persisted["channel"] == "beta"
     assert persisted["update_available"] is True
+
+
+def test_a_switch_during_the_commit_cannot_leave_a_stale_verdict(
+    isolated_update_files, monkeypatch,
+):
+    """The interleaving a bare comparison cannot cover.
+
+    The check passes its channel comparison, and only *then* does the switch
+    land. Without a shared lock the check writes its stable answer after the
+    invalidation removed it, leaving config saying beta and the cache saying
+    stable. The invariant: whatever the ordering, the cached verdict either is
+    absent or names the channel that config now holds.
+    """
+    import threading
+
+    from server.lifecycle import update_check
+
+    config: dict = {}
+    monkeypatch.setattr(update_check, "read_user_config", lambda: config)
+    monkeypatch.setattr("server.config.read_user_config", lambda: config)
+    monkeypatch.setattr("server.config.USER_CONFIG_FILE",
+                        isolated_update_files / "config.json")
+    monkeypatch.setattr("server.config.CONFIG_DIR", isolated_update_files)
+    monkeypatch.setattr(update_check, "_get_local_version", lambda: "0.14.0")
+    monkeypatch.setattr(update_check, "_get_head_sha", lambda: None)
+
+    switched = threading.Event()
+    real_write = update_check._write_update_info
+
+    def slow_write(info):
+        # Inside the lock, past the comparison. Kick off the switch and give it
+        # time to block, so the commit really is the one holding the lock.
+        switched.set()
+        time.sleep(0.25)
+        real_write(info)
+
+    monkeypatch.setattr(update_check, "_write_update_info", slow_write)
+
+    def switcher():
+        switched.wait(timeout=5)
+        update_check.switch_channel("beta")
+
+    t = threading.Thread(target=switcher)
+    t.start()
+    with patch(
+        "urllib.request.urlopen",
+        return_value=_fake_response({"update_available": True, "latest_version": "9.9.9"}),
+    ):
+        update_check.check_for_updates()
+    t.join(timeout=5)
+    assert not t.is_alive()
+
+    from server.config import get_update_channel
+
+    assert get_update_channel() == "beta"
+    persisted = update_check.read_update_info()
+    assert persisted is None or persisted["channel"] == "beta", (
+        f"stale verdict survived the switch: {persisted}"
+    )
+
+
+def test_switch_channel_reports_a_bad_name_before_invalidating(
+    isolated_update_files, monkeypatch,
+):
+    """The cache must survive a typo. Raising after invalidating would cost a
+    valid update notification for nothing."""
+    from server.lifecycle import update_check
+
+    monkeypatch.setattr("server.config.USER_CONFIG_FILE",
+                        isolated_update_files / "config.json")
+    monkeypatch.setattr("server.config.CONFIG_DIR", isolated_update_files)
+    info = isolated_update_files / "update-info.json"
+    info.write_text('{"update_available": true, "channel": "stable"}')
+
+    with pytest.raises(ValueError):
+        update_check.switch_channel("nightly")
+
+    assert info.exists()
 
 
 def test_invalidate_clears_both_the_stamp_and_the_answer(isolated_update_files):

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -143,6 +143,39 @@ def test_check_for_updates_sends_the_configured_channel(
     requested_url = urlopen.call_args[0][0].full_url
     assert f"channel={channel}" in requested_url
     assert "sha=abc123" in requested_url
+    # The persisted answer records which channel produced it. Without this a
+    # reader cannot tell a "you are up to date" cached under stable from one
+    # cached under beta, and the two mean different things.
+    persisted = json.loads((isolated_update_files / "update-info.json").read_text())
+    assert persisted["channel"] == channel
+
+
+def test_invalidate_clears_both_the_stamp_and_the_answer(isolated_update_files):
+    """Switching channel must not leave the old channel's answer in place.
+
+    The rate-limit stamp alone would suppress a fresh check for 24 hours, so
+    clearing only the answer would leave no answer at all for a day.
+    """
+    from server.lifecycle import update_check
+
+    stamp = isolated_update_files / "last-update-check"
+    info = isolated_update_files / "update-info.json"
+    stamp.touch()
+    info.write_text(json.dumps({"update_available": True, "channel": "stable"}))
+
+    update_check.invalidate_update_check()
+
+    assert not stamp.exists()
+    assert not info.exists()
+    assert update_check.read_update_info() is None
+
+
+def test_invalidate_is_a_no_op_when_nothing_is_cached(isolated_update_files):
+    """Called on a fresh install, before any check has ever run."""
+    from server.lifecycle import update_check
+
+    update_check.invalidate_update_check()  # must not raise
+    assert update_check.read_update_info() is None
 
 
 def test_message_names_the_version_when_the_endpoint_supplies_one(

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -150,6 +150,58 @@ def test_check_for_updates_sends_the_configured_channel(
     assert persisted["channel"] == channel
 
 
+def test_a_channel_switch_mid_check_discards_the_result(
+    isolated_update_files, monkeypatch,
+):
+    """The network call can block for seconds, long enough for the user to
+    switch channels. That switch deletes the cache precisely because the
+    in-flight answer no longer applies, so writing it would undo the
+    invalidation and leave the old channel's verdict reading as current.
+    """
+    from server.lifecycle import update_check
+
+    monkeypatch.setattr(update_check, "read_user_config", lambda: {})
+    monkeypatch.setattr(update_check, "_get_local_version", lambda: "0.14.0")
+    monkeypatch.setattr(update_check, "_get_head_sha", lambda: None)
+
+    # "stable" when the request is built, "beta" by the time it returns.
+    channels = iter(["stable", "beta"])
+    monkeypatch.setattr("server.config.get_update_channel", lambda: next(channels))
+
+    with patch(
+        "urllib.request.urlopen",
+        return_value=_fake_response({"update_available": True, "latest_version": "9.9.9"}),
+    ):
+        message = update_check.check_for_updates()
+
+    assert message is None
+    assert not (isolated_update_files / "update-info.json").exists()
+
+
+def test_an_unchanged_channel_still_writes_the_result(
+    isolated_update_files, monkeypatch,
+):
+    """The guard must only fire on an actual switch. Discarding every result
+    would silently disable update notifications altogether."""
+    from server.lifecycle import update_check
+
+    monkeypatch.setattr(update_check, "read_user_config", lambda: {})
+    monkeypatch.setattr(update_check, "_get_local_version", lambda: "0.14.0")
+    monkeypatch.setattr(update_check, "_get_head_sha", lambda: None)
+    monkeypatch.setattr("server.config.get_update_channel", lambda: "beta")
+
+    with patch(
+        "urllib.request.urlopen",
+        return_value=_fake_response({"update_available": True, "latest_version": "9.9.9"}),
+    ):
+        message = update_check.check_for_updates()
+
+    assert message is not None and "9.9.9" in message
+    persisted = json.loads((isolated_update_files / "update-info.json").read_text())
+    assert persisted["channel"] == "beta"
+    assert persisted["update_available"] is True
+
+
 def test_invalidate_clears_both_the_stamp_and_the_answer(isolated_update_files):
     """Switching channel must not leave the old channel's answer in place.
 


### PR DESCRIPTION
The menu-bar app surfaced two gaps where the server knows something and never writes it down, so every reader outside the process has to display a placeholder.

## Device name

`active-device.json` held only a UDID, so a reader could offer the user `F5AF3736-C05F-493F-AA52-CA883B13B18C` and nothing else. The name is now written beside it, from a cache filled by `list_devices()` in the same pass that fills the device-type cache.

It is deliberately best-effort. The pool assigns a UDID directly with no enumeration behind it, and a device with no name is still usable, so the key is **omitted** rather than written empty. Readers key off absence and fall back to the UDID; an empty string would render as a blank label, which is worse.

`POST /device/active` is the exception worth fixing rather than tolerating, because it is the one route that names a device the server may never have enumerated. It now warms the caches first, which also closes a real bug on the side: without the warm-up the device type defaulted to simulator, routing a **physical device to idb instead of WDA**.

## Update channel

`update-info.json` recorded an answer without recording the question. The answer is only meaningful for the channel it was asked about, since quern.dev compares the SHA against that channel's pointer branch. "You are up to date" cached under stable and the same string cached under beta mean different things and were indistinguishable.

That exposed a live bug rather than a cosmetic one. Switching channel left the previous channel's verdict in place *and* left the 24-hour rate-limit stamp, so the stale answer was pinned for a day: a user moving to beta kept being measured against stable, and one moving back could be offered an update to the version they had just left. Both channel-setting paths, the CLI subcommand and `PUT /system/channel`, now clear the cache.

## Verification

Full suite: 1955 passed. New coverage for the name round-trip, omission when unknown, replacement on device switch, the malformed-file cases, channel provenance under both channels, and invalidation including the no-op on a fresh install.

Also exercised against reality, in redirected state directories so the running server was untouched:

- `resolve_udid` against real `simctl` enumeration wrote `{"udid": "001A8175-…", "name": "iPhone 17 Pro"}`.
- `python -m server set-channel beta` with a seeded stale answer persisted the channel and removed both `update-info.json` and `last-update-check`.

## Note for the reader

Deleting `update-info.json` on a channel switch is correct only because the channel's source of truth is `config.json`. A client should read the channel from there, not from the cached check result. The menu-bar branch is being changed to do exactly that; until then it briefly falls back to its "stable" default after a switch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Active devices now display their human-readable names alongside their identifiers when available.
  * Active-device information is handled more reliably when device details are missing or unavailable.

* **Bug Fixes**
  * Changing the update channel now triggers an immediate fresh update check instead of using stale cached results.
  * Update results remain associated with the channel that produced them, preventing mismatched cached information.
  * Active-device status remains consistent while device information is being updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->