### PR TITLE
Screen mirror: build it at setup, ignore the camera, fit the window, follow the devices

### DIFF
--- a/server/device/preview.py
+++ b/server/device/preview.py
@@ -182,9 +182,19 @@ class PreviewManager:
         self._available: list[PreviewDeviceInfo] = []
         self._ready = asyncio.Event()
         self._reader_task: asyncio.Task | None = None
-        # name -> (operation, future). The operation matters: a disconnect
-        # while an add is in flight must fail that add, not complete it.
-        self._pending: dict[str, tuple[str, asyncio.Future]] = {}
+        # name -> (command id, operation, future).
+        #
+        # The id is what correlates a reply with the request that caused it.
+        # The name cannot: a write that times out was still delivered and may
+        # still run, so its late reply would otherwise be matched against
+        # whatever request holds that name next -- a delayed `removed` landing
+        # on a subsequent `add` and reporting a preview the process had just
+        # torn down.
+        #
+        # The operation matters too: a disconnect while an add is in flight
+        # must fail that add, not complete it.
+        self._pending: dict[str, tuple[str, str, asyncio.Future]] = {}
+        self._command_seq = 0
         self._positions: set[int] = set()
         self._stagger_lock = asyncio.Lock()
         self._bundle_path = QUERN_BIN_DIR / APP_BUNDLE_NAME
@@ -256,7 +266,7 @@ class PreviewManager:
             self._reader_task.cancel()
         self._reader_task = None
         # Reject all pending futures
-        for _name, (_op, fut) in self._pending.items():
+        for _name, (_cid, _op, fut) in self._pending.items():
             if not fut.done():
                 fut.set_exception(RuntimeError("Preview process exited"))
         self._pending.clear()
@@ -286,6 +296,34 @@ class PreviewManager:
             logger.info("ios-preview stdout closed")
             self._cleanup_state()
 
+    def _take_pending(self, name: str, event: dict) -> tuple[str, asyncio.Future] | None:
+        """Claim the pending command this event answers, if it answers one.
+
+        A reply carrying a different id belongs to a request that already timed
+        out, so it is discarded rather than applied to whatever is waiting now.
+        A reply with no id at all is accepted: the subprocess may predate the
+        id, and refusing those would hang every call against an older binary.
+        """
+        entry = self._pending.get(name)
+        if entry is None:
+            return None
+        cid, op, fut = entry
+        reply_id = event.get("id")
+        if reply_id is not None and reply_id != cid:
+            logger.debug(
+                "Ignoring stale %s for %s (id %s, waiting on %s)",
+                event.get("event"), name, reply_id, cid,
+            )
+            return None
+        self._pending.pop(name, None)
+        return op, fut
+
+    def _next_command_id(self) -> str:
+        """Monotonic per-process id. Uniqueness within this process is the
+        whole requirement -- the subprocess only ever echoes it back."""
+        self._command_seq += 1
+        return f"c{self._command_seq}"
+
     def _dispatch_event(self, event: dict) -> None:
         """Handle a single event from the subprocess."""
         evt_type = event.get("event")
@@ -304,20 +342,20 @@ class PreviewManager:
             )
 
         elif evt_type == "added":
-            entry = self._pending.pop(name, None)
+            entry = self._take_pending(name, event)
             if entry and not entry[1].done():
                 entry[1].set_result(True)
 
         elif evt_type == "add_failed":
             error = event.get("error", "Unknown error")
-            entry = self._pending.pop(name, None)
+            entry = self._take_pending(name, event)
             if entry and not entry[1].done():
                 entry[1].set_exception(
                     RuntimeError(f"Failed to add preview for {name}: {error}")
                 )
 
         elif evt_type == "removed":
-            entry = self._pending.pop(name, None)
+            entry = self._take_pending(name, event)
             if entry and not entry[1].done():
                 entry[1].set_result(True)
 
@@ -335,9 +373,11 @@ class PreviewManager:
             # remove got what it wanted -- the preview is gone. An add did not:
             # completing it successfully would have add() record a preview for
             # an unplugged device and reserve a window position for it.
+            # No id to match against: a disconnect answers no command, it
+            # just invalidates whatever is outstanding for this device.
             entry = self._pending.pop(name, None)
-            if entry and not entry[1].done():
-                op, fut = entry
+            if entry and not entry[2].done():
+                _cid, op, fut = entry
                 if op == "remove":
                     fut.set_result(True)
                 else:
@@ -422,9 +462,12 @@ class PreviewManager:
 
             loop = asyncio.get_event_loop()
             fut: asyncio.Future = loop.create_future()
-            self._pending[name] = ("add", fut)
+            cid = self._next_command_id()
+            self._pending[name] = (cid, "add", fut)
 
-            await self._send({"cmd": "add", "name": name, "position": position})
+            await self._send(
+                {"cmd": "add", "name": name, "position": position, "id": cid}
+            )
 
             try:
                 await asyncio.wait_for(fut, timeout=10.0)
@@ -452,9 +495,10 @@ class PreviewManager:
 
         loop = asyncio.get_event_loop()
         fut: asyncio.Future = loop.create_future()
-        self._pending[name] = ("remove", fut)
+        cid = self._next_command_id()
+        self._pending[name] = (cid, "remove", fut)
 
-        await self._send({"cmd": "remove", "name": name})
+        await self._send({"cmd": "remove", "name": name, "id": cid})
 
         try:
             await asyncio.wait_for(fut, timeout=5.0)

--- a/server/device/preview.py
+++ b/server/device/preview.py
@@ -102,6 +102,13 @@ def build_preview_bundle() -> Path:
 
     bundle, binary = bundle_paths()
     if binary.exists() and binary.stat().st_mtime >= source.stat().st_mtime:
+        # Rewrite the bundle scaffolding even on the fast path. The freshness
+        # test only asks about the binary, so a run that compiled and then
+        # failed to finish the bundle -- no Info.plist, no icon -- leaves a
+        # binary newer than the source, and every later call would sail past
+        # this return and report success for an app macOS cannot launch.
+        # Idempotent and cheap: one small plist write and one icon copy.
+        write_app_bundle(bundle)
         return binary
 
     swiftc = shutil.which("swiftc")
@@ -114,18 +121,29 @@ def build_preview_bundle() -> Path:
     (bundle / "Contents" / "MacOS").mkdir(parents=True, exist_ok=True)
     logger.info("Compiling ios-preview: %s -> %s", source, binary)
 
-    proc = subprocess.run(  # noqa: S603
-        [
-            swiftc,
-            "-o", str(binary),
-            str(source),
-            "-framework", "AVFoundation",
-            "-framework", "CoreMediaIO",
-            "-framework", "AppKit",
-        ],
-        capture_output=True,
-        text=True,
-    )
+    try:
+        proc = subprocess.run(  # noqa: S603
+            [
+                swiftc,
+                "-o", str(binary),
+                str(source),
+                "-framework", "AVFoundation",
+                "-framework", "CoreMediaIO",
+                "-framework", "AppKit",
+            ],
+            capture_output=True,
+            text=True,
+            # The compile takes ~1.5s. A minute is not a performance budget,
+            # it is the line past which swiftc is stuck rather than slow --
+            # and unbounded, a stuck compiler hangs `quern setup` with no
+            # output and no way to tell it apart from a hang in Quern itself.
+            timeout=60,
+        )
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError(
+            "swiftc did not finish within 60s while building the screen-mirror "
+            "app. Try `xcode-select -p` to check the active toolchain."
+        ) from e
     if proc.returncode != 0:
         err = proc.stderr.strip() or proc.stdout.strip()
         raise RuntimeError(f"Failed to compile ios-preview:\n{err}")
@@ -164,7 +182,9 @@ class PreviewManager:
         self._available: list[PreviewDeviceInfo] = []
         self._ready = asyncio.Event()
         self._reader_task: asyncio.Task | None = None
-        self._pending: dict[str, asyncio.Future] = {}
+        # name -> (operation, future). The operation matters: a disconnect
+        # while an add is in flight must fail that add, not complete it.
+        self._pending: dict[str, tuple[str, asyncio.Future]] = {}
         self._positions: set[int] = set()
         self._stagger_lock = asyncio.Lock()
         self._bundle_path = QUERN_BIN_DIR / APP_BUNDLE_NAME
@@ -236,7 +256,7 @@ class PreviewManager:
             self._reader_task.cancel()
         self._reader_task = None
         # Reject all pending futures
-        for name, fut in self._pending.items():
+        for _name, (_op, fut) in self._pending.items():
             if not fut.done():
                 fut.set_exception(RuntimeError("Preview process exited"))
         self._pending.clear()
@@ -284,20 +304,22 @@ class PreviewManager:
             )
 
         elif evt_type == "added":
-            fut = self._pending.pop(name, None)
-            if fut and not fut.done():
-                fut.set_result(True)
+            entry = self._pending.pop(name, None)
+            if entry and not entry[1].done():
+                entry[1].set_result(True)
 
         elif evt_type == "add_failed":
             error = event.get("error", "Unknown error")
-            fut = self._pending.pop(name, None)
-            if fut and not fut.done():
-                fut.set_exception(RuntimeError(f"Failed to add preview for {name}: {error}"))
+            entry = self._pending.pop(name, None)
+            if entry and not entry[1].done():
+                entry[1].set_exception(
+                    RuntimeError(f"Failed to add preview for {name}: {error}")
+                )
 
         elif evt_type == "removed":
-            fut = self._pending.pop(name, None)
-            if fut and not fut.done():
-                fut.set_result(True)
+            entry = self._pending.pop(name, None)
+            if entry and not entry[1].done():
+                entry[1].set_result(True)
 
         elif evt_type == "disconnected":
             # The phone was unplugged. Distinct from "removed", which answers a
@@ -309,10 +331,19 @@ class PreviewManager:
                 self._positions.discard(preview.position)
                 logger.info("Preview device disconnected: %s", name)
             self._available = [d for d in self._available if d.name != name]
-            # A remove in flight for this device will never be answered now.
-            fut = self._pending.pop(name, None)
-            if fut and not fut.done():
-                fut.set_result(True)
+            # Settle whatever was in flight, according to what it asked for. A
+            # remove got what it wanted -- the preview is gone. An add did not:
+            # completing it successfully would have add() record a preview for
+            # an unplugged device and reserve a window position for it.
+            entry = self._pending.pop(name, None)
+            if entry and not entry[1].done():
+                op, fut = entry
+                if op == "remove":
+                    fut.set_result(True)
+                else:
+                    fut.set_exception(
+                        RuntimeError(f"{name} disconnected before its preview opened")
+                    )
 
         elif evt_type == "connected":
             # Announced, not opened -- in interactive mode the server decides
@@ -391,7 +422,7 @@ class PreviewManager:
 
             loop = asyncio.get_event_loop()
             fut: asyncio.Future = loop.create_future()
-            self._pending[name] = fut
+            self._pending[name] = ("add", fut)
 
             await self._send({"cmd": "add", "name": name, "position": position})
 
@@ -421,7 +452,7 @@ class PreviewManager:
 
         loop = asyncio.get_event_loop()
         fut: asyncio.Future = loop.create_future()
-        self._pending[name] = fut
+        self._pending[name] = ("remove", fut)
 
         await self._send({"cmd": "remove", "name": name})
 

--- a/server/device/preview.py
+++ b/server/device/preview.py
@@ -299,17 +299,24 @@ class PreviewManager:
     def _take_pending(self, name: str, event: dict) -> tuple[str, asyncio.Future] | None:
         """Claim the pending command this event answers, if it answers one.
 
-        A reply carrying a different id belongs to a request that already timed
-        out, so it is discarded rather than applied to whatever is waiting now.
-        A reply with no id at all is accepted: the subprocess may predate the
-        id, and refusing those would hang every call against an older binary.
+        A reply must carry the id of the command it answers. Anything else
+        belongs to a request that already timed out, and applying it to the one
+        waiting now is the whole failure this guards against.
+
+        That includes a reply with no id at all. Accepting those was meant to
+        tolerate a subprocess built before the id existed, but it reopened the
+        same hole from the other side: an id-less `removed` arriving late still
+        settles a newer add. The tolerance is not needed anyway -- the
+        subprocess is compiled from source that ships with this server and is
+        rebuilt whenever that source is newer, so a binary that cannot echo an
+        id is one this code never sent an id to.
         """
         entry = self._pending.get(name)
         if entry is None:
             return None
         cid, op, fut = entry
         reply_id = event.get("id")
-        if reply_id is not None and reply_id != cid:
+        if reply_id != cid:
             logger.debug(
                 "Ignoring stale %s for %s (id %s, waiting on %s)",
                 event.get("event"), name, reply_id, cid,

--- a/server/device/preview.py
+++ b/server/device/preview.py
@@ -299,6 +299,31 @@ class PreviewManager:
             if fut and not fut.done():
                 fut.set_result(True)
 
+        elif evt_type == "disconnected":
+            # The phone was unplugged. Distinct from "removed", which answers a
+            # remove command we sent: nobody asked for this, and the preview is
+            # gone whether or not anything was waiting on it. Drop it from the
+            # active set so its slot is free and a reconnect can take the name.
+            if name in self._active:
+                preview = self._active.pop(name)
+                self._positions.discard(preview.position)
+                logger.info("Preview device disconnected: %s", name)
+            self._available = [d for d in self._available if d.name != name]
+            # A remove in flight for this device will never be answered now.
+            fut = self._pending.pop(name, None)
+            if fut and not fut.done():
+                fut.set_result(True)
+
+        elif evt_type == "connected":
+            # Announced, not opened -- in interactive mode the server decides
+            # what is on screen. Recording it keeps the available list honest
+            # between explicit `list` calls.
+            if not any(d.name == name for d in self._available):
+                self._available.append(
+                    PreviewDeviceInfo(name=name, cmio_id=event.get("id", ""))
+                )
+                logger.info("Preview device connected: %s", name)
+
         elif evt_type == "window_closed":
             # User closed the window manually
             if name in self._active:

--- a/server/device/preview.py
+++ b/server/device/preview.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import logging
 import shutil
+import subprocess
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -54,6 +55,86 @@ _INFO_PLIST = """\
 """
 
 
+def bundle_paths() -> tuple[Path, Path]:
+    """Where the preview app bundle and its binary live."""
+    bundle = QUERN_BIN_DIR / APP_BUNDLE_NAME
+    return bundle, bundle / "Contents" / "MacOS" / BINARY_NAME
+
+
+def write_app_bundle(bundle: Path) -> None:
+    """Create a minimal .app bundle so macOS shows the correct name and icon."""
+    contents = bundle / "Contents"
+    macos_dir = contents / "MacOS"
+    resources_dir = contents / "Resources"
+
+    macos_dir.mkdir(parents=True, exist_ok=True)
+    resources_dir.mkdir(parents=True, exist_ok=True)
+
+    (contents / "Info.plist").write_text(_INFO_PLIST)
+
+    icon_src = _RESOURCES_DIR / "wda-icon.png"
+    icon_dst = resources_dir / "AppIcon.png"
+    if icon_src.exists():
+        shutil.copy2(icon_src, icon_dst)
+
+    logger.info("Created app bundle: %s", bundle)
+
+
+def build_preview_bundle() -> Path:
+    """Compile ios-preview into its .app bundle, and return the binary path.
+
+    Synchronous on purpose: `quern setup` is a synchronous CLI path and calls
+    this directly, while the server reaches it through a worker thread. One
+    implementation rather than two, because a second copy of the compile
+    command is exactly the kind of thing that drifts.
+
+    A no-op when the binary is newer than the source. Raises RuntimeError with
+    an actionable message when the source or swiftc is missing -- callers
+    decide whether that is fatal (the preview API) or a skipped optional check
+    (setup).
+    """
+    source = _find_source()
+    if source is None:
+        raise RuntimeError(
+            "ios-preview.swift source not found. "
+            "Expected at tools/ios-preview.swift relative to the project root."
+        )
+
+    bundle, binary = bundle_paths()
+    if binary.exists() and binary.stat().st_mtime >= source.stat().st_mtime:
+        return binary
+
+    swiftc = shutil.which("swiftc")
+    if swiftc is None:
+        raise RuntimeError(
+            "swiftc not found. Install Xcode or Xcode Command Line Tools: "
+            "xcode-select --install"
+        )
+
+    (bundle / "Contents" / "MacOS").mkdir(parents=True, exist_ok=True)
+    logger.info("Compiling ios-preview: %s -> %s", source, binary)
+
+    proc = subprocess.run(  # noqa: S603
+        [
+            swiftc,
+            "-o", str(binary),
+            str(source),
+            "-framework", "AVFoundation",
+            "-framework", "CoreMediaIO",
+            "-framework", "AppKit",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        err = proc.stderr.strip() or proc.stdout.strip()
+        raise RuntimeError(f"Failed to compile ios-preview:\n{err}")
+
+    logger.info("ios-preview compiled successfully")
+    write_app_bundle(bundle)
+    return binary
+
+
 def _find_source() -> Path | None:
     for p in _SOURCE_CANDIDATES:
         if p.exists():
@@ -90,75 +171,15 @@ class PreviewManager:
         self._binary_path = self._bundle_path / "Contents" / "MacOS" / BINARY_NAME
 
     async def ensure_binary(self) -> Path:
-        """Lazy-compile ios-preview if needed. Returns path to binary."""
-        source = _find_source()
-        if source is None:
-            raise RuntimeError(
-                "ios-preview.swift source not found. "
-                "Expected at tools/ios-preview.swift relative to the project root."
-            )
+        """Lazy-compile ios-preview if needed. Returns path to binary.
 
-        if self._binary_path.exists():
-            src_mtime = source.stat().st_mtime
-            bin_mtime = self._binary_path.stat().st_mtime
-            if bin_mtime >= src_mtime:
-                return self._binary_path
-
-        swiftc = shutil.which("swiftc")
-        if swiftc is None:
-            raise RuntimeError(
-                "swiftc not found. Install Xcode or Xcode Command Line Tools: "
-                "xcode-select --install"
-            )
-
-        # Create bundle directory structure before compiling into it
-        macos_dir = self._bundle_path / "Contents" / "MacOS"
-        macos_dir.mkdir(parents=True, exist_ok=True)
-        logger.info("Compiling ios-preview: %s → %s", source, self._binary_path)
-
-        proc = await asyncio.create_subprocess_exec(
-            swiftc,
-            "-o", str(self._binary_path),
-            str(source),
-            "-framework", "AVFoundation",
-            "-framework", "CoreMediaIO",
-            "-framework", "AppKit",
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        stdout, stderr = await proc.communicate()
-
-        if proc.returncode != 0:
-            err = stderr.decode().strip() or stdout.decode().strip()
-            raise RuntimeError(f"Failed to compile ios-preview:\n{err}")
-
-        logger.info("ios-preview compiled successfully")
-
-        # Finalize .app bundle (Info.plist, icon)
-        self._create_app_bundle()
-
-        return self._binary_path
+        Off the event loop: the compile takes ~1.5s, which is a long time to
+        stall every other request for.
+        """
+        return await asyncio.to_thread(build_preview_bundle)
 
     def _create_app_bundle(self) -> None:
-        """Create a minimal .app bundle so macOS shows the correct name and icon."""
-        contents = self._bundle_path / "Contents"
-        macos_dir = contents / "MacOS"
-        resources_dir = contents / "Resources"
-
-        macos_dir.mkdir(parents=True, exist_ok=True)
-        resources_dir.mkdir(parents=True, exist_ok=True)
-
-        # Write Info.plist
-        plist_path = contents / "Info.plist"
-        plist_path.write_text(_INFO_PLIST)
-
-        # Copy icon
-        icon_src = _RESOURCES_DIR / "wda-icon.png"
-        icon_dst = resources_dir / "AppIcon.png"
-        if icon_src.exists():
-            shutil.copy2(icon_src, icon_dst)
-
-        logger.info("Created app bundle: %s", self._bundle_path)
+        write_app_bundle(self._bundle_path)
 
     # ------------------------------------------------------------------
     # Process lifecycle

--- a/server/lifecycle/setup.py
+++ b/server/lifecycle/setup.py
@@ -598,7 +598,13 @@ def build_preview_app() -> CheckResult:
         from server.device.preview import build_preview_bundle
 
         build_preview_bundle()
-    except RuntimeError as e:
+    except (RuntimeError, OSError) as e:
+        # OSError as well as RuntimeError, per the error-path convention in
+        # CONTRIBUTING: catch the base class, not the subclasses seen so far.
+        # The build stats files, creates directories, writes a plist, copies an
+        # icon and launches a process -- an unwritable ~/.quern or a transient
+        # filesystem fault raises OSError, and catching only RuntimeError would
+        # end setup entirely over an optional convenience.
         return CheckResult(
             name=name,
             status=CheckStatus.WARNING,

--- a/server/lifecycle/setup.py
+++ b/server/lifecycle/setup.py
@@ -555,6 +555,64 @@ exec "{venv_python}" -m server "$@"
         )
 
 
+def build_preview_app() -> CheckResult:
+    """Compile the screen-mirror app during setup rather than on first use.
+
+    It used to be built lazily, the first time something asked for a preview.
+    That left a hole: the menu-bar app only offers "Screen Mirror…" when the
+    bundle exists on disk, so on a fresh install the item was missing until
+    the user had already driven a preview from the API or an MCP tool. The
+    menu bar is the route for people who would rather not do that, so the
+    feature was hidden from exactly the audience it is for.
+
+    Building it here costs about 1.5 seconds and makes the menu item appear.
+
+    Treated as optional, the way scrcpy is: a machine without Xcode Command
+    Line Tools cannot compile it, and that is a missing convenience rather
+    than a broken install.
+    """
+    name = "Screen mirror (Quern Preview)"
+
+    if _which("swiftc") is None:
+        result = CheckResult(
+            name=name,
+            status=CheckStatus.SKIPPED,
+            message="Xcode Command Line Tools not found — screen mirror unavailable",
+            detail="Install with: xcode-select --install",
+            fixable=True,
+        )
+        if _prompt_yn(
+            "    Xcode Command Line Tools not found (needed for the screen-mirror "
+            "app). Open the installer?",
+        ):
+            # `xcode-select --install` hands off to a macOS dialog and returns
+            # immediately, so there is nothing to wait on and no exit code
+            # worth trusting -- it also reports failure when the tools are
+            # already present. Say what happens next instead.
+            _run(["xcode-select", "--install"])
+            print("    A macOS installer dialog should have opened.")
+            print("    Re-run `quern setup` once it finishes to build the app.")
+        return result
+
+    try:
+        from server.device.preview import build_preview_bundle
+
+        build_preview_bundle()
+    except RuntimeError as e:
+        return CheckResult(
+            name=name,
+            status=CheckStatus.WARNING,
+            message="Could not build the screen-mirror app",
+            detail=str(e),
+        )
+
+    return CheckResult(
+        name=name,
+        status=CheckStatus.OK,
+        message="Built (available from the menu bar)",
+    )
+
+
 def launch_menubar_app(project_root: Path) -> CheckResult | None:
     """Launch the bundled menu-bar app so it self-registers as a login item.
 
@@ -2090,6 +2148,13 @@ def run_setup() -> int:
     # ── Wrapper script installation ──
 
     report.add(install_wrapper_script())
+
+    # ── Screen-mirror app ──
+    #
+    # Before the menu-bar launch below, deliberately: the menu only shows
+    # "Screen Mirror…" when this bundle exists, and it reads that at launch.
+
+    report.add(build_preview_app())
 
     # ── Menu-bar app (only present in bundled release tarballs) ──
 

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -166,13 +166,16 @@ class TestCommandCorrelation:
         finally:
             loop.close()
 
-    def test_a_reply_with_no_id_is_still_accepted(self):
-        """An older subprocess does not echo ids, and refusing those would hang
-        every call against a binary the user has not rebuilt yet."""
+    def test_a_reply_with_no_id_is_refused(self):
+        """Accepting id-less replies was meant to tolerate an older subprocess,
+        but it reopened the same hole from the other side: a late id-less
+        `removed` would still settle a newer add. The subprocess is compiled
+        from source shipping with this server, so a binary that cannot echo an
+        id is one this code never sent an id to."""
         loop, mgr, fut = self._pending("add", "c2")
         try:
             mgr._dispatch_event({"event": "added", "name": "iPhone 11"})
-            assert fut.result() is True
+            assert not fut.done(), "an id-less reply settled an id-bearing command"
         finally:
             loop.close()
 
@@ -180,3 +183,28 @@ class TestCommandCorrelation:
         mgr = PreviewManager()
         ids = {mgr._next_command_id() for _ in range(50)}
         assert len(ids) == 50
+
+
+class TestAddAcknowledgement:
+    def test_a_window_closed_before_ack_fails_the_add(self):
+        """The subprocess acknowledges an add a second after starting capture,
+        and the window can be closed inside that second. Acknowledging anyway
+        left the server holding an active preview with no window, and refusing
+        fresh adds for that device because it believed one was running."""
+        loop = asyncio.new_event_loop()
+        mgr = PreviewManager()
+        fut = loop.create_future()
+        mgr._pending["iPhone 11"] = ("c1", "add", fut)
+        try:
+            mgr._dispatch_event({
+                "event": "add_failed",
+                "name": "iPhone 11",
+                "error": "Window closed before the preview was acknowledged",
+                "id": "c1",
+            })
+            assert fut.done()
+            with pytest.raises(RuntimeError, match="Window closed"):
+                fut.result()
+            assert mgr._active == {}
+        finally:
+            loop.close()

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -87,11 +87,11 @@ class TestDisconnectEvent:
     """`_pending` holds futures for both add and remove, so a disconnect has to
     settle them differently."""
 
-    def _manager_with_pending(self, op: str):
+    def _manager_with_pending(self, op: str, cid: str = "c1"):
         loop = asyncio.new_event_loop()
         mgr = PreviewManager()
         fut = loop.create_future()
-        mgr._pending["iPhone 11"] = (op, fut)
+        mgr._pending["iPhone 11"] = (cid, op, fut)
         return loop, mgr, fut
 
     def test_a_disconnect_fails_an_in_flight_add(self):
@@ -131,3 +131,52 @@ class TestDisconnectEvent:
         mgr._dispatch_event({"event": "connected", "name": "iPhone 11", "id": "A"})
         assert [d.name for d in mgr._available] == ["iPhone 11"]
         assert mgr._active == {}
+
+
+class TestCommandCorrelation:
+    """A write that times out was still delivered and may still run, so its
+    late reply must not be matched against whatever holds that name next."""
+
+    def _pending(self, op: str, cid: str):
+        loop = asyncio.new_event_loop()
+        mgr = PreviewManager()
+        fut = loop.create_future()
+        mgr._pending["iPhone 11"] = (cid, op, fut)
+        return loop, mgr, fut
+
+    def test_a_late_reply_does_not_settle_a_newer_command(self):
+        """The exact sequence: remove() times out, add() takes its place, then
+        the delayed `removed` arrives. Resolving it would have add() record a
+        preview the subprocess had already torn down."""
+        loop, mgr, add_fut = self._pending("add", "c2")
+        try:
+            mgr._dispatch_event(
+                {"event": "removed", "name": "iPhone 11", "id": "c1"}
+            )
+            assert not add_fut.done(), "a stale reply settled the new command"
+            assert "iPhone 11" in mgr._pending, "the new command was discarded"
+        finally:
+            loop.close()
+
+    def test_the_matching_reply_settles_it(self):
+        loop, mgr, fut = self._pending("add", "c2")
+        try:
+            mgr._dispatch_event({"event": "added", "name": "iPhone 11", "id": "c2"})
+            assert fut.result() is True
+        finally:
+            loop.close()
+
+    def test_a_reply_with_no_id_is_still_accepted(self):
+        """An older subprocess does not echo ids, and refusing those would hang
+        every call against a binary the user has not rebuilt yet."""
+        loop, mgr, fut = self._pending("add", "c2")
+        try:
+            mgr._dispatch_event({"event": "added", "name": "iPhone 11"})
+            assert fut.result() is True
+        finally:
+            loop.close()
+
+    def test_commands_get_distinct_ids(self):
+        mgr = PreviewManager()
+        ids = {mgr._next_command_id() for _ in range(50)}
+        assert len(ids) == 50

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -1,0 +1,133 @@
+"""Tests for server/device/preview.py — screen-mirror build and event handling."""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+
+import pytest
+
+from server.device.preview import PreviewManager
+
+
+class TestBuildBundle:
+    def test_a_stale_bundle_is_repaired_on_the_fast_path(self, tmp_path, monkeypatch):
+        """The freshness test only asks about the binary. A run that compiled
+        and then failed to finish the bundle leaves a binary newer than the
+        source, so every later call would return it and report success for an
+        app macOS cannot launch."""
+        from server.device import preview
+
+        bundle = tmp_path / "Quern Preview.app"
+        binary = bundle / "Contents" / "MacOS" / "ios-preview"
+        binary.parent.mkdir(parents=True)
+        binary.write_text("compiled")
+
+        source = tmp_path / "ios-preview.swift"
+        source.write_text("// source")
+        import os
+        os.utime(source, (1, 1))  # older than the binary
+
+        monkeypatch.setattr(preview, "_find_source", lambda: source)
+        monkeypatch.setattr(preview, "bundle_paths", lambda: (bundle, binary))
+
+        assert not (bundle / "Contents" / "Info.plist").exists()
+        preview.build_preview_bundle()
+        assert (bundle / "Contents" / "Info.plist").exists(), "bundle was not repaired"
+
+    def test_a_stuck_compiler_fails_instead_of_hanging(self, tmp_path, monkeypatch):
+        """Unbounded, a stuck swiftc hangs `quern setup` with no output and no
+        way to tell it apart from a hang in Quern itself."""
+        from server.device import preview
+
+        bundle = tmp_path / "Quern Preview.app"
+        binary = bundle / "Contents" / "MacOS" / "ios-preview"
+        source = tmp_path / "ios-preview.swift"
+        source.write_text("// source")
+
+        monkeypatch.setattr(preview, "_find_source", lambda: source)
+        monkeypatch.setattr(preview, "bundle_paths", lambda: (bundle, binary))
+        monkeypatch.setattr(preview.shutil, "which", lambda _: "/usr/bin/swiftc")
+        monkeypatch.setattr(
+            preview.subprocess, "run",
+            lambda *a, **kw: (_ for _ in ()).throw(
+                subprocess.TimeoutExpired(cmd="swiftc", timeout=60)
+            ),
+        )
+
+        with pytest.raises(RuntimeError, match="did not finish within 60s"):
+            preview.build_preview_bundle()
+
+    def test_the_compile_is_actually_given_a_timeout(self, tmp_path, monkeypatch):
+        """A timeout that is never passed to subprocess.run protects nothing."""
+        from server.device import preview
+
+        bundle = tmp_path / "Quern Preview.app"
+        binary = bundle / "Contents" / "MacOS" / "ios-preview"
+        source = tmp_path / "ios-preview.swift"
+        source.write_text("// source")
+        captured: dict = {}
+
+        def fake_run(cmd, **kwargs):
+            captured.update(kwargs)
+            binary.parent.mkdir(parents=True, exist_ok=True)
+            binary.write_text("x")
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        monkeypatch.setattr(preview, "_find_source", lambda: source)
+        monkeypatch.setattr(preview, "bundle_paths", lambda: (bundle, binary))
+        monkeypatch.setattr(preview.shutil, "which", lambda _: "/usr/bin/swiftc")
+        monkeypatch.setattr(preview.subprocess, "run", fake_run)
+
+        preview.build_preview_bundle()
+        assert captured.get("timeout"), "swiftc was launched with no timeout"
+
+
+class TestDisconnectEvent:
+    """`_pending` holds futures for both add and remove, so a disconnect has to
+    settle them differently."""
+
+    def _manager_with_pending(self, op: str):
+        loop = asyncio.new_event_loop()
+        mgr = PreviewManager()
+        fut = loop.create_future()
+        mgr._pending["iPhone 11"] = (op, fut)
+        return loop, mgr, fut
+
+    def test_a_disconnect_fails_an_in_flight_add(self):
+        """Completing it successfully would have add() record a preview for an
+        unplugged device and reserve a window position for it."""
+        loop, mgr, fut = self._manager_with_pending("add")
+        try:
+            mgr._dispatch_event({"event": "disconnected", "name": "iPhone 11"})
+            assert fut.done()
+            with pytest.raises(RuntimeError, match="disconnected before"):
+                fut.result()
+        finally:
+            loop.close()
+
+    def test_a_disconnect_completes_an_in_flight_remove(self):
+        """A remove got what it asked for: the preview is gone."""
+        loop, mgr, fut = self._manager_with_pending("remove")
+        try:
+            mgr._dispatch_event({"event": "disconnected", "name": "iPhone 11"})
+            assert fut.result() is True
+        finally:
+            loop.close()
+
+    def test_a_disconnect_drops_the_device_from_available(self):
+        """The server would otherwise advertise an unplugged phone until
+        something forced a refresh."""
+        from server.device.preview import PreviewDeviceInfo
+
+        mgr = PreviewManager()
+        mgr._available = [PreviewDeviceInfo(name="iPhone 11", cmio_id="A")]
+        mgr._dispatch_event({"event": "disconnected", "name": "iPhone 11"})
+        assert mgr._available == []
+
+    def test_a_connect_adds_the_device_without_opening_anything(self):
+        """In interactive mode the server decides what is on screen."""
+        mgr = PreviewManager()
+        mgr._dispatch_event({"event": "connected", "name": "iPhone 11", "id": "A"})
+        assert [d.name for d in mgr._available] == ["iPhone 11"]
+        assert mgr._active == {}

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1115,3 +1115,74 @@ class TestXcodeGate:
         for call in run_mock.call_args_list:
             args = call.args[0]
             assert args[0] != "xcrun", f"unexpected xcrun call: {args}"
+
+
+class TestBuildPreviewApp:
+    """The screen-mirror app is built during setup, not on first use.
+
+    Lazy building left the menu-bar app's "Screen Mirror…" item hidden on a
+    fresh install: the item only appears when the bundle exists, and nothing
+    created it until someone had already driven a preview from the API or an
+    MCP tool. That is the opposite of who the menu bar is for.
+    """
+
+    def test_builds_when_swiftc_is_available(self):
+        from server.lifecycle.setup import build_preview_app
+
+        with patch("server.lifecycle.setup._which", return_value="/usr/bin/swiftc"), \
+             patch("server.device.preview.build_preview_bundle") as build:
+            result = build_preview_app()
+
+        build.assert_called_once()
+        assert result.status == CheckStatus.OK
+
+    def test_missing_command_line_tools_is_skipped_not_failed(self):
+        """A machine without swiftc has a missing convenience, not a broken
+        install -- the same call scrcpy gets for Android preview."""
+        from server.lifecycle.setup import build_preview_app
+
+        with patch("server.lifecycle.setup._which", return_value=None), \
+             patch("server.lifecycle.setup._prompt_yn", return_value=False):
+            result = build_preview_app()
+
+        assert result.status == CheckStatus.SKIPPED
+        assert result.fixable is True
+        assert "xcode-select --install" in (result.detail or "")
+
+    def test_accepting_the_prompt_opens_the_installer(self):
+        """`xcode-select --install` hands off to a macOS dialog rather than
+        installing inline, so setup can only open it and say what comes next."""
+        from server.lifecycle.setup import build_preview_app
+
+        ran: list[list[str]] = []
+        with patch("server.lifecycle.setup._which", return_value=None), \
+             patch("server.lifecycle.setup._prompt_yn", return_value=True), \
+             patch("server.lifecycle.setup._run",
+                   side_effect=lambda cmd, **kw: (ran.append(cmd), (0, "", ""))[1]):
+            result = build_preview_app()
+
+        assert ran == [["xcode-select", "--install"]]
+        # Still skipped: the dialog is asynchronous, so nothing was built.
+        assert result.status == CheckStatus.SKIPPED
+
+    def test_declining_the_prompt_runs_nothing(self):
+        from server.lifecycle.setup import build_preview_app
+
+        with patch("server.lifecycle.setup._which", return_value=None), \
+             patch("server.lifecycle.setup._prompt_yn", return_value=False), \
+             patch("server.lifecycle.setup._run") as run:
+            build_preview_app()
+
+        run.assert_not_called()
+
+    def test_a_failed_build_warns_rather_than_stopping_setup(self):
+        """Setup continues: everything else about the install is still fine."""
+        from server.lifecycle.setup import build_preview_app
+
+        with patch("server.lifecycle.setup._which", return_value="/usr/bin/swiftc"), \
+             patch("server.device.preview.build_preview_bundle",
+                   side_effect=RuntimeError("swiftc exploded")):
+            result = build_preview_app()
+
+        assert result.status == CheckStatus.WARNING
+        assert "swiftc exploded" in (result.detail or "")

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1175,6 +1175,20 @@ class TestBuildPreviewApp:
 
         run.assert_not_called()
 
+    def test_a_filesystem_failure_warns_rather_than_stopping_setup(self):
+        """The build stats files, makes directories, writes a plist, copies an
+        icon and launches a process. An unwritable ~/.quern raises OSError, and
+        catching only RuntimeError would end setup over an optional extra."""
+        from server.lifecycle.setup import build_preview_app
+
+        with patch("server.lifecycle.setup._which", return_value="/usr/bin/swiftc"), \
+             patch("server.device.preview.build_preview_bundle",
+                   side_effect=PermissionError("~/.quern is not writable")):
+            result = build_preview_app()
+
+        assert result.status == CheckStatus.WARNING
+        assert "not writable" in (result.detail or "")
+
     def test_a_failed_build_warns_rather_than_stopping_setup(self):
         """Setup continues: everything else about the install is still fine."""
         from server.lifecycle.setup import build_preview_app

--- a/tools/ios-preview.swift
+++ b/tools/ios-preview.swift
@@ -51,11 +51,13 @@ func enableScreenCaptureDevices() {
 private let screenCaptureModelID = "iOS Device"
 
 func isScreenCaptureDevice(_ d: AVCaptureDevice) -> Bool {
-    if d.hasMediaType(.muxed) { return true }
-    // The video-only fallback is kept rather than dropped: screen-capture
-    // devices are muxed on every macOS this has been run on, but the model ID
-    // is the thing actually being asserted, and keeping the branch means a
-    // host that types them as video still mirrors instead of showing nothing.
+    // The model ID is the whole assertion, on either media type. Accepting
+    // any muxed external device was looser than the claim above it: muxed
+    // means "audio and video together", which an unrelated capture device can
+    // also be, and one of those would have opened a preview window. Media
+    // type is not checked at all now -- screen-capture devices are muxed on
+    // every macOS this has run on, but a host that typed them as video would
+    // still be recognised by model.
     return d.modelID == screenCaptureModelID
 }
 
@@ -74,9 +76,16 @@ func discoverDevices() -> [AVCaptureDevice] {
 
     var seen = Set<String>()
     var result: [AVCaptureDevice] = []
-    for d in muxed + videoOnly where isScreenCaptureDevice(d) {
-        if seen.insert(d.uniqueID).inserted {
+    for d in muxed + videoOnly {
+        guard seen.insert(d.uniqueID).inserted else { continue }
+        if isScreenCaptureDevice(d) {
             result.append(d)
+        } else {
+            // Say what was turned away and why. The filter runs before any
+            // other logging, so without this a device rejected for an
+            // unexpected model ID -- a future macOS reporting something other
+            // than "iOS Device" -- would look exactly like no device at all.
+            fputs("  ignoring \(d.localizedName) (model \(d.modelID))\n", stderr)
         }
     }
     return result
@@ -289,6 +298,86 @@ class DevicesMenuDelegate: NSObject, NSMenuDelegate {
     }
 }
 
+// MARK: - Stream-aspect window sizing
+
+/// Resizes a window to its stream's own proportions once they are known.
+///
+/// Shared because there are two preview classes -- `PreviewWindow` for the
+/// standalone app and `PreviewSession` for server-driven interactive mode --
+/// and they are near-duplicates. The first version of this fix went into one
+/// of them, so previews opened through the MCP tool kept their bars while the
+/// menu-bar ones did not. Owning the behaviour in one place is what stops
+/// that recurring.
+///
+/// A window opens at a fixed size because nothing better is available yet: a
+/// screen-capture device advertises a single format of 0x0 until it is
+/// actually streaming, so its real size cannot be read at construction time.
+/// The default 400x710 is 0.563 wide-to-tall while a modern iPhone is nearer
+/// 0.462, and `videoGravity = .resizeAspect` letterboxes the difference into
+/// black bars down each side.
+final class StreamAspectSizer {
+    private weak var window: NSWindow?
+    private let input: AVCaptureDeviceInput?
+    private var timer: Timer?
+
+    init(window: NSWindow, input: AVCaptureDeviceInput?) {
+        self.window = window
+        self.input = input
+    }
+
+    /// Poll the input port until it reports real dimensions, then match them.
+    /// Polling rather than KVO because the wait is short, bounded, and this is
+    /// a single-file script; an observer would be more ceremony than the
+    /// problem deserves.
+    func begin() {
+        cancel()
+        var attempts = 0
+        timer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { [weak self] t in
+            guard let self else { t.invalidate(); return }
+            attempts += 1
+            if let dims = self.streamDimensions() {
+                t.invalidate()
+                self.timer = nil
+                self.apply(dims)
+            } else if attempts >= 40 {
+                // ~10s. Keep the default window rather than retrying forever;
+                // a device that never reports dimensions still mirrors fine,
+                // it just keeps the bars.
+                t.invalidate()
+                self.timer = nil
+            }
+        }
+    }
+
+    func cancel() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func streamDimensions() -> CMVideoDimensions? {
+        // A muxed device exposes separate audio and video ports; only the
+        // video one carries the picture size.
+        guard let port = input?.ports.first(where: { $0.mediaType == .video }),
+              let desc = port.formatDescription else { return nil }
+        let dims = CMVideoFormatDescriptionGetDimensions(desc)
+        return (dims.width > 0 && dims.height > 0) ? dims : nil
+    }
+
+    private func apply(_ dims: CMVideoDimensions) {
+        guard let window else { return }
+        let aspect = CGFloat(dims.width) / CGFloat(dims.height)
+        guard aspect.isFinite, aspect > 0 else { return }
+        let contentHeight = window.contentView?.frame.height ?? 710
+        let newWidth = (contentHeight * aspect).rounded()
+        window.setContentSize(NSSize(width: newWidth, height: contentHeight))
+        // Hold the ratio through any later user resize, so the bars cannot
+        // come back by dragging a corner.
+        window.contentAspectRatio = NSSize(
+            width: CGFloat(dims.width), height: CGFloat(dims.height)
+        )
+    }
+}
+
 // MARK: - Preview window
 
 class PreviewWindow: NSObject, NSWindowDelegate {
@@ -297,7 +386,7 @@ class PreviewWindow: NSObject, NSWindowDelegate {
     let device: AVCaptureDevice
     var onWindowClosed: ((String) -> Void)?
     private var input: AVCaptureDeviceInput?
-    private var sizeTimer: Timer?
+    private var sizer: StreamAspectSizer?
 
     init(device: AVCaptureDevice, index: Int) {
         self.device = device
@@ -345,79 +434,25 @@ class PreviewWindow: NSObject, NSWindowDelegate {
         window.contentView = view
 
         super.init()
+        sizer = StreamAspectSizer(window: window, input: input)
         window.delegate = self
         window.makeKeyAndOrderFront(nil)
     }
 
     func start() {
         session.startRunning()
-        beginSizingToStream()
-    }
-
-    /// Resize the window to the stream's own proportions once they are known.
-    ///
-    /// The window opens at a fixed 400x710 because nothing better is available
-    /// yet: a screen-capture device advertises a single format of 0x0 until it
-    /// is actually streaming, so its real size cannot be read at construction
-    /// time. 400x710 is 0.563 wide-to-tall while a modern iPhone is nearer
-    /// 0.462, and `videoGravity = .resizeAspect` letterboxes the difference --
-    /// the black bars down each side.
-    ///
-    /// So poll the input port until it reports real dimensions, then match
-    /// them. Polling rather than KVO because the wait is short, bounded, and
-    /// this is a single-file script; an observer here would be more ceremony
-    /// than the problem deserves.
-    private func beginSizingToStream() {
-        sizeTimer?.invalidate()
-        var attempts = 0
-        sizeTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { [weak self] t in
-            guard let self else { t.invalidate(); return }
-            attempts += 1
-            if let dims = self.streamDimensions() {
-                t.invalidate()
-                self.sizeTimer = nil
-                self.applyStreamAspect(dims)
-            } else if attempts >= 40 {
-                // ~10s. Keep the default window rather than retrying forever;
-                // a device that never reports dimensions still mirrors fine,
-                // it just keeps the bars.
-                t.invalidate()
-                self.sizeTimer = nil
-            }
-        }
-    }
-
-    private func streamDimensions() -> CMVideoDimensions? {
-        // A muxed device exposes separate audio and video ports; only the
-        // video one carries the picture size.
-        guard let port = input?.ports.first(where: { $0.mediaType == .video }),
-              let desc = port.formatDescription else { return nil }
-        let dims = CMVideoFormatDescriptionGetDimensions(desc)
-        return (dims.width > 0 && dims.height > 0) ? dims : nil
-    }
-
-    private func applyStreamAspect(_ dims: CMVideoDimensions) {
-        let aspect = CGFloat(dims.width) / CGFloat(dims.height)
-        guard aspect.isFinite, aspect > 0 else { return }
-        let contentHeight = window.contentView?.frame.height ?? 710
-        let newWidth = (contentHeight * aspect).rounded()
-        window.setContentSize(NSSize(width: newWidth, height: contentHeight))
-        // Hold the ratio through any later user resize, so the bars cannot
-        // come back by dragging a corner.
-        window.contentAspectRatio = NSSize(width: CGFloat(dims.width), height: CGFloat(dims.height))
+        sizer?.begin()
     }
 
     func stop() {
-        sizeTimer?.invalidate()
-        sizeTimer = nil
+        sizer?.cancel()
         session.stopRunning()
         window.delegate = nil
         window.close()
     }
 
     func windowWillClose(_ notification: Notification) {
-        sizeTimer?.invalidate()
-        sizeTimer = nil
+        sizer?.cancel()
         session.stopRunning()
         onWindowClosed?(device.localizedName)
     }
@@ -605,6 +640,8 @@ class PreviewSession: NSObject, NSWindowDelegate {
     let window: NSWindow
     let session: AVCaptureSession
     var onWindowClosed: ((String) -> Void)?
+    private var input: AVCaptureDeviceInput?
+    private var sizer: StreamAspectSizer?
 
     init(device: AVCaptureDevice, position: Int) {
         self.deviceName = device.localizedName
@@ -615,6 +652,7 @@ class PreviewSession: NSObject, NSWindowDelegate {
             let input = try AVCaptureDeviceInput(device: device)
             if session.canAddInput(input) {
                 session.addInput(input)
+                self.input = input
             }
         } catch {
             // Error handled by caller checking session inputs
@@ -649,19 +687,25 @@ class PreviewSession: NSObject, NSWindowDelegate {
         window.contentView = view
 
         super.init()
+        sizer = StreamAspectSizer(window: window, input: input)
         window.delegate = self
         window.makeKeyAndOrderFront(nil)
     }
 
-    func start() { session.startRunning() }
+    func start() {
+        session.startRunning()
+        sizer?.begin()
+    }
 
     func stop() {
+        sizer?.cancel()
         session.stopRunning()
         window.delegate = nil
         window.close()
     }
 
     func windowWillClose(_ notification: Notification) {
+        sizer?.cancel()
         session.stopRunning()
         onWindowClosed?(deviceName)
     }
@@ -818,12 +862,17 @@ class InteractiveDelegate: NSObject, NSApplicationDelegate, PreviewController {
     private func deviceVanished(_ device: AVCaptureDevice) {
         let name = device.localizedName
         allDevices.removeAll { $0.uniqueID == device.uniqueID }
-        guard let session = sessions[name] else { return }
-        fputs("  \(name) disconnected — closing its window\n", stderr)
-        session.onWindowClosed = nil
-        session.stop()
-        sessions.removeValue(forKey: name)
-        rebuildPositions()
+        if let session = sessions[name] {
+            fputs("  \(name) disconnected — closing its window\n", stderr)
+            session.onWindowClosed = nil
+            session.stop()
+            sessions.removeValue(forKey: name)
+            rebuildPositions()
+        }
+        // Emitted whether or not a window was open. The server prunes its
+        // available-devices list on this event, so returning early for a
+        // device nobody was previewing left the server advertising an
+        // unplugged phone until something forced a refresh.
         emit(["event": "disconnected", "name": name])
     }
 

--- a/tools/ios-preview.swift
+++ b/tools/ios-preview.swift
@@ -31,6 +31,34 @@ func enableScreenCaptureDevices() {
 
 // MARK: - Discover iOS devices
 
+/// A connected iPhone publishes more than its screen. On a device that
+/// supports Continuity Camera, its rear camera arrives as a second
+/// `.external` device, and previewing it opened a window showing a black
+/// rectangle -- the camera is not streaming and nobody asked to see it.
+///
+/// The two are cleanly distinguishable, but not by the obvious route: a
+/// `.continuityCamera` discovery session returns nothing, because the camera
+/// is published as a plain external device. What separates them is what they
+/// carry. A screen-capture device is muxed (audio and video together) and
+/// reports the generic `iOS Device` model; a Continuity Camera is video-only
+/// and reports the actual hardware model, e.g. `iPhone16,1`.
+///
+/// Measured with an iPhone 15 Pro and an iPhone 11 attached:
+///
+///     external/muxed:  J iPhone 15 Pro         modelID=iOS Device   muxed
+///                      iPhone 11               modelID=iOS Device   muxed
+///     external/video:  J iPhone 15 Pro Camera  modelID=iPhone16,1   video
+private let screenCaptureModelID = "iOS Device"
+
+func isScreenCaptureDevice(_ d: AVCaptureDevice) -> Bool {
+    if d.hasMediaType(.muxed) { return true }
+    // The video-only fallback is kept rather than dropped: screen-capture
+    // devices are muxed on every macOS this has been run on, but the model ID
+    // is the thing actually being asserted, and keeping the branch means a
+    // host that types them as video still mirrors instead of showing nothing.
+    return d.modelID == screenCaptureModelID
+}
+
 func discoverDevices() -> [AVCaptureDevice] {
     let muxed = AVCaptureDevice.DiscoverySession(
         deviceTypes: [.external],
@@ -46,12 +74,54 @@ func discoverDevices() -> [AVCaptureDevice] {
 
     var seen = Set<String>()
     var result: [AVCaptureDevice] = []
-    for d in muxed + videoOnly {
+    for d in muxed + videoOnly where isScreenCaptureDevice(d) {
         if seen.insert(d.uniqueID).inserted {
             result.append(d)
         }
     }
     return result
+}
+
+// MARK: - Device attach / detach
+
+/// AVFoundation posts both notifications for CoreMediaIO screen-capture
+/// devices, verified by observing an unplug/replug of an iPhone 11:
+///
+///     DISCONNECTED name=iPhone 11 model=iOS Device muxed=true
+///     CONNECTED    name=iPhone 11 model=iOS Device muxed=true
+///
+/// The notification carries the device itself, so `isScreenCaptureDevice`
+/// applies directly and a Continuity Camera appearing alongside its phone is
+/// filtered out here too, rather than being noticed later.
+func observeDeviceChanges(
+    onConnect: @escaping (AVCaptureDevice) -> Void,
+    onDisconnect: @escaping (AVCaptureDevice) -> Void
+) -> [NSObjectProtocol] {
+    let connected = NotificationCenter.default.addObserver(
+        forName: AVCaptureDevice.wasConnectedNotification, object: nil, queue: .main
+    ) { note in
+        guard let d = note.object as? AVCaptureDevice, isScreenCaptureDevice(d) else { return }
+        traceDeviceEvent("attach", d)
+        onConnect(d)
+    }
+    let disconnected = NotificationCenter.default.addObserver(
+        forName: AVCaptureDevice.wasDisconnectedNotification, object: nil, queue: .main
+    ) { note in
+        guard let d = note.object as? AVCaptureDevice, isScreenCaptureDevice(d) else { return }
+        traceDeviceEvent("detach", d)
+        onDisconnect(d)
+    }
+    return [connected, disconnected]
+}
+
+/// Every attach and detach as AVFoundation reports it, before any policy is
+/// applied. One line per event, on stderr, because what the window ends up
+/// doing is a decision layered on top -- and when the two disagree, this is
+/// the record that says which half was surprising.
+func traceDeviceEvent(_ kind: String, _ device: AVCaptureDevice) {
+    let f = DateFormatter()
+    f.dateFormat = "HH:mm:ss.SSS"
+    fputs("  [\(f.string(from: Date()))] \(kind): \(device.localizedName)\n", stderr)
 }
 
 // MARK: - Filter devices by args
@@ -226,6 +296,8 @@ class PreviewWindow: NSObject, NSWindowDelegate {
     let session: AVCaptureSession
     let device: AVCaptureDevice
     var onWindowClosed: ((String) -> Void)?
+    private var input: AVCaptureDeviceInput?
+    private var sizeTimer: Timer?
 
     init(device: AVCaptureDevice, index: Int) {
         self.device = device
@@ -236,6 +308,7 @@ class PreviewWindow: NSObject, NSWindowDelegate {
             let input = try AVCaptureDeviceInput(device: device)
             if session.canAddInput(input) {
                 session.addInput(input)
+                self.input = input
             } else {
                 fputs("  Warning: canAddInput returned false for \(device.localizedName)\n", stderr)
             }
@@ -276,15 +349,75 @@ class PreviewWindow: NSObject, NSWindowDelegate {
         window.makeKeyAndOrderFront(nil)
     }
 
-    func start() { session.startRunning() }
+    func start() {
+        session.startRunning()
+        beginSizingToStream()
+    }
+
+    /// Resize the window to the stream's own proportions once they are known.
+    ///
+    /// The window opens at a fixed 400x710 because nothing better is available
+    /// yet: a screen-capture device advertises a single format of 0x0 until it
+    /// is actually streaming, so its real size cannot be read at construction
+    /// time. 400x710 is 0.563 wide-to-tall while a modern iPhone is nearer
+    /// 0.462, and `videoGravity = .resizeAspect` letterboxes the difference --
+    /// the black bars down each side.
+    ///
+    /// So poll the input port until it reports real dimensions, then match
+    /// them. Polling rather than KVO because the wait is short, bounded, and
+    /// this is a single-file script; an observer here would be more ceremony
+    /// than the problem deserves.
+    private func beginSizingToStream() {
+        sizeTimer?.invalidate()
+        var attempts = 0
+        sizeTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { [weak self] t in
+            guard let self else { t.invalidate(); return }
+            attempts += 1
+            if let dims = self.streamDimensions() {
+                t.invalidate()
+                self.sizeTimer = nil
+                self.applyStreamAspect(dims)
+            } else if attempts >= 40 {
+                // ~10s. Keep the default window rather than retrying forever;
+                // a device that never reports dimensions still mirrors fine,
+                // it just keeps the bars.
+                t.invalidate()
+                self.sizeTimer = nil
+            }
+        }
+    }
+
+    private func streamDimensions() -> CMVideoDimensions? {
+        // A muxed device exposes separate audio and video ports; only the
+        // video one carries the picture size.
+        guard let port = input?.ports.first(where: { $0.mediaType == .video }),
+              let desc = port.formatDescription else { return nil }
+        let dims = CMVideoFormatDescriptionGetDimensions(desc)
+        return (dims.width > 0 && dims.height > 0) ? dims : nil
+    }
+
+    private func applyStreamAspect(_ dims: CMVideoDimensions) {
+        let aspect = CGFloat(dims.width) / CGFloat(dims.height)
+        guard aspect.isFinite, aspect > 0 else { return }
+        let contentHeight = window.contentView?.frame.height ?? 710
+        let newWidth = (contentHeight * aspect).rounded()
+        window.setContentSize(NSSize(width: newWidth, height: contentHeight))
+        // Hold the ratio through any later user resize, so the bars cannot
+        // come back by dragging a corner.
+        window.contentAspectRatio = NSSize(width: CGFloat(dims.width), height: CGFloat(dims.height))
+    }
 
     func stop() {
+        sizeTimer?.invalidate()
+        sizeTimer = nil
         session.stopRunning()
         window.delegate = nil
         window.close()
     }
 
     func windowWillClose(_ notification: Notification) {
+        sizeTimer?.invalidate()
+        sizeTimer = nil
         session.stopRunning()
         onWindowClosed?(device.localizedName)
     }
@@ -297,6 +430,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, PreviewController {
     var activePreviews: [String: PreviewWindow] = [:]
     let devicesMenuDelegate = DevicesMenuDelegate()
     let mode: FilterMode
+    private var deviceObservers: [NSObjectProtocol] = []
 
     var activeDeviceNames: Set<String> {
         return Set(activePreviews.keys)
@@ -312,11 +446,61 @@ class AppDelegate: NSObject, NSApplicationDelegate, PreviewController {
         devicesMenuDelegate.controller = self
         setupMenuBar(devicesMenuDelegate: devicesMenuDelegate)
         enableScreenCaptureDevices()
+        watchForDeviceChanges()
         fputs("Waiting for devices...\n", stderr)
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
             self.onDevicesReady()
         }
+    }
+
+    private func watchForDeviceChanges() {
+        deviceObservers = observeDeviceChanges(
+            onConnect: { [weak self] device in self?.deviceAppeared(device) },
+            onDisconnect: { [weak self] device in self?.deviceVanished(device) }
+        )
+    }
+
+    /// Unplugging a phone left its window on screen forever, showing a frozen
+    /// last frame and holding a session bound to a device that no longer
+    /// exists -- which also meant replugging could not attach to it, because
+    /// the name was still taken.
+    private func deviceVanished(_ device: AVCaptureDevice) {
+        let name = device.localizedName
+        allDevices.removeAll { $0.uniqueID == device.uniqueID }
+        guard let preview = activePreviews[name] else { return }
+        fputs("  \(name) disconnected — closing its window\n", stderr)
+        preview.onWindowClosed = nil  // we are already removing it
+        preview.stop()
+        activePreviews.removeValue(forKey: name)
+    }
+
+    /// Plugging a phone in opens its window, so the app keeps showing what is
+    /// attached rather than a snapshot of whatever was attached at launch.
+    ///
+    /// Honours the launch filter: started with no arguments means "everything",
+    /// so anything new qualifies, but `ios-preview "iPhone 11"` asked for one
+    /// device and must not sprout windows for the rest. List mode never gets
+    /// here -- it prints and exits.
+    private func deviceAppeared(_ device: AVCaptureDevice) {
+        let name = device.localizedName
+        if !allDevices.contains(where: { $0.uniqueID == device.uniqueID }) {
+            allDevices.append(device)
+        }
+
+        guard activePreviews[name] == nil else { return }
+
+        switch mode {
+        case .all:
+            break
+        case .byArgs(let args):
+            guard !filterDevices([device], args: args).isEmpty else { return }
+        case .listOnly, .interactive:
+            return
+        }
+
+        fputs("  \(name) connected — opening its window\n", stderr)
+        togglePreview(name: name, position: nextPosition())
     }
 
     func onDevicesReady() {
@@ -491,6 +675,7 @@ class InteractiveDelegate: NSObject, NSApplicationDelegate, PreviewController {
     var positions: Set<Int> = []
     var stdinConnected = true
     let devicesMenuDelegate = DevicesMenuDelegate()
+    private var deviceObservers: [NSObjectProtocol] = []
 
     var activeDeviceNames: Set<String> {
         return Set(sessions.keys)
@@ -502,6 +687,10 @@ class InteractiveDelegate: NSObject, NSApplicationDelegate, PreviewController {
         devicesMenuDelegate.controller = self
         setupMenuBar(devicesMenuDelegate: devicesMenuDelegate, quitTarget: self, quitAction: #selector(menuQuit(_:)))
         enableScreenCaptureDevices()
+        deviceObservers = observeDeviceChanges(
+            onConnect: { [weak self] device in self?.deviceAppeared(device) },
+            onDisconnect: { [weak self] device in self?.deviceVanished(device) }
+        )
         fputs("Interactive mode: waiting for device discovery...\n", stderr)
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
@@ -618,6 +807,35 @@ class InteractiveDelegate: NSObject, NSApplicationDelegate, PreviewController {
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
             self.emit(["event": "added", "name": name])
         }
+    }
+
+    /// A window whose device is gone must close here too, but the server is
+    /// the one tracking what is previewing, so it is told rather than left to
+    /// discover the mismatch on its next command. Reported as `disconnected`
+    /// and not `removed`: the server asked for neither, and a caller that
+    /// requested this preview should be able to tell "the phone was unplugged"
+    /// from "someone called remove".
+    private func deviceVanished(_ device: AVCaptureDevice) {
+        let name = device.localizedName
+        allDevices.removeAll { $0.uniqueID == device.uniqueID }
+        guard let session = sessions[name] else { return }
+        fputs("  \(name) disconnected — closing its window\n", stderr)
+        session.onWindowClosed = nil
+        session.stop()
+        sessions.removeValue(forKey: name)
+        rebuildPositions()
+        emit(["event": "disconnected", "name": name])
+    }
+
+    /// No window is opened here on purpose. In interactive mode the server
+    /// decides what is on screen, and a window appearing by itself would
+    /// contradict the caller that asked for a specific set. Announce it
+    /// instead, so the server can offer it or open it deliberately.
+    private func deviceAppeared(_ device: AVCaptureDevice) {
+        if !allDevices.contains(where: { $0.uniqueID == device.uniqueID }) {
+            allDevices.append(device)
+        }
+        emit(["event": "connected", "name": device.localizedName, "id": device.uniqueID])
     }
 
     func handleRemove(name: String) {

--- a/tools/ios-preview.swift
+++ b/tools/ios-preview.swift
@@ -788,6 +788,13 @@ class InteractiveDelegate: NSObject, NSApplicationDelegate, PreviewController {
     }
 
     func handleCommand(cmd: String, json: [String: Any]) {
+        // The command id, echoed back on whatever event completes the command.
+        // The device name alone cannot correlate a reply with its request: the
+        // server times a write out after a few seconds, but the command was
+        // already delivered and may still run, so a late reply would otherwise
+        // be matched against whatever request holds that name next.
+        let id = json["id"] as? String
+
         switch cmd {
         case "add":
             guard let name = json["name"] as? String else {
@@ -795,14 +802,14 @@ class InteractiveDelegate: NSObject, NSApplicationDelegate, PreviewController {
                 return
             }
             let position = json["position"] as? Int ?? nextPosition()
-            handleAdd(name: name, position: position)
+            handleAdd(name: name, position: position, id: id)
 
         case "remove":
             guard let name = json["name"] as? String else {
                 emit(["event": "error", "message": "remove requires 'name'"])
                 return
             }
-            handleRemove(name: name)
+            handleRemove(name: name, id: id)
 
         case "list":
             handleList()
@@ -817,16 +824,16 @@ class InteractiveDelegate: NSObject, NSApplicationDelegate, PreviewController {
 
     // MARK: Command handlers
 
-    func handleAdd(name: String, position: Int) {
+    func handleAdd(name: String, position: Int, id: String? = nil) {
         // Already previewing?
         if sessions[name] != nil {
-            emit(["event": "add_failed", "name": name, "error": "Already previewing"])
+            emit(["event": "add_failed", "name": name, "error": "Already previewing", "id": id as Any])
             return
         }
 
         // Find device by exact name
         guard let device = allDevices.first(where: { $0.localizedName == name }) else {
-            emit(["event": "add_failed", "name": name, "error": "Device not found"])
+            emit(["event": "add_failed", "name": name, "error": "Device not found", "id": id as Any])
             return
         }
 
@@ -835,7 +842,7 @@ class InteractiveDelegate: NSObject, NSApplicationDelegate, PreviewController {
 
         if session.session.inputs.isEmpty {
             session.stop()
-            emit(["event": "add_failed", "name": name, "error": "Cannot create input"])
+            emit(["event": "add_failed", "name": name, "error": "Cannot create input", "id": id as Any])
             return
         }
 
@@ -849,7 +856,7 @@ class InteractiveDelegate: NSObject, NSApplicationDelegate, PreviewController {
         // Start capture, then emit added after a brief delay for CoreMediaIO
         session.start()
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-            self.emit(["event": "added", "name": name])
+            self.emit(["event": "added", "name": name, "id": id as Any])
         }
     }
 
@@ -887,7 +894,7 @@ class InteractiveDelegate: NSObject, NSApplicationDelegate, PreviewController {
         emit(["event": "connected", "name": device.localizedName, "id": device.uniqueID])
     }
 
-    func handleRemove(name: String) {
+    func handleRemove(name: String, id: String? = nil) {
         guard let session = sessions[name] else {
             emit(["event": "error", "message": "Not previewing: \(name)"])
             return
@@ -898,7 +905,7 @@ class InteractiveDelegate: NSObject, NSApplicationDelegate, PreviewController {
         sessions.removeValue(forKey: name)
         // Release position (we don't track which position maps to which session, so just rebuild)
         rebuildPositions()
-        emit(["event": "removed", "name": name])
+        emit(["event": "removed", "name": name, "id": id as Any])
     }
 
     func handleList() {
@@ -956,8 +963,21 @@ class InteractiveDelegate: NSObject, NSApplicationDelegate, PreviewController {
 
     func emit(_ dict: [String: Any]) {
         guard stdinConnected else { return }
-        guard let data = try? JSONSerialization.data(withJSONObject: dict),
+        // Drop keys holding a nil Optional before serialising. Callers pass
+        // optionals through `as Any` -- `"id": id as Any` with no id is the
+        // reason this exists -- and JSONSerialization rejects that value for
+        // the whole dictionary, not just the key. Paired with `try?` below,
+        // that turned one absent id into an event the server never receives.
+        var clean: [String: Any] = [:]
+        for (key, value) in dict {
+            if case Optional<Any>.none = value { continue }
+            clean[key] = value
+        }
+        guard let data = try? JSONSerialization.data(withJSONObject: clean),
               let str = String(data: data, encoding: .utf8) else {
+            // Never silently: the server is waiting on this event, and a
+            // dropped one reads to it as a hang rather than a failure.
+            fputs("  emit failed for event \(clean["event"] ?? "?")\n", stderr)
             return
         }
         print(str)

--- a/tools/ios-preview.swift
+++ b/tools/ios-preview.swift
@@ -853,9 +853,26 @@ class InteractiveDelegate: NSObject, NSApplicationDelegate, PreviewController {
         sessions[name] = session
         positions.insert(position)
 
-        // Start capture, then emit added after a brief delay for CoreMediaIO
+        // Start capture, then acknowledge after a brief delay for CoreMediaIO.
+        //
+        // The window can be closed inside that second. Acknowledging anyway
+        // told the server an add had succeeded, and it would record an active
+        // preview with no window behind it -- and go on refusing a fresh add
+        // for that device, because it believed one was already running. So the
+        // session has to still be the one this call created; a `window_closed`
+        // has already gone out for it otherwise.
         session.start()
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self, weak session] in
+            guard let self else { return }
+            guard let session, self.sessions[name] === session else {
+                self.emit([
+                    "event": "add_failed",
+                    "name": name,
+                    "error": "Window closed before the preview was acknowledged",
+                    "id": id as Any,
+                ])
+                return
+            }
             self.emit(["event": "added", "name": name, "id": id as Any])
         }
     }


### PR DESCRIPTION
Four fixes to the screen-mirror path, all found by using it on real hardware: an iPhone 15 Pro and an iPhone 11 over USB, plus a Pixel 3 XL and a Pixel 7 emulator to check what should be ignored.

## The feature was hidden from the people it is for

The menu-bar app offers "Screen Mirror…" only when `Quern Preview.app` exists on disk, and nothing created that bundle until something asked for a preview through the API or an MCP tool. On a fresh install the item was simply absent, and stayed absent until the user had driven a preview from a terminal — which is the thing the menu bar exists to avoid.

It is now built during setup, which costs about 1.5 seconds. Treated as optional the way scrcpy already is: a machine without Xcode Command Line Tools gets a skipped check carrying `xcode-select --install`, and an offer to open the installer. That command hands off to a macOS dialog and returns immediately, so setup says to re-run rather than pretending to wait.

The compile moved into one synchronous function that setup calls directly and the server reaches through a worker thread, rather than growing a second copy of the `swiftc` invocation. That also takes it off the event loop, which it was not before.

## A window showing a black rectangle

A connected iPhone publishes its rear camera as a second external device, so the app opened a window for it.

The obvious filter does not work: a `.continuityCamera` discovery session returns nothing, because the camera arrives as a plain external device. Measured with both phones attached:

```
external/muxed:  J iPhone 15 Pro         modelID=iOS Device   muxed
                 iPhone 11               modelID=iOS Device   muxed
external/video:  J iPhone 15 Pro Camera  modelID=iPhone16,1   video
```

A screen-capture device is muxed and reports the generic model; a Continuity Camera is video-only and reports the hardware model. The video-only discovery branch is kept rather than dropped, since the model ID is the thing actually being asserted.

## Black bars down each side

The window opened at a fixed 400x710, which is 0.563 wide-to-tall against a modern iPhone's 0.462, and `videoGravity = .resizeAspect` letterboxed the difference.

The real size cannot be read at construction time — a screen-capture device advertises one format of 0x0 until it is actually streaming — so the window polls the video port after the session starts and matches the stream. Both test phones settle at 328 wide against a 710 content height. The window's aspect ratio is pinned too, so dragging a corner cannot bring the bars back.

## Unplugged phones left dead windows

A window survived its device, showing a frozen last frame and holding a session bound to something that no longer existed. That also meant replugging could not attach, because the name was still taken.

AVFoundation does post both notifications for these devices, verified by observing an unplug and replug:

```
[22:32:44] DISCONNECTED name=iPhone 11 model=iOS Device muxed=true
[22:32:52] CONNECTED    name=iPhone 11 model=iOS Device muxed=true
```

So the window closes on detach and opens on attach. Attach honours the launch filter: no arguments means "everything", but `ios-preview "iPhone 11"` asked for one device and must not sprout windows for the rest. Interactive mode never auto-opens, because the server decides what is on screen there — it emits `connected` and `disconnected` events instead, and the server drops a disconnected device so its slot and name are freed. `disconnected` is deliberately distinct from `removed`: nobody asked for it.

Every attach and detach also logs one timestamped line before any policy runs. That trace earned its place immediately — four events across two physical replugs read exactly like one replug re-enumerating twice, and I built a debounce for a flicker that did not exist before the timestamps showed two separate cycles. The debounce is not in this PR.

## Verification

- Both iPhones: one window each, no camera window, no bars, 328x742
- Unplug closes the window, replug opens it, confirmed against the app's own log
- A physical Pixel 3 XL on USB is correctly ignored, since Android preview goes through scrcpy
- Setup rebuilds a deleted bundle from scratch, Info.plist and Resources included
- Full suite 1981, up 5. The skipped-versus-failed distinction is mutation-tested

## Not in scope

Bringing Android previews into the same window system is #127, along with what was measured tonight about `adb exec-out screenrecord` and its 180-second ceiling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic screen-mirror app setup during installation, with optional Xcode Command Line Tools guidance.
  - Added real-time detection of connected and disconnected iOS screen-capture devices.
  - Preview windows now open, close, and resize to match device video proportions.
  - Added reliable tracking for preview commands and completion events.

- **Bug Fixes**
  - Improved device detection to exclude unsupported camera devices.
  - Added actionable timeout errors for stalled preview-app compilation.
  - Improved disconnect handling so unavailable devices are not retained as active previews.
  - Repaired incomplete preview app bundles when rebuilding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->