### PR TITLE
Check certificate trust before enabling capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Quern checks certificate trust before enabling capture** — configuring the system proxy against a simulator that does not trust the mitmproxy CA fails every HTTPS request from it, and the symptom points nowhere near the proxy: a blank screen, or an app with no network. Both halves of that state were already Quern's — it configures the proxy and it installs the CA — and only the correlation was missing. `configure_system_proxy` now refuses in that state and names the devices, rather than creating it and leaving it to be discovered. `proxy_status` reports the same condition as a `capture_without_cert` warning for the cases the check cannot reach.
+- **`quern set-auto-install-cert`** — answers the question once instead of every time. Off by default, because installing a MITM root certificate authority is a larger and longer-lived commitment than the proxy toggle that prompts it: it persists across sessions and outlives the capture window. The setting appears in the menu-bar app's Settings pane and in `proxy_status`, deliberately — a silent, persistent CA-install policy would be worse than the failure it prevents. Pass `skip_cert_check` to configure the proxy anyway, which is the right answer when deliberately exercising TLS-failure paths.
+
 ## [0.15.0] - 2026-09-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -348,6 +348,9 @@ quern version                # Print the installed version
 quern update                 # Update to the latest release on your channel and rebuild
 quern update --tools         # Also upgrade external tools quern installed (pipx, brew)
 quern set-channel [name]     # Show or set the update channel (stable / beta)
+quern set-auto-install-cert [on|off]
+                             # Show or set whether the capture certificate is installed
+                             #   automatically, or Quern asks first (default: ask)
 quern uninstall              # Remove Quern and dependencies installed by setup
 quern regenerate-key         # New API key
 quern mcp-install            # Register MCP server with Claude Code

--- a/docs/proposals/cert-preflight-on-launch.md
+++ b/docs/proposals/cert-preflight-on-launch.md
@@ -1,6 +1,10 @@
 # Cert Preflight on `launch_app` — Proposal
 
-**Status:** proposal, not a decision. Written up for consideration; nothing implemented.
+**Status:** partially implemented. The preflight ships on `configure_system_proxy`
+rather than `launch_app` — enabling capture is where the broken state is created, and
+catching it there costs no relaunch. `auto_install_cert` (§4.2) ships as proposed, and
+is surfaced in `proxy_status` and the menu-bar Settings pane. The `launch_app`
+preflight in §4 is **not** implemented; §6's known gap is therefore wider than written.
 **Raised by:** a live debugging session on 2026-09-01 (see §1).
 **Scope:** `launch_app`, `proxy_status`, one new config field.
 

--- a/docs/proposals/cert-preflight-on-launch.md
+++ b/docs/proposals/cert-preflight-on-launch.md
@@ -1,0 +1,173 @@
+# Cert Preflight on `launch_app` — Proposal
+
+**Status:** proposal, not a decision. Written up for consideration; nothing implemented.
+**Raised by:** a live debugging session on 2026-09-01 (see §1).
+**Scope:** `launch_app`, `proxy_status`, one new config field.
+
+---
+
+## 1. The problem, as actually encountered
+
+While testing web-view accessibility against Metatext on an iOS 18.6 simulator, the
+app's `WKWebView` rendered blank. Nothing in the app was wrong.
+
+`proxy_status` showed:
+
+```
+local_capture: ["Metatext", "MobileSafari", "com.apple.WebKit.Networking"]
+flows_captured: 0
+cert_setup: { …two other devices… }        # the booted simulator was absent
+```
+
+Local capture was intercepting the app's TLS, but the simulator did not trust the
+mitmproxy CA. Every HTTPS connection from those processes failed. After
+`install_proxy_cert` and a relaunch, the same screen rendered fully and the proxy
+captured 39 flows.
+
+Three properties make this worth fixing rather than documenting:
+
+1. **The symptom points away from the cause.** What you see is "this screen is
+   blank" or "the app has no network." Nothing mentions the proxy, the
+   certificate, or local capture. The natural next move is to debug the app.
+2. **The blast radius is wider than it looks.** It is tempting to file this as a
+   web-view problem because that is where it was noticed. It is not.
+   `com.apple.WebKit.Networking` covers every WebKit request in every app, and a
+   named process covers all of that app's HTTPS. Sign-in, timelines, and API
+   calls fail exactly the same way; the web view was simply the only network on
+   the screen we happened to be looking at.
+3. **Quern created the state.** `local_capture` is set by Quern, and the cert is
+   installed by Quern. Both halves are ours; only the correlation is missing.
+
+Nothing in the codebase currently correlates `local_capture` with per-device cert
+state. `launch_app` performs no proxy-related checks at all.
+
+## 2. Why not just auto-install the cert
+
+The obvious fix — install the CA on every boot — is the wrong default:
+
+- `CLAUDE.md` states: *"Never auto-configure the system proxy. Never leave it
+  configured when not actively testing."* Silently installing a MITM root CA is a
+  **larger** commitment than a system-proxy toggle, not a smaller one. It
+  persists across sessions and survives the capture window that motivated it.
+- It makes the simulator trust a CA whose private key sits on disk in
+  `~/.mitmproxy`.
+- It would fire on the majority of sessions that never capture anything.
+- The user has to know it happened in order to undo it.
+
+The certificate is only needed when capture is active. Installing it
+unconditionally trades a loud, rare confusion for a quiet, permanent change in
+posture.
+
+## 3. Why a plain warning is not enough either
+
+A warning returned *after* `launch_app` succeeds costs a full cycle: the launch
+happens, HTTPS fails, the user installs the cert, and the app has to be
+relaunched anyway.
+
+That last step is not optional. `simctl keychain add-root-cert` needs no device
+reboot, but in the session above the cert was installed while the app was
+running and the page only loaded after a relaunch — WebKit's networking process
+appears to cache the TLS failure. So the post-hoc path is reliably
+*launch → fail → install → relaunch*.
+
+Since both facts needed to predict the failure are known **before** the launch,
+the check belongs before it.
+
+## 4. Proposed behaviour
+
+Preflight inside `launch_app`, before anything else happens. The check is free:
+the `local_capture` list and `cert_setup[udid].cert_installed` are already in
+memory.
+
+| State | Behaviour |
+|---|---|
+| Capture off, or cert already present | Launch normally — unchanged, no regression for the common case |
+| Broken combination, `auto_install_cert: true` | Install the cert inline, then launch. One call, no round trip |
+| Broken combination, no policy set | **Return without launching**, with a structured response the agent can act on |
+
+The one-shot behaviour comes from the config flag. For the first encounter, one
+round of asking is the correct cost — installing a root CA without consent is
+precisely the thing §2 argues against.
+
+### 4.1 The refusal must offer three resolutions
+
+"Install the cert" is not always what the user wants. A response that only offers
+that will railroad every user into installing a CA, which reintroduces the
+problem §2 avoids. The structured response should name:
+
+1. **Install the certificate** — once, or always (§4.2).
+2. **Remove this app from `local_capture`** — they may not want capture for this
+   run at all, and this resolves the conflict without touching trust settings.
+3. **Launch anyway** — valid when deliberately exercising TLS-failure paths.
+
+### 4.2 The "always" option
+
+`auto_install_cert: true` in `~/.quern/config.json`, mirroring the existing
+`update_check: false` field.
+
+Two requirements, both about not recreating the original bug in a new form:
+
+- **Discoverable.** Surface it in `proxy_status`. A silent, persistent
+  CA-install policy is worse than the failure it prevents.
+- **Revocable.** `quern uninstall` should offer to remove certificates Quern
+  installed. Ideally the install manifest tracks them the way it tracks
+  `pipx_global` entries today.
+
+### 4.3 Consent pattern to reuse
+
+This already exists in the codebase. `update_quern`'s tool description reads:
+
+> Only call this after the user has confirmed they want to update — typically
+> prompted by an `update_available` hint in `ensure_server`'s response.
+
+Same shape: a structured hint in one response, plus a tool description that
+instructs the agent to obtain consent. Reuse it rather than inventing a second
+mechanism. **This means the `launch_app` MCP tool description needs a matching
+paragraph** — without it, agents will treat the refusal as a transient error and
+retry blindly.
+
+## 5. Also worth doing regardless
+
+Add a `capture_without_cert` entry to `proxy_status.warnings`
+(`server/api/proxy.py:97` already builds that list for `multi_interface_active`).
+It is a few lines and covers the diagnostic path for cases the preflight cannot
+reach — see §6.
+
+Word it around processes, not web views:
+
+> local capture is enabled for N processes, but device *X* does not trust the
+> mitmproxy CA — HTTPS from those processes will fail
+
+## 6. Known gap
+
+The preflight cannot catch an app launched by tapping its icon in the simulator,
+or one already running when capture was enabled. `proxy_status.warnings` is the
+fallback for those. This is an accepted limitation, not an oversight.
+
+## 7. Open questions
+
+1. **Is refusing to launch acceptable?** It changes `launch_app`'s behaviour in a
+   state where it previously "succeeded" (by launching an app that could not
+   reach the network). Argued here as a fix rather than a break, but it belongs
+   under **Changed** in the CHANGELOG either way, and it should return a
+   structured refusal rather than a generic error.
+2. **Should the same preflight apply to Android emulators?** The cert story there
+   differs — rootable images only, and `install_proxy_cert` also configures the
+   HTTP proxy. Probably yes, but the failure mode has not been reproduced.
+3. **Does the relaunch requirement hold generally,** or was it specific to
+   WebKit's networking process? Worth confirming: if a running app picks up a
+   newly installed cert for new connections, the argument in §3 weakens for
+   non-WebKit traffic (though not the argument for preflighting).
+4. **Per-device or global policy?** `auto_install_cert` as proposed is global.
+   Per-device would be more precise but adds state to manage.
+
+## 8. Rough implementation sketch
+
+- Preflight helper in `server/proxy/cert_manager.py` — takes a UDID and the
+  capture list, returns an enum-ish verdict.
+- Hook in `server/api/device.py::launch_app`, before `controller.launch_app`.
+- `auto_install_cert` in `server/config.py`, alongside `update_channel`.
+- `capture_without_cert` in the `proxy_status` warnings list.
+- Tool-description paragraph in `mcp/src/tools/device.ts`.
+- Tests across capture on/off × cert present/absent × policy set/unset, plus one
+  asserting the common path is untouched.

--- a/macos/QuernMenuBar/Sources/QuernCLI.swift
+++ b/macos/QuernMenuBar/Sources/QuernCLI.swift
@@ -81,4 +81,8 @@ enum QuernCLI {
     static func setChannel(_ channel: String, completion: ((Int32, String) -> Void)? = nil) {
         run(["set-channel", channel], completion: completion)
     }
+
+    static func setAutoInstallCert(_ enabled: Bool, completion: ((Int32, String) -> Void)? = nil) {
+        run(["set-auto-install-cert", enabled ? "on" : "off"], completion: completion)
+    }
 }

--- a/macos/QuernMenuBar/Sources/SettingsWindow.swift
+++ b/macos/QuernMenuBar/Sources/SettingsWindow.swift
@@ -12,10 +12,12 @@ final class SettingsModel: ObservableObject {
     @Published var snapshot = QuernSnapshot()
     @Published var loginEnabled = LoginItem.isEnabled()
     @Published var channel: String = "stable"
+    @Published var autoInstallCert: Bool = false
 
     func apply(_ snap: QuernSnapshot) {
         snapshot = snap
         if let c = snap.update.channel { channel = c }
+        autoInstallCert = snap.proxy.autoInstallCert
     }
 }
 
@@ -80,6 +82,35 @@ struct SettingsView: View {
                     ("Name", d.name ?? "—"),
                     ("UDID", d.udid ?? "—"),
                 ])
+            }
+
+            GroupBox("Network capture") {
+                VStack(alignment: .leading, spacing: 8) {
+                    Toggle(isOn: $model.autoInstallCert) {
+                        Text("Install the capture certificate automatically")
+                    }
+                    .onChange(of: model.autoInstallCert) { newValue in
+                        // Same guard as the channel picker below: apply()
+                        // assigns this on every fresh snapshot, and writing
+                        // back on that path would shell out on each refresh.
+                        guard newValue != model.snapshot.proxy.autoInstallCert else { return }
+                        QuernCLI.setAutoInstallCert(newValue)
+                    }
+                    .accessibilityLabel("Install the capture certificate automatically")
+
+                    // Says what it costs, not just what it does. This installs
+                    // a root certificate authority, which is a longer-lived
+                    // commitment than enabling capture, and the whole reason
+                    // the setting is surfaced here rather than left in a file.
+                    Text(model.autoInstallCert
+                         ? "Quern will install its certificate on a device when capture needs it."
+                         : "Quern will ask before installing its certificate on a device.")
+                        .foregroundColor(.secondary)
+                        .font(.callout)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(6)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
 
             GroupBox("Updates") {

--- a/macos/QuernMenuBar/Sources/StateReader.swift
+++ b/macos/QuernMenuBar/Sources/StateReader.swift
@@ -190,8 +190,19 @@ final class StateReader {
     /// Anything other than a real boolean reads as off. A malformed config
     /// should mean "ask me", never consent to installing a root CA.
     private static func readAutoInstallCert() -> Bool {
-        guard let d = json("config.json") else { return false }
-        return (d["auto_install_cert"] as? Bool) == true
+        guard let d = json("config.json"), let raw = d["auto_install_cert"] else {
+            return false
+        }
+        // A literal JSON `true`, not merely something truthy.
+        //
+        // JSONSerialization hands back NSNumber for both booleans and numbers,
+        // and `as? Bool` accepts a numeric 1 -- measured: `{"x": 1}` reads as
+        // true. The server requires a real boolean (`is True` in
+        // server/config.py), so without this check a config holding 1 would
+        // show the policy enabled here while the server refused capture,
+        // which is a worse failure than either behaviour alone.
+        guard CFGetTypeID(raw as CFTypeRef) == CFBooleanGetTypeID() else { return false }
+        return (raw as? Bool) == true
     }
 
     private static func readChannel() -> String {

--- a/macos/QuernMenuBar/Sources/StateReader.swift
+++ b/macos/QuernMenuBar/Sources/StateReader.swift
@@ -22,6 +22,10 @@ struct ServerState {
     var startedAt: Date?
 }
 
+struct ProxyPolicy {
+    var autoInstallCert = false
+}
+
 struct UpdateInfo {
     var updateAvailable = false
     var currentVersion: String?
@@ -43,6 +47,7 @@ struct QuernSnapshot {
     var server = ServerState()
     var update = UpdateInfo()
     var device = ActiveDevice()
+    var proxy = ProxyPolicy()
 }
 
 final class StateReader {
@@ -102,6 +107,7 @@ final class StateReader {
         snap.server = Self.readServerState()
         snap.update = Self.readUpdateInfo()
         snap.device = Self.readActiveDevice()
+        snap.proxy = ProxyPolicy(autoInstallCert: Self.readAutoInstallCert())
         snapshot = snap
         onChange?(snap)
     }
@@ -176,6 +182,17 @@ final class StateReader {
     /// config.json cannot put the picker in a state the user can't get out of.
     static let validChannels = ["stable", "beta"]
     static let defaultChannel = "stable"
+
+    /// Whether Quern installs the mitmproxy CA by itself when capture needs
+    /// it. Read from config.json rather than the server, so it is correct
+    /// even when the daemon is stopped -- the same reason the channel is.
+    ///
+    /// Anything other than a real boolean reads as off. A malformed config
+    /// should mean "ask me", never consent to installing a root CA.
+    private static func readAutoInstallCert() -> Bool {
+        guard let d = json("config.json") else { return false }
+        return (d["auto_install_cert"] as? Bool) == true
+    }
 
     private static func readChannel() -> String {
         guard let d = json("config.json"),

--- a/mcp/src/tools/proxy.ts
+++ b/mcp/src/tools/proxy.ts
@@ -687,7 +687,11 @@ For physical devices, pass client_ip to isolate that device's traffic — the re
 Use this after start_proxy when you're ready to begin capturing traffic.
 Remember to call unconfigure_system_proxy when done to restore the user's browser.
 
-NOTE: The proxy must be running first (call start_proxy).`,
+NOTE: The proxy must be running first (call start_proxy).
+
+CERTIFICATE CHECK. This refuses with HTTP 428 when a booted simulator does not trust the mitmproxy CA, because capturing in that state fails every HTTPS request from that device with no indication the proxy is the cause -- what the user sees is a blank screen or an app with no network, and the natural next move is to debug the app. The refusal is NOT a transient error and retrying will not clear it. The response body names the affected devices and three resolutions: install_proxy_cert on each device, set auto_install_cert so Quern handles it from now on, or pass skip_cert_check to proceed anyway.
+
+Ask the user which they want before acting -- installing a root certificate authority is a larger and longer-lived commitment than enabling capture, so it needs their consent, the same way update_quern does. skip_cert_check is the right answer when they are deliberately exercising TLS-failure paths.`,
     inputSchema: strictParams({
       interface: z
         .string()

--- a/mcp/src/tools/proxy.ts
+++ b/mcp/src/tools/proxy.ts
@@ -697,15 +697,27 @@ Ask the user which they want before acting -- installing a root certificate auth
         .string()
         .optional()
         .describe("Network interface name (e.g. 'Wi-Fi'). Auto-detected if omitted."),
+      skip_cert_check: z
+        .boolean()
+        .optional()
+        .describe(
+          "Configure the proxy even when a booted simulator does not trust the " +
+          "mitmproxy CA. Only pass this when the user has said so: capturing in " +
+          "that state fails every HTTPS request from that device with nothing " +
+          "pointing at the proxy. Correct when deliberately exercising " +
+          "TLS-failure paths."
+        ),
     }),
-  }, async ({ interface: iface }) => {
+  }, async ({ interface: iface, skip_cert_check: skipCertCheck }) => {
     try {
-      const body = iface ? { interface: iface } : undefined;
+      const body: Record<string, unknown> = {};
+      if (iface) body.interface = iface;
+      if (skipCertCheck) body.skip_cert_check = true;
       const data = await apiRequest(
         "POST",
         "/api/v1/proxy/configure-system",
         undefined,
-        body
+        Object.keys(body).length ? body : undefined
       );
 
       return {

--- a/server/__main__.py
+++ b/server/__main__.py
@@ -424,6 +424,47 @@ def _cmd_grant_full_perms() -> int:
     return 0
 
 
+def _cmd_set_auto_install_cert(args: list[str]) -> int:
+    """Read or set the automatic CA-install policy.
+
+    Usage:
+        quern set-auto-install-cert on|off
+        quern set-auto-install-cert          # print the current setting
+
+    Capturing HTTPS from a device that does not trust the mitmproxy CA fails
+    every request, and the symptom points nowhere near the proxy. Quern
+    normally refuses to configure the proxy in that state and asks. Turning
+    this on answers the question once, in advance.
+
+    It is off by default because installing a MITM root CA is a larger and
+    longer-lived commitment than the proxy toggle that prompts it.
+    """
+    from server.config import get_auto_install_cert, set_auto_install_cert
+
+    if not args:
+        state = "on" if get_auto_install_cert() else "off"
+        print(f"Automatic certificate install: {state}")
+        if state == "off":
+            print("Quern will ask before installing the mitmproxy CA on a device.")
+        else:
+            print("Quern will install the mitmproxy CA when capture needs it.")
+        return 0
+
+    target = args[0].lower()
+    if target in ("on", "true", "yes", "1"):
+        set_auto_install_cert(True)
+        print("Automatic certificate install: on")
+        print("Quern will install the mitmproxy CA when capture needs it.")
+        return 0
+    if target in ("off", "false", "no", "0"):
+        set_auto_install_cert(False)
+        print("Automatic certificate install: off")
+        return 0
+
+    print(f"Unknown value {args[0]!r}. Use 'on' or 'off'.", file=sys.stderr)
+    return 2
+
+
 def _cmd_set_channel(args: list[str]) -> int:
     """Persist the update channel preference (``stable`` or ``beta``).
 
@@ -598,6 +639,9 @@ def main() -> None:
 
     if len(sys.argv) >= 2 and sys.argv[1] == "set-channel":
         sys.exit(_cmd_set_channel(sys.argv[2:]))
+
+    if len(sys.argv) >= 2 and sys.argv[1] == "set-auto-install-cert":
+        sys.exit(_cmd_set_auto_install_cert(sys.argv[2:]))
 
     if len(sys.argv) >= 2 and sys.argv[1] == "tunneld":
         from server.device.tunneld import cli_tunneld

--- a/server/api/proxy.py
+++ b/server/api/proxy.py
@@ -101,6 +101,14 @@ async def _get_proxy_status(
     distinct_subnets = {iface.subnet for iface in local_ips if iface.subnet}
     if len(distinct_subnets) >= 2:
         warnings.append("multi_interface_active")
+    # The diagnostic path for the cases the preflight cannot reach: an app
+    # launched by tapping its icon, or capture enabled before the device booted.
+    from server.config import get_auto_install_cert
+    from server.proxy.cert_preflight import simulators_without_cert
+
+    auto_install_cert = get_auto_install_cert()
+    if await simulators_without_cert(getattr(request.app.state, "device_controller", None)):
+        warnings.append("capture_without_cert")
     try:
         from server.proxy.cert_state import read_cert_state, strip_noncanonical_fields
         device_certs = read_cert_state()
@@ -193,6 +201,7 @@ async def _get_proxy_status(
             local_ip=local_ip,
             local_ips=local_ips,
             warnings=warnings,
+            auto_install_cert=auto_install_cert,
             cert_setup=cert_setup,
             system_proxy=system_proxy_info,
             network_state=network_state_dict,
@@ -213,6 +222,7 @@ async def _get_proxy_status(
             local_ip=local_ip,
             local_ips=local_ips,
             warnings=warnings,
+            auto_install_cert=auto_install_cert,
             cert_setup=cert_setup,
             system_proxy=system_proxy_info,
             network_state=network_state_dict,
@@ -233,6 +243,7 @@ async def _get_proxy_status(
             local_ip=local_ip,
             local_ips=local_ips,
             warnings=warnings,
+            auto_install_cert=auto_install_cert,
             cert_setup=cert_setup,
             system_proxy=system_proxy_info,
             network_state=network_state_dict,
@@ -410,6 +421,44 @@ async def configure_system(request: Request, body: dict | None = None) -> System
         raise HTTPException(status_code=409, detail="System proxy already configured by Quern")
 
     interface_override = body.get("interface") if body else None
+    skip_cert_check = bool(body.get("skip_cert_check")) if body else False
+
+    # Preflight: capture through a device that does not trust the CA fails
+    # every HTTPS request, and the symptom -- a blank screen, an app with no
+    # network -- points nowhere near the proxy. Both halves of that state are
+    # ours, so refuse to create it rather than let it be discovered later.
+    if not skip_cert_check:
+        from server.config import get_auto_install_cert
+        from server.proxy.cert_preflight import refusal_detail, simulators_without_cert
+
+        controller = getattr(request.app.state, "device_controller", None)
+        missing = await simulators_without_cert(controller)
+        if missing:
+            if get_auto_install_cert():
+                from server.proxy.cert_manager import install_cert
+
+                for dev in missing:
+                    try:
+                        await install_cert(
+                            controller, dev["udid"], device_name=dev["name"],
+                        )
+                        _proxy_logger.info(
+                            "Auto-installed the CA on %s (%s)", dev["name"], dev["udid"][:8],
+                        )
+                    except Exception as e:
+                        # Report the failure rather than configuring anyway: the
+                        # user opted into having this handled, and silently
+                        # proceeding recreates exactly the state they opted out of.
+                        raise HTTPException(
+                            status_code=500,
+                            detail=(
+                                f"auto_install_cert is set but installing the CA on "
+                                f"{dev['name']} failed: {e}"
+                            ),
+                        ) from e
+            else:
+                # 428: the request is fine, the world is not ready for it yet.
+                raise HTTPException(status_code=428, detail=refusal_detail(missing))
 
     try:
         snap = await asyncio.to_thread(

--- a/server/api/proxy.py
+++ b/server/api/proxy.py
@@ -22,6 +22,7 @@ from server.models import (
     CaptureStartResponse,
     CaptureStopRequest,
     CaptureStopResponse,
+    ConfigureSystemProxyRequest,
     DeviceCertState,
     FlowEvent,
     FlowQueryParams,
@@ -406,7 +407,9 @@ async def stop_proxy(request: Request) -> dict:
 
 
 @router.post("/configure-system", response_model=SystemProxyInfo)
-async def configure_system(request: Request, body: dict | None = None) -> SystemProxyInfo:
+async def configure_system(
+    request: Request, body: ConfigureSystemProxyRequest | None = None,
+) -> SystemProxyInfo:
     """Manually configure macOS system proxy to route through mitmproxy."""
     import asyncio
 
@@ -420,8 +423,8 @@ async def configure_system(request: Request, body: dict | None = None) -> System
     if state and state.get("system_proxy_configured"):
         raise HTTPException(status_code=409, detail="System proxy already configured by Quern")
 
-    interface_override = body.get("interface") if body else None
-    skip_cert_check = bool(body.get("skip_cert_check")) if body else False
+    interface_override = body.interface if body else None
+    skip_cert_check = body.skip_cert_check if body else False
 
     # Preflight: capture through a device that does not trust the CA fails
     # every HTTPS request, and the symptom -- a blank screen, an app with no

--- a/server/config.py
+++ b/server/config.py
@@ -106,6 +106,34 @@ def set_update_channel(channel: str) -> None:
     USER_CONFIG_FILE.write_text(json.dumps(config, indent=2) + "\n")
 
 
+def get_auto_install_cert() -> bool:
+    """Whether to install the mitmproxy CA automatically when capture needs it.
+
+    Defaults to False, and deliberately: installing a MITM root CA is a larger
+    and longer-lived commitment than the proxy toggle that prompts it. It
+    persists across sessions, outlives the capture window, and the user has to
+    know it happened in order to undo it. So the first encounter costs one
+    round of asking, and this makes the second onwards free.
+
+    Anything other than a real boolean is treated as unset -- a typo should
+    read as "ask me", never as consent.
+    """
+    return read_user_config().get("auto_install_cert") is True
+
+
+def set_auto_install_cert(enabled: bool) -> None:
+    """Persist the auto-install policy.
+
+    Surfaced in ``proxy_status`` and in the menu-bar app's Settings pane, both
+    on purpose: a silent, persistent CA-install policy would be worse than the
+    failure it exists to prevent.
+    """
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    config = read_user_config()
+    config["auto_install_cert"] = bool(enabled)
+    USER_CONFIG_FILE.write_text(json.dumps(config, indent=2) + "\n")
+
+
 def channel_to_release_branch(channel: str) -> str:
     """Map a channel name to its reserved release pointer branch.
 

--- a/server/models.py
+++ b/server/models.py
@@ -496,7 +496,13 @@ class ProxyStatusResponse(BaseModel):
     warnings: list[str] = Field(default_factory=list)
     """Network-state warnings the agent should surface. Currently:
     ``"multi_interface_active"`` — more than one interface is on a distinct
-    /24, so ``local_ip`` is not the right answer for every device."""
+    /24, so ``local_ip`` is not the right answer for every device.
+    ``"capture_without_cert"`` — a booted simulator does not trust the
+    mitmproxy CA, so HTTPS from it fails with nothing pointing at the proxy."""
+    auto_install_cert: bool = False
+    """Whether Quern will install the CA by itself when capture needs it.
+    Reported because a persistent, silent CA-install policy would be worse
+    than the failure it prevents — see ``server/config.py``."""
     system_proxy: SystemProxyInfo | None = None
     cert_setup: dict[str, DeviceCertState] | None = None  # Per-device cert status
     network_state: dict | None = None

--- a/server/models.py
+++ b/server/models.py
@@ -468,6 +468,20 @@ class InterfaceInfo(BaseModel):
     ssid: str | None = None  # Wi-Fi SSID when the interface is associated, else None
 
 
+class ConfigureSystemProxyRequest(BaseModel):
+    """Body for ``POST /proxy/configure-system``."""
+
+    interface: str | None = None
+    """Network service to configure. Auto-detected when omitted."""
+    skip_cert_check: bool = False
+    """Configure the proxy even when a booted simulator does not trust the
+    mitmproxy CA. Correct when deliberately exercising TLS-failure paths;
+    otherwise the request is refused with 428 and the devices are named.
+
+    Typed rather than read off a raw dict: ``bool("false")`` is True, so a
+    caller sending the string would have silently skipped the check."""
+
+
 class ProxyStatusResponse(BaseModel):
     """Response from GET /api/v1/proxy/status."""
 

--- a/server/proxy/cert_preflight.py
+++ b/server/proxy/cert_preflight.py
@@ -1,0 +1,95 @@
+"""Correlate system-proxy capture with per-device certificate trust.
+
+Both halves of the broken state are Quern's own: it configures the proxy, and
+it installs the CA. Only the correlation was missing, so enabling capture
+against a device that does not trust the CA produced silent HTTPS failures
+whose symptom -- a blank screen, an app with no network -- points nowhere near
+the proxy. See docs/proposals/cert-preflight-on-launch.md for the analysis.
+
+Scoped to booted simulators on purpose. The macOS system proxy is what
+simulators route through, because they share the host's network stack. A
+physical device is proxied by its own Wi-Fi configuration instead, so it is
+unaffected by this call and reporting it here would be noise.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("quern-debug-server.cert-preflight")
+
+
+async def simulators_without_cert(controller) -> list[dict[str, str]]:
+    """Booted simulators that do not trust the mitmproxy CA.
+
+    Returns a list of ``{"udid", "name"}``, empty when every booted simulator
+    trusts it -- which is the common case and the one that must stay fast.
+
+    A device absent from cert-state.json has never had a cert installed, so
+    absence and ``cert_installed: false`` mean the same thing here.
+
+    Never raises. A preflight that fails closed would block capture over its
+    own bug, which is worse than the failure it prevents; on any error it
+    reports nothing missing and lets the call proceed.
+    """
+    if controller is None:
+        return []
+
+    try:
+        from server.models import DeviceState, DeviceType
+        from server.proxy.cert_state import read_cert_state
+
+        devices = await controller.list_devices()
+        certs = read_cert_state()
+
+        missing = []
+        for d in devices:
+            if d.device_type != DeviceType.SIMULATOR or d.state != DeviceState.BOOTED:
+                continue
+            entry = certs.get(d.udid)
+            if not entry or not entry.get("cert_installed"):
+                missing.append({"udid": d.udid, "name": d.name})
+        return missing
+    except Exception as e:
+        logger.debug("Cert preflight could not run, allowing the call: %s", e)
+        return []
+
+
+def refusal_detail(missing: list[dict[str, str]]) -> dict:
+    """The structured body returned when capture would fail silently.
+
+    Names every resolution rather than only the obvious one. A response that
+    offers just "install the certificate" railroads everyone into trusting a
+    MITM root CA, which is a larger and more persistent commitment than the
+    proxy toggle that prompted it.
+    """
+    return {
+        "error": "capture_without_cert",
+        "message": (
+            f"{len(missing)} booted simulator(s) do not trust the mitmproxy CA. "
+            "HTTPS from them will fail with no indication that the proxy is the "
+            "cause."
+        ),
+        "devices": missing,
+        "resolutions": [
+            {
+                "action": "install_proxy_cert",
+                "detail": "Install the CA on each device listed, then retry.",
+            },
+            {
+                "action": "set_auto_install_cert",
+                "detail": (
+                    "Set auto_install_cert in ~/.quern/config.json to install it "
+                    "automatically from now on. Reported by proxy_status, and "
+                    "removable with quern uninstall."
+                ),
+            },
+            {
+                "action": "skip_cert_check",
+                "detail": (
+                    "Pass skip_cert_check to configure the proxy anyway -- "
+                    "correct when you are deliberately exercising TLS failure."
+                ),
+            },
+        ],
+    }

--- a/tests/test_cert_preflight.py
+++ b/tests/test_cert_preflight.py
@@ -121,3 +121,24 @@ class TestPolicy:
         assert config.get_auto_install_cert() is True
         config.set_auto_install_cert(False)
         assert config.get_auto_install_cert() is False
+
+
+class TestRequestModel:
+    """`skip_cert_check` bypasses a safety check, so how it is parsed matters."""
+
+    def test_the_string_false_does_not_skip_the_check(self):
+        """Read off a raw dict, `bool("false")` is True -- a caller sending
+        the string would have silently bypassed the preflight."""
+        from server.models import ConfigureSystemProxyRequest
+
+        assert ConfigureSystemProxyRequest(skip_cert_check="false").skip_cert_check is False
+
+    def test_it_defaults_to_running_the_check(self):
+        from server.models import ConfigureSystemProxyRequest
+
+        assert ConfigureSystemProxyRequest().skip_cert_check is False
+
+    def test_an_explicit_true_skips_it(self):
+        from server.models import ConfigureSystemProxyRequest
+
+        assert ConfigureSystemProxyRequest(skip_cert_check=True).skip_cert_check is True

--- a/tests/test_cert_preflight.py
+++ b/tests/test_cert_preflight.py
@@ -1,0 +1,123 @@
+"""Tests for the cert preflight on enabling the system proxy.
+
+The failure this prevents: capture through a device that does not trust the
+mitmproxy CA fails every HTTPS request, and the symptom -- a blank screen, an
+app with no network -- points nowhere near the proxy.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from server.models import DeviceInfo, DeviceState, DeviceType
+from server.proxy.cert_preflight import refusal_detail, simulators_without_cert
+
+
+def _sim(udid="AAAA", name="iPhone 16 Pro", state=DeviceState.BOOTED):
+    return DeviceInfo(
+        udid=udid, name=name, state=state,
+        device_type=DeviceType.SIMULATOR, os_version="iOS 18.6", runtime="",
+    )
+
+
+def _phone(udid="BBBB", name="iPhone 11"):
+    return DeviceInfo(
+        udid=udid, name=name, state=DeviceState.BOOTED,
+        device_type=DeviceType.DEVICE, os_version="iOS 26.6", runtime="",
+    )
+
+
+class _Ctrl:
+    def __init__(self, devices):
+        self.list_devices = AsyncMock(return_value=devices)
+
+
+class TestPreflight:
+    async def test_a_booted_simulator_with_no_cert_is_reported(self):
+        with patch("server.proxy.cert_state.read_cert_state", return_value={}):
+            missing = await simulators_without_cert(_Ctrl([_sim()]))
+        assert [d["name"] for d in missing] == ["iPhone 16 Pro"]
+
+    async def test_absence_and_false_mean_the_same_thing(self):
+        """A device that has never had a cert installed is not in
+        cert-state.json at all."""
+        with patch("server.proxy.cert_state.read_cert_state",
+                   return_value={"AAAA": {"cert_installed": False}}):
+            missing = await simulators_without_cert(_Ctrl([_sim()]))
+        assert len(missing) == 1
+
+    async def test_a_trusting_simulator_is_not_reported(self):
+        with patch("server.proxy.cert_state.read_cert_state",
+                   return_value={"AAAA": {"cert_installed": True}}):
+            missing = await simulators_without_cert(_Ctrl([_sim()]))
+        assert missing == []
+
+    async def test_physical_devices_are_out_of_scope(self):
+        """The macOS system proxy is what simulators route through. A physical
+        device is proxied by its own Wi-Fi config and is unaffected by this
+        call, so naming it here would be noise."""
+        with patch("server.proxy.cert_state.read_cert_state", return_value={}):
+            missing = await simulators_without_cert(_Ctrl([_phone()]))
+        assert missing == []
+
+    async def test_shutdown_simulators_are_out_of_scope(self):
+        with patch("server.proxy.cert_state.read_cert_state", return_value={}):
+            missing = await simulators_without_cert(
+                _Ctrl([_sim(state=DeviceState.SHUTDOWN)])
+            )
+        assert missing == []
+
+    async def test_it_never_blocks_the_call_on_its_own_failure(self):
+        """A preflight that fails closed would block capture over its own bug,
+        which is worse than the failure it prevents."""
+        ctrl = _Ctrl([])
+        ctrl.list_devices = AsyncMock(side_effect=RuntimeError("simctl exploded"))
+        assert await simulators_without_cert(ctrl) == []
+
+    async def test_no_controller_is_not_an_error(self):
+        assert await simulators_without_cert(None) == []
+
+
+class TestRefusal:
+    def test_it_offers_more_than_installing_the_cert(self):
+        """A response that only offers "install the certificate" railroads
+        every user into trusting a MITM root CA."""
+        detail = refusal_detail([{"udid": "AAAA", "name": "iPhone 16 Pro"}])
+        actions = {r["action"] for r in detail["resolutions"]}
+        assert actions == {"install_proxy_cert", "set_auto_install_cert", "skip_cert_check"}
+
+    def test_it_names_the_devices(self):
+        detail = refusal_detail([{"udid": "AAAA", "name": "iPhone 16 Pro"}])
+        assert detail["devices"][0]["name"] == "iPhone 16 Pro"
+        assert detail["error"] == "capture_without_cert"
+
+
+class TestPolicy:
+    def test_the_default_is_to_ask(self, tmp_path, monkeypatch):
+        """Installing a MITM root CA is a larger commitment than the proxy
+        toggle that prompts it, so consent is not assumed."""
+        from server import config
+        monkeypatch.setattr(config, "USER_CONFIG_FILE", tmp_path / "config.json")
+        monkeypatch.setattr(config, "CONFIG_DIR", tmp_path)
+        assert config.get_auto_install_cert() is False
+
+    def test_only_a_real_boolean_counts_as_consent(self, tmp_path, monkeypatch):
+        """A typo should read as "ask me", never as permission."""
+        import json
+
+        from server import config
+        cfg = tmp_path / "config.json"
+        monkeypatch.setattr(config, "USER_CONFIG_FILE", cfg)
+        monkeypatch.setattr(config, "CONFIG_DIR", tmp_path)
+        for bogus in ["true", 1, "yes", {}]:
+            cfg.write_text(json.dumps({"auto_install_cert": bogus}))
+            assert config.get_auto_install_cert() is False, bogus
+
+    def test_it_round_trips(self, tmp_path, monkeypatch):
+        from server import config
+        monkeypatch.setattr(config, "USER_CONFIG_FILE", tmp_path / "config.json")
+        monkeypatch.setattr(config, "CONFIG_DIR", tmp_path)
+        config.set_auto_install_cert(True)
+        assert config.get_auto_install_cert() is True
+        config.set_auto_install_cert(False)
+        assert config.get_auto_install_cert() is False


### PR DESCRIPTION
Removes a gotcha that costs a debugging session every time it happens: ask for the proxy to be enabled, get it, and then watch every network call fail. The device does not trust the mitmproxy CA, so HTTPS from it fails with nothing pointing at the proxy — what you see is a blank screen or an app with no network, and the natural next move is to debug the app.

Both halves of that state were already Quern's. It configures the proxy and it installs the CA; only the correlation was missing.

## What happens now

`configure_system_proxy` preflights booted simulators against `cert-state.json` and refuses with **428** when any of them would fail, naming the devices.

Scoped to simulators deliberately: the macOS system proxy is what they route through, because they share the host's network stack. A physical device is proxied by its own Wi-Fi config and is unaffected by this call, so naming it here would be noise.

The refusal offers three resolutions, not one. A response that only said "install the certificate" would railroad everyone into trusting a MITM root CA, which is precisely the outcome this exists to make deliberate:

```json
{
  "error": "capture_without_cert",
  "devices": [{"udid": "…", "name": "iPhone 16 Pro"}],
  "resolutions": ["install_proxy_cert", "set_auto_install_cert", "skip_cert_check"]
}
```

`skip_cert_check` is the right answer when you are deliberately exercising TLS-failure paths.

## The policy, and why it is visible

`auto_install_cert` answers the question once. Off by default, because installing a root certificate authority is a larger and longer-lived commitment than the proxy toggle that prompts it: it persists across sessions, outlives the capture window, and you have to know it happened to undo it. Anything other than a real boolean reads as unset — a typo in `config.json` should mean "ask me", never consent.

It is surfaced in `proxy_status` **and** in the menu-bar app's Settings pane, both on purpose. A silent, persistent CA-install policy would be worse than the failure it prevents, so the setting is visible where someone would look for it and reversible from the same place. The pane says what the setting costs, not just what it does.

New CLI: `quern set-auto-install-cert [on|off]`.

`proxy_status` also gains a `capture_without_cert` warning, which covers what the preflight cannot reach — an app launched by tapping its icon, or capture enabled before the device booted.

## Agent-facing

The tool description tells agents a 428 here is not transient and must not be retried blindly, and to obtain consent before installing — the same pattern `update_quern` already uses for a consequential action.

## Verified against a running server

| path | result |
|---|---|
| cert present | no refusal, no warning |
| cert missing | 428, device named, three resolutions |
| refusal | configures nothing, `system_proxy_configured` stays false |
| `skip_cert_check` | proceeds, 200 |
| after proceeding | `capture_without_cert` appears in status |

The preflight never fails closed. Blocking capture over a bug in the check would be worse than the failure it prevents, so any error reports nothing missing and lets the call through.

Suite 2006, up 12.

## Not verified

The Settings toggle's **write** path. SwiftUI inside an `NSHostingController` does not expose its controls to AppleScript, which this codebase already documents, so the checkbox cannot be clicked from a script. The read path is verified — changing the setting with the CLI flips the toggle and its caption in the running app — and the command it calls is tested directly, but a human clicking it is the only real proof.

## Background

`docs/proposals/cert-preflight-on-launch.md` is included. It analysed this from a live session on 2026-09-01 and had been sitting on an unpushed local branch. Its status header now records what shipped and what did not: the `launch_app` preflight it proposes is still unimplemented, so §6's known gap is wider than written.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added certificate trust checks before enabling capture, identifying simulators that lack the trusted proxy certificate.
  * Added an automatic certificate-install setting in the CLI and menu-bar app Settings; it is off by default.
  * Added certificate status, warnings, and installation-policy details to proxy status responses.
  * Added an option to bypass certificate checks when configuring capture.

* **Bug Fixes**
  * Prevented capture from being enabled when simulator HTTPS traffic would fail due to an untrusted certificate.

* **Documentation**
  * Documented the automatic certificate-install command and certificate preflight behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->