### PR TITLE
Docs: the menu-bar app, web content for agents, and the release procedure we actually followed

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,13 +125,33 @@ The server prints connection info on startup — URL, API key, and proxy port. A
 | File | Purpose |
 |------|---------|
 | `state.json` | Running instance info (port, PID, API key) — deleted on stop |
-| `active-device.json` | UDID of the active device set via `resolve_device` — persists across stop/start so you don't have to re-resolve after every restart |
+| `active-device.json` | The active device set via `resolve_device` — its UDID, name and type — persists across stop/start so you don't have to re-resolve after every restart, and is what the menu-bar app reads |
 | `cert-state.json` | Per-device certificate installation state, including per-SSID Wi-Fi proxy configs — persists across restarts |
 | `device-pool.json` | Device pool state (simctl cache) — persists across restarts |
 | `config.json` | Local capture settings and other configuration |
 | `installed-by-setup.json` | Packages installed by `quern setup` — used by `quern uninstall` |
 | `api-key` | Persistent API key |
 | `server.log` | Daemon log output |
+
+### The menu bar app
+
+On macOS, Quern installs a menu-bar app so you can see whether the server is up
+without opening a terminal. It appears automatically after `quern setup`, and
+`quern update` keeps it current.
+
+It shows the daemon's state and uptime, the active device, the proxy's port,
+and an update notice when one is available. From its menu you can start, stop
+and restart the server, open a live screen mirror of a connected device, and
+reach Settings — which carries the update channel picker and a launch-at-login
+toggle.
+
+It does not own the daemon. Starting Quern from the app and starting it from
+the CLI do the same thing, and quitting the app leaves the server running;
+"Quit and Stop Server" is a separate item for when you mean both.
+
+The app is signed and notarized, and ships inside the release asset rather than
+the source tarball. If you installed before v0.15.0 and have never run
+`quern update`, you will not have it — updating brings it in.
 
 ### Connect via MCP
 

--- a/README.md
+++ b/README.md
@@ -237,8 +237,14 @@ tool is installed:
 - **tunneld** — a failed device pairing can leave the daemon alive but not serving. It
   holds no listener and never exits, so `KeepAlive` never fires and launchd reports it
   healthy indefinitely. Doctor separates that *wedged* state from a merely *stopped*
-  one by pairing the HTTP probe with the launchd job state, and prints the `bootout` +
-  `bootstrap` recovery. It never runs it — recovery is tracked in issue #73.
+  one by pairing the HTTP probe with the launchd job state.
+
+  Since v0.15.0 Quern can also recover it. Getting the stuck process to exit is the
+  entire fix, because the plist sets `KeepAlive` and launchd respawns it against clean
+  state in about a second. That needs root, so the authorisation is taken once and
+  explicitly with `quern tunneld grant-recovery` — a single `NOPASSWD` rule for one
+  signal to one job, nothing else. Without the grant the behaviour is unchanged: the
+  wedge is reported, not healed.
 - **local capture extension** — the mitmproxy macOS system extension is approved once
   by a human and then upgraded underneath that approval by ordinary dependency updates.
   When the version macOS runs falls behind the version the installed wheel ships, local
@@ -349,7 +355,8 @@ quern grant-full-perms       # Allow all Quern MCP tools in Claude Code without 
 quern install-precommit-hook # Install the pre-commit checklist hook
 quern enable-local-capture   # Enable transparent simulator traffic capture
 quern disable-local-capture  # Disable local capture
-quern tunneld <cmd>          # Manage the tunneld LaunchDaemon (install/uninstall/status/restart)
+quern tunneld <cmd>          # Manage the tunneld LaunchDaemon (install/uninstall/status/restart,
+                             #   grant-recovery/revoke-recovery for password-free wedge recovery)
 ```
 
 `~/.quern/state.json` is the single source of truth for discovering a running instance.
@@ -409,7 +416,7 @@ server/
   device/              Simulator control (simctl, sim-bridge, idb fallback) + physical device control (WDA, pymobiledevice3), device pool
   api/                 HTTP route handlers
 mcp/                   MCP server (TypeScript)
-tests/                 993 tests
+tests/                 pytest suite (~2,000 tests)
 ```
 
 ## Development

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -73,6 +73,8 @@ Use `wait_for_element` instead of calling `get_ui_tree` in a loop. It polls serv
 
 Use `wait_for_flow` after triggering a UI action to observe the resulting network request — it blocks until a matching flow appears or times out. Auto-sets `since` to 5 seconds before the call to catch flows that completed between the action and the wait. Use `list_held_flows` with a `timeout` when you need to intercept and *modify* flows.
 
+Use `wait_for_settle` when you are waiting for the screen to stop changing rather than for a specific element — after a navigation, a pull-to-refresh, or an animation you cannot name a target inside. It is the right tool when "wait until this is done" has no single element that marks done.
+
 ---
 
 ### 6. Filter Aggressively
@@ -157,6 +159,19 @@ Logs, network flows, and UI trees can be huge. Always filter to what you need.
 **If the element isn't on screen**: reach for `tap_element` (which auto-scrolls) or `scroll_to_element` rather than a manual `swipe` loop. Be aware that reading the full UI tree can itself scroll the content — on Android's `CoordinatorLayout`/`RecyclerView` screens the accessibility traversal a dump performs pushes top controls out of view before your tap lands. Both scroll paths avoid the dump for exactly this reason, so prefer them over "dump, read coordinates, tap".
 
 **Debugging the platform normalizer**: When `tap_element` or a landmark match doesn't behave as expected and you suspect the underlying source attributes aren't surfacing correctly (e.g. an Android tab that doesn't appear `selected`), call `get_ui_tree` with `include_raw=true` to get the raw provider attributes (full uiautomator2 XML on Android) on each element under `extra_attrs`. This is faster than dropping to `adb shell uiautomator dump` and stays inside the Quern API surface.
+
+**If the screen looks empty apart from its chrome**: you are probably looking at
+a `WKWebView`. On iOS simulators it is absent from the accessibility tree
+entirely, so `get_screen_summary` shows the navigation bar and nothing else,
+and it is easy to read that as a failed load or a blank screen. Call
+`get_web_content` — it pairs the Web Inspector's view of the DOM with the
+native tree so elements come back with real screen frames, which means you can
+tap them like any other element.
+
+Simulator only, and deliberately: Android's accessibility tree already descends
+into `WebView`, and physical iOS devices are reached over a different
+transport. On both, the ordinary UI tree is the right tool and this one has
+nothing to add.
 
 ---
 
@@ -277,6 +292,11 @@ Open real-time video windows to see what's happening on USB-connected physical d
 - Full detail: `get_ui_tree`
 - Visual for humans: `take_screenshot`
 - Accessibility overlay: `take_annotated_screenshot` — draws bounding boxes on interactive elements, useful for debugging why `tap_element` can't find an element
+
+**"The screen looks empty, or I know it's a web view"**
+- `get_web_content` — reads `WKWebView` content the accessibility tree cannot see, with real screen coordinates
+- iOS simulator only; on Android and physical iOS the normal `get_ui_tree` already covers web views
+- Optional `bundle_id` when several apps are running, and `hints` to narrow what comes back
 
 **"I need to tap/interact with UI"**
 - Known element: `tap_element` with label and element_type

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -73,7 +73,11 @@ Use `wait_for_element` instead of calling `get_ui_tree` in a loop. It polls serv
 
 Use `wait_for_flow` after triggering a UI action to observe the resulting network request — it blocks until a matching flow appears or times out. Auto-sets `since` to 5 seconds before the call to catch flows that completed between the action and the wait. Use `list_held_flows` with a `timeout` when you need to intercept and *modify* flows.
 
-Use `wait_for_settle` when you are waiting for the screen to stop changing rather than for a specific element — after a navigation, a pull-to-refresh, or an animation you cannot name a target inside. It is the right tool when "wait until this is done" has no single element that marks done.
+Use `wait_for_settle` when you are waiting for the screen to stop changing rather than for a specific element — after a navigation, an animation, or before interacting with a web view, whose content is invisible to the accessibility tree so nothing else can tell you it has finished drawing.
+
+It answers "has drawing stopped", not "has content arrived". A blank page still loading is perfectly still, and will be called settled in under two seconds. Raising the timeout does not help, because nothing is moving. So for a slow load, wait for the content first — poll `get_web_content` until it returns elements, or `wait_for_element` for a native one — and use `wait_for_settle` afterwards to let the result stop moving.
+
+Check the `settled` field before acting on the result. `settled: false` means something is animating rather than loading — a spinner, a video, a carousel — and will never settle. Treat that as a fact about the screen, not a failed wait.
 
 ---
 
@@ -167,6 +171,18 @@ and it is easy to read that as a failed load or a blank screen. Call
 `get_web_content` — it pairs the Web Inspector's view of the DOM with the
 native tree so elements come back with real screen frames, which means you can
 tap them like any other element.
+
+The results are merged into subsequent UI reads, so `tap_element`,
+`get_ui_tree` and `get_screen_summary` all see them and you can tap by label as
+usual. That overlay is dropped as soon as anything changes the screen — a tap,
+swipe, scroll or launch — so **call `get_web_content` again after each
+interaction with the page** rather than reusing an earlier read. A tap against
+stale web content is refused with reason `stale_web_content` instead of landing
+somewhere wrong.
+
+If the response reports `anchored: false`, the page was found but its position
+on screen could not be confirmed, and the elements are withheld rather than
+returned at a guessed offset. Treat that as "look again", not "no content".
 
 Simulator only, and deliberately: Android's accessibility tree already descends
 into `WebView`, and physical iOS devices are reached over a different
@@ -296,7 +312,8 @@ Open real-time video windows to see what's happening on USB-connected physical d
 **"The screen looks empty, or I know it's a web view"**
 - `get_web_content` — reads `WKWebView` content the accessibility tree cannot see, with real screen coordinates
 - iOS simulator only; on Android and physical iOS the normal `get_ui_tree` already covers web views
-- Optional `bundle_id` when several apps are running, and `hints` to narrow what comes back
+- Optional `bundle_id` when several apps are running, and `udid` to target a specific simulator
+- Re-read after every interaction; the merged results are dropped when the screen changes
 
 **"I need to tap/interact with UI"**
 - Known element: `tap_element` with label and element_type

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -12,6 +12,7 @@ For the AI agent's reference, see the [Agent Guide](../agent-guide.md). For inst
 - [Device Pool & Resolution](device-pool.md) — How Quern manages devices, the iOS 17+ complexity it hides, and what you should know
 - [Build & Install](build-and-install.md) — Building and deploying to multiple devices at once
 - [Update Channels](update-channels.md) — Staying on stable, or opting into beta to see releases early
+- [The Menu Bar App](menu-bar-app.md) — Seeing whether Quern is running, and restarting it, without a terminal
 
 ---
 

--- a/docs/guides/menu-bar-app.md
+++ b/docs/guides/menu-bar-app.md
@@ -1,0 +1,89 @@
+# The Menu Bar App
+
+Quern runs as a background daemon, which means the honest answer to "is it
+running?" usually involves a terminal. The menu-bar app puts that answer in the
+corner of your screen instead, and gives you the handful of controls you would
+otherwise type.
+
+It is macOS only. Everything it does, the CLI already did.
+
+## Getting it
+
+It arrives with Quern. `quern setup` installs it and `quern update` keeps it
+current, so there is nothing separate to download.
+
+If you installed before v0.15.0 and have never updated, you will not have it —
+the app ships inside the release asset rather than GitHub's generated source
+tarball. One `quern update` brings it in.
+
+## What the menu shows
+
+Clicking the icon gives you the daemon's state at a glance:
+
+```
+Quern is running · up 3h
+Active device: iPhone 16 Pro (Simulator)
+Proxy: running :9101
+```
+
+The active device row names the device rather than showing its 36-character
+identifier, and says what kind it is — `(Simulator)`, `(Device)` or
+`(Emulator)` — because a simulator and the phone on your desk otherwise look
+identical. When Quern has not enumerated the device it says nothing rather than
+guessing, so an unqualified name means "type unknown", not "simulator".
+
+The icon itself dims when the server is stopped, and its tooltip tells you when
+an update is waiting.
+
+## What you can do from it
+
+**Start, stop and restart the server.** The same operations as `quern start`,
+`quern stop` and `quern restart`. There is no separate lifecycle: the app does
+not own the daemon, it asks.
+
+**Restart to update.** Appears only once an update has been staged, and
+restarts into the new version. This is the Ollama pattern — no separate
+updater, no second update path.
+
+**Screen mirror.** Opens a live view of connected devices. Windows fit the
+device's own proportions, open when you plug a phone in, and close when you
+unplug it. See [Live Video Preview](ios-preview.md) for the detail.
+
+This item is hidden if the screen-mirror app could not be built, which happens
+when Xcode Command Line Tools are missing. `quern setup` will tell you, and
+offer to open the installer.
+
+**Settings.** The update channel picker — stable or beta, the same setting as
+`quern set-channel` — and a launch-at-login toggle. It also shows the server's
+address, version and uptime, and the full UDID of the active device, which the
+menu deliberately leaves out to keep itself narrow.
+
+## Quitting
+
+**Quit Quern** closes the app and leaves the server running. That is usually
+what you want: the daemon is doing the work, and the menu bar is only a window
+onto it.
+
+Hold Option to reveal **Quit and Stop Server** for when you mean both. If the
+stop fails, the app stays open and tells you, rather than quitting and leaving
+a server running with nothing to say so.
+
+## Launch at login
+
+The app registers itself the first time it runs, so it comes back after a
+reboot. Turn it off in Settings.
+
+This depends on the app having a stable code-signing identity, which the
+released build has. If you build the app yourself from `macos/QuernMenuBar`,
+the signature changes on every rebuild and macOS will treat each one as a
+different app, so launch-at-login and permissions will not stick. That is
+expected for local development.
+
+## What it deliberately does not do
+
+It is not a control surface for Quern's features. There is no proxy toggle, no
+device picker, no log viewer. Those live in the CLI and the MCP tools, where an
+agent can reach them and where the output is something you can pipe.
+
+The menu bar answers "is it up, what is it pointed at, and can I restart it" —
+the questions you would otherwise open a terminal to answer.

--- a/docs/release-channels.md
+++ b/docs/release-channels.md
@@ -261,11 +261,17 @@ git push origin "$TAG"
 git push origin main:refs/heads/release/stable
 git push origin main:refs/heads/release/beta
 
-# 3. Verify — the rejection above is silent.
+# 3. Verify — the rejection above is silent, so this has to fail loudly.
 git fetch origin
-for ref in release/stable release/beta main; do
-  echo "  $ref $(git rev-parse --short "origin/$ref")"
-done   # expect three identical SHAs, and stop here if they differ
+main_sha=$(git rev-parse origin/main)
+for ref in release/stable release/beta; do
+  ref_sha=$(git rev-parse "origin/$ref")
+  if [ "$ref_sha" != "$main_sha" ]; then
+    echo "error: origin/$ref is at ${ref_sha:0:8}, expected ${main_sha:0:8}" >&2
+    echo "       The push above was rejected. Do NOT create the Release." >&2
+    exit 1
+  fi
+done
 
 # 4. Now create the Release
 gh release create "$TAG" --title "$TAG" --notes "see CHANGELOG.md"

--- a/docs/release-channels.md
+++ b/docs/release-channels.md
@@ -262,8 +262,15 @@ else
   CHANNELS="release/stable release/beta"
 fi
 
-# 1. Tag
-git tag -a "$TAG" -m "$TAG"
+# 1. Tag. Reuse an existing one only when it points where this run intends;
+#    a mismatch means the tag was cut somewhere else and must be resolved by
+#    hand. Without this, any retry after a later step failed dies here on
+#    "tag already exists" with the remote tag already pushed.
+if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+  echo "note: $TAG already exists locally, reusing it"
+else
+  git tag -a "$TAG" -m "$TAG"
+fi
 git push origin "$TAG"
 
 # 2. Fast-forward the channel branches — MUST happen before step 4.
@@ -292,6 +299,16 @@ gh release create "$TAG" $PRERELEASE --title "$TAG" --notes "see CHANGELOG.md"
 The verification compares against the tag rather than `origin/main` on purpose.
 Only the branches this release actually moves are checked, so a prerelease is
 not failed for leaving `release/stable` where it belongs.
+
+**If it stops partway.** Every step before the Release is repeatable: the tag
+is reused when it already points at the intended commit, and pushing a channel
+branch to the same tag twice is a no-op. So the fix for a failed run is
+normally to resolve the cause and run it again.
+
+The exception is the one the ordering exists for. Once the Release is created,
+GitHub silently refuses to point any branch at that commit, so a channel branch
+left behind at that moment cannot be fixed by rerunning — it has to wait for
+the next cut. That is why step 3 refuses to continue rather than warning.
 
 ---
 

--- a/docs/release-channels.md
+++ b/docs/release-channels.md
@@ -247,38 +247,51 @@ remember:
 
 ```sh
 #!/bin/bash
-# scripts/cut-stable-release.sh — usage: ./scripts/cut-stable-release.sh vN.M.K
+# scripts/cut-release.sh — usage: ./scripts/cut-release.sh vN.M.K [--prerelease]
 set -euo pipefail
 TAG="$1"
+PRERELEASE=""
+[ "${2:-}" = "--prerelease" ] && PRERELEASE="--prerelease"
+
+# Which channels this release moves. A stable cut advances both -- leaving beta
+# behind hands beta users older content than stable users get. A prerelease
+# advances only beta; release/stable must stay on the last stable tag.
+if [ -n "$PRERELEASE" ]; then
+  CHANNELS="release/beta"
+else
+  CHANNELS="release/stable release/beta"
+fi
 
 # 1. Tag
 git tag -a "$TAG" -m "$TAG"
 git push origin "$TAG"
 
-# 2. Fast-forward BOTH channel branches — MUST happen before step 3.
-#    Beta too: a stable release is newer than anything beta users are on, so
-#    leaving beta behind hands them older content than stable users get.
-git push origin main:refs/heads/release/stable
-git push origin main:refs/heads/release/beta
+# 2. Fast-forward the channel branches — MUST happen before step 4.
+#    From the tag, not from main: the tag is what was published, and a
+#    prerelease is often cut somewhere other than main HEAD.
+for ref in $CHANNELS; do
+  git push origin "$TAG:refs/heads/$ref"
+done
 
 # 3. Verify — the rejection above is silent, so this has to fail loudly.
 git fetch origin
-main_sha=$(git rev-parse origin/main)
-for ref in release/stable release/beta; do
-  ref_sha=$(git rev-parse "origin/$ref")
-  if [ "$ref_sha" != "$main_sha" ]; then
-    echo "error: origin/$ref is at ${ref_sha:0:8}, expected ${main_sha:0:8}" >&2
+expected=$(git rev-parse "$TAG^{commit}")
+for ref in $CHANNELS; do
+  actual=$(git rev-parse "origin/$ref")
+  if [ "$actual" != "$expected" ]; then
+    echo "error: origin/$ref is at ${actual:0:8}, expected ${expected:0:8}" >&2
     echo "       The push above was rejected. Do NOT create the Release." >&2
     exit 1
   fi
 done
 
 # 4. Now create the Release
-gh release create "$TAG" --title "$TAG" --notes "see CHANGELOG.md"
+gh release create "$TAG" $PRERELEASE --title "$TAG" --notes "see CHANGELOG.md"
 ```
 
-For a **prerelease**, advance only `release/beta` and add `--prerelease` to
-step 4; `release/stable` should keep pointing at the last stable tag.
+The verification compares against the tag rather than `origin/main` on purpose.
+Only the branches this release actually moves are checked, so a prerelease is
+not failed for leaving `release/stable` where it belongs.
 
 ---
 

--- a/docs/release-channels.md
+++ b/docs/release-channels.md
@@ -262,12 +262,20 @@ else
   CHANNELS="release/stable release/beta"
 fi
 
-# 1. Tag. Reuse an existing one only when it points where this run intends;
-#    a mismatch means the tag was cut somewhere else and must be resolved by
-#    hand. Without this, any retry after a later step failed dies here on
-#    "tag already exists" with the remote tag already pushed.
+# 1. Tag. Reuse an existing one only when it points at the commit this run is
+#    releasing; a mismatch means the tag was cut somewhere else, and moving a
+#    published tag is not something a script should decide to do. Without the
+#    reuse, any retry after a later step failed dies here on "tag already
+#    exists" with the remote tag already pushed.
+INTENDED=$(git rev-parse HEAD)
 if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
-  echo "note: $TAG already exists locally, reusing it"
+  EXISTING=$(git rev-parse "$TAG^{commit}")
+  if [ "$EXISTING" != "$INTENDED" ]; then
+    echo "error: $TAG exists at ${EXISTING:0:8} but HEAD is ${INTENDED:0:8}" >&2
+    echo "       Resolve that by hand before rerunning." >&2
+    exit 1
+  fi
+  echo "note: $TAG already exists at ${EXISTING:0:8}, reusing it"
 else
   git tag -a "$TAG" -m "$TAG"
 fi

--- a/docs/release-channels.md
+++ b/docs/release-channels.md
@@ -109,17 +109,46 @@ git rev-parse origin/release/stable origin/release/beta origin/main   # expect t
 # 5. Now create the GitHub Release.
 gh release create vN.M.K --title "vN.M.K — short release headline" --notes-file RELEASE_NOTES.md
 
-# 5. Build, sign, notarize, and attach the menu-bar app asset.
-#    Run on a Mac with the Developer ID identity + notarytool profile.
-#    See macos/QuernMenuBar/README.md for the one-time credential setup.
+# 6. Attach the menu-bar app asset, using the app staged in step 0.
 DEVELOPER_ID_APP="Developer ID Application: Your Name (TEAMID)" \
-NOTARY_PROFILE="quern-notary" \
-  scripts/release-menubar.sh vN.M.K
+  scripts/release-menubar.sh --publish vN.M.K
 ```
 
-**Why the ordering matters:** see the *GitHub quirk* section. Once step 5 has
-happened, you cannot retroactively move any branch to that commit. The
-fast-forwards in step 3 have to happen first.
+**Step 0, before any of the above.** Build, sign and notarize the app first,
+while nothing has been cut yet:
+
+```sh
+DEVELOPER_ID_APP="Developer ID Application: Your Name (TEAMID)" \
+NOTARY_PROFILE="your-notarytool-profile" \
+  scripts/release-menubar.sh --app-only N.M.K      # note: no leading v
+```
+
+That leaves a signed, notarized `Quern.app` in `dist/`, and prints the exact
+`--publish` command to run at step 6.
+
+Doing it first is the point of the split. Notarization is the slow step, the
+one that depends on Apple's service being reachable, and the one that would
+otherwise abort a release *after* the tag and Release existed — leaving
+nothing to clean up except by hand. If Apple is having a bad day you find out
+before anything is published.
+
+`--publish` re-verifies the staged app rather than trusting it: stamped
+version against the tag, signature validity, stapled ticket, Gatekeeper
+acceptance, and that the signing team matches `DEVELOPER_ID_APP`. Hence that
+variable is required in both phases.
+
+The one-shot form, `scripts/release-menubar.sh vN.M.K`, still does everything
+in a single run. It needs the tag and Release to already exist, so it belongs
+at step 6, not step 0.
+
+Both forms need a `notarytool` keychain profile; see
+`macos/QuernMenuBar/README.md` for the one-time credential setup. Use whatever
+name you gave it when you ran `store-credentials`.
+
+**Why the ordering matters:** see the *GitHub quirk* section. Once the Release
+in step 5 exists, you cannot retroactively move any branch to that commit. The
+fast-forwards in step 3 have to happen first, and step 4 exists because a
+rejection there is silent.
 
 **Why `release/beta` too.** A stable release is by definition newer than
 anything beta users are running, so leaving `release/beta` behind means
@@ -226,16 +255,24 @@ TAG="$1"
 git tag -a "$TAG" -m "$TAG"
 git push origin "$TAG"
 
-# 2. Fast-forward release/stable — MUST happen before step 3
+# 2. Fast-forward BOTH channel branches — MUST happen before step 3.
+#    Beta too: a stable release is newer than anything beta users are on, so
+#    leaving beta behind hands them older content than stable users get.
 git push origin main:refs/heads/release/stable
+git push origin main:refs/heads/release/beta
 
-# 3. Now create the Release
+# 3. Verify — the rejection above is silent.
+git fetch origin
+for ref in release/stable release/beta main; do
+  echo "  $ref $(git rev-parse --short "origin/$ref")"
+done   # expect three identical SHAs, and stop here if they differ
+
+# 4. Now create the Release
 gh release create "$TAG" --title "$TAG" --notes "see CHANGELOG.md"
-
-echo "release/stable now at $(git rev-parse "$TAG")"
 ```
 
-(Same shape works for `release/beta`; swap `--prerelease` in for step 3.)
+For a **prerelease**, advance only `release/beta` and add `--prerelease` to
+step 4; `release/stable` should keep pointing at the last stable tag.
 
 ---
 

--- a/macos/QuernMenuBar/README.md
+++ b/macos/QuernMenuBar/README.md
@@ -58,20 +58,45 @@ Quern's existing updater (Option A — no Sparkle, no second update path).
 One-time credential setup:
 
 ```sh
-# Store an App Store Connect API key (or Apple ID) for notarytool.
-xcrun notarytool store-credentials quern-notary \
+# Store an App Store Connect API key (or Apple ID) for notarytool. The profile
+# name is yours to choose -- pass the same one to the script below.
+xcrun notarytool store-credentials my-notary-profile \
   --apple-id "you@example.com" --team-id TEAMID --password "app-specific-pw"
 ```
 
-Per release (also documented in `docs/release-channels.md`, step 5):
+Per release, in two phases. The full procedure is in
+`docs/release-channels.md`; this is the part that runs here.
+
+**Before cutting the tag** — build, sign and notarize:
 
 ```sh
 DEVELOPER_ID_APP="Developer ID Application: Your Name (TEAMID)" \
-NOTARY_PROFILE="quern-notary" \
-  ../../scripts/release-menubar.sh v0.14.0
+NOTARY_PROFILE="my-notary-profile" \
+  ../../scripts/release-menubar.sh --app-only 0.15.0     # no leading v
 ```
 
-That script builds a universal binary, signs with hardened runtime, notarizes
-and staples, assembles `dist/quern-<version>.tar.gz` (source tree + signed
-`Quern.app` at the top level), and uploads it as a release asset. The updater
-(`_select_asset_url` in `server/lifecycle/updater.py`) prefers this asset.
+This leaves a signed, notarized `Quern.app` in `dist/` and prints the publish
+command for later. Doing it first means a notary-service failure costs you
+nothing: no tag has been cut and no Release exists yet.
+
+**After the tag and Release exist** — assemble and upload:
+
+```sh
+DEVELOPER_ID_APP="Developer ID Application: Your Name (TEAMID)" \
+  ../../scripts/release-menubar.sh --publish v0.15.0
+```
+
+That assembles `dist/quern-<version>.tar.gz` (source tree at the tag + the
+signed `Quern.app` at the top level) and uploads it as a release asset. Both
+the updater (`_select_asset_url` in `server/lifecycle/updater.py`) and the
+install script on quern.dev prefer this asset over GitHub's generated source
+tarball, so a fresh install and an upgrade both get the app.
+
+`--publish` re-verifies the staged app before uploading anything: stamped
+version against the tag, signature validity, stapled ticket, Gatekeeper
+acceptance, and that the signing team matches `DEVELOPER_ID_APP` — which is
+why that variable is needed in both phases. A staged app can come from
+anywhere, including a previous release.
+
+The one-shot form, `release-menubar.sh v0.15.0`, still does everything in a
+single run, but it needs the tag and Release to already exist.

--- a/macos/QuernMenuBar/README.md
+++ b/macos/QuernMenuBar/README.md
@@ -58,10 +58,18 @@ Quern's existing updater (Option A — no Sparkle, no second update path).
 One-time credential setup:
 
 ```sh
-# Store an App Store Connect API key (or Apple ID) for notarytool. The profile
-# name is yours to choose -- pass the same one to the script below.
+# Apple ID credentials, with an app-specific password (not your Apple ID
+# password). The profile name is yours to choose -- pass the same one to the
+# script below.
 xcrun notarytool store-credentials my-notary-profile \
   --apple-id "you@example.com" --team-id TEAMID --password "app-specific-pw"
+```
+
+An App Store Connect API key works too, and avoids storing a password:
+
+```sh
+xcrun notarytool store-credentials my-notary-profile \
+  --key AuthKey_XXXXXXXXXX.p8 --key-id XXXXXXXXXX --issuer "issuer-uuid"
 ```
 
 Per release, in two phases. The full procedure is in


### PR DESCRIPTION
An audit after the 0.15.0 cut, prompted by noticing the release doc had two steps numbered 5 while I was following it.

## The headline feature had no documentation

The menu-bar app shipped in 0.15.0 and appeared in no user-facing doc — not the README, and no guide, so nothing reached quern.dev either. The only writing about it was `macos/QuernMenuBar/README.md`, which is build and release instructions for maintainers.

`docs/guides/menu-bar-app.md` covers what the menu shows, what you can do from it, why **Quit Quern** leaves the server running and **Quit and Stop Server** is separate, and why a locally-built copy will not hold launch-at-login (unstable signing identity). It also says plainly what the app deliberately does not do, since "why is there no proxy toggle" is the obvious next question.

The README gains a shorter section pointing the same way, including the fact that anyone who installed before v0.15.0 and never ran `quern update` will not have the app.

## Agents were not told about web content

`get_web_content` shipped in 0.15.0-beta.1 and never reached `docs/agent-guide.md`, which is the document that tells an agent which tool to reach for.

This one matters more than a missing entry usually would. A `WKWebView` is absent from the accessibility tree entirely on iOS simulators, so the symptom is an apparently empty screen rather than an error — an agent with no reason to suspect a web view will conclude the page failed to load and start debugging the wrong thing. It is documented in the UI-debugging workflow, where that symptom shows up, and in the tool selection guide.

Also added `wait_for_settle` to the server-side waiting principle, which argued for exactly that habit while naming only `wait_for_element` and `wait_for_flow`.

## The release procedure had drifted from the script

- Two steps numbered 5, with the surrounding prose saying "step 5" while meaning the Release — which sits immediately beside the irreversible step, where ambiguity is least affordable.
- Only the one-shot form of `release-menubar.sh` was documented, which needs the tag and Release to already exist. That is the wrong order for the step most likely to fail. The two-phase form is now step 0, with the reasoning attached.
- `NOTARY_PROFILE="quern-notary"` appeared in two docs as though it were a required name. No such profile exists; it is whatever you passed to `store-credentials`.
- **The worked example script at the bottom advanced only `release/stable`**, directly contradicting the warning above it that a stable cut must move beta too. Anyone copying it would have reproduced the v0.14.0 mistake that same doc describes. It now advances both and verifies, since the rejection is silent.

## Smaller

The README's state table described `active-device.json` as holding a UDID. It has carried the device name and type since #125.

## Verified

The new guide is registered in `docs/guides/index.md` and in quern.dev's sync mapping and sidebar; the site builds with it and its cross-guide link rewrites correctly to `/ios/ios-preview/`. Those site-side changes are a separate commit in the quern.dev repo.

## Found but not fixed here

The live site has been serving the **uncorrected** deep-link-testing guide since 2 September. The correction landed in this repo that day and the sync was run locally but never committed, so quern.dev still omits the cold-launch double-delivery note. Fixed in the quern.dev repo, not this one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documented the macOS menu-bar app, including daemon status, active device details, screen mirroring, controls, settings, update channels, and launch-at-login.
  * Documented tunneld recovery commands for handling wedged daemons.

* **Documentation**
  * Added guidance for waiting for screens to settle and reading iOS simulator web content.
  * Clarified active-device state information, menu-bar app behavior, and installation requirements.
  * Updated tool-selection guidance and test-suite references.
  * Updated release guidance for signed, notarized app builds and staged publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->