### PR TITLE
Release prep: v0.16.0, and the docs the cert preflight invalidated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-09-11
+
 ### Added
 - **Quern checks certificate trust before enabling capture** — configuring the system proxy against a simulator that does not trust the mitmproxy CA fails every HTTPS request from it, and the symptom points nowhere near the proxy: a blank screen, or an app with no network. Both halves of that state were already Quern's — it configures the proxy and it installs the CA — and only the correlation was missing. `configure_system_proxy` now refuses in that state and names the devices, rather than creating it and leaving it to be discovered. `proxy_status` reports the same condition as a `capture_without_cert` warning for the cases the check cannot reach.
 - **`quern set-auto-install-cert`** — answers the question once instead of every time. Off by default, because installing a MITM root certificate authority is a larger and longer-lived commitment than the proxy toggle that prompts it: it persists across sessions and outlives the capture window. The setting appears in the menu-bar app's Settings pane and in `proxy_status`, deliberately — a silent, persistent CA-install policy would be worse than the failure it prevents. Pass `skip_cert_check` to configure the proxy anyway, which is the right answer when deliberately exercising TLS-failure paths.
@@ -383,7 +385,8 @@ First versioned release — MVP with iOS and Android support.
 - Live device preview (CoreMediaIO for iOS, MJPEG streaming for Android).
 - `quern --version` command.
 
-[Unreleased]: https://github.com/quern-dev/quern/compare/v0.15.0...main
+[Unreleased]: https://github.com/quern-dev/quern/compare/v0.16.0...main
+[0.16.0]: https://github.com/quern-dev/quern/releases/tag/v0.16.0
 [0.15.0]: https://github.com/quern-dev/quern/releases/tag/v0.15.0
 [0.15.0-beta.1]: https://github.com/quern-dev/quern/releases/tag/v0.15.0-beta.1
 [0.14.1]: https://github.com/quern-dev/quern/releases/tag/v0.14.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,6 +117,21 @@ The proxy follows an **opt-in capture** model:
 
 Never auto-configure the system proxy. Never leave it configured when not actively testing.
 
+**The same rule governs the CA.** Installing a MITM root certificate authority
+is a *larger* commitment than a system-proxy toggle, not a smaller one: it
+persists across sessions, outlives the capture window that motivated it, and
+the user has to know it happened in order to undo it. So
+`configure_system_proxy` refuses with 428 when a booted simulator does not
+trust the CA, names the devices, and offers three ways out rather than one --
+offering only "install the certificate" railroads every user into trusting a
+CA, which is the outcome the refusal exists to make deliberate.
+
+`auto_install_cert` in `~/.quern/config.json` answers the question once. It is
+surfaced in `proxy_status` and in the menu-bar app's Settings pane on purpose:
+a silent, persistent CA-install policy would be worse than the failure it
+prevents. Anything other than a literal boolean reads as unset, on both sides
+-- a typo should mean "ask me", never consent.
+
 ## Where the API is documented
 
 Deliberately not restated here. [`docs/api-reference.md`](docs/api-reference.md)

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Spawns `mitmdump` as a subprocess to capture HTTP/HTTPS traffic (port 9101 by de
 - **Bypass** — exclude domains from capture with an allowlist, so analytics and telemetry noise never enters the flow store
 - **Local capture** — transparently capture simulator traffic per-process via mitmproxy's macOS System Extension, without configuring a system proxy. Each flow is tagged with the originating simulator's UDID for per-simulator filtering
 - **System proxy** — auto-configures macOS network settings to route traffic through the proxy (for physical devices or non-simulator traffic)
-- **Certificate management** — check, install, and verify mitmproxy CA certificates
+- **Certificate management** — check, install, and verify mitmproxy CA certificates. Quern asks before installing one: capturing through a device that does not trust the CA fails every HTTPS request with nothing pointing at the proxy, so enabling capture refuses in that state rather than creating it. `quern set-auto-install-cert on` answers the question once
 - **LLM summaries** — traffic digests grouped by host with error highlights
 
 **Proxy setup for simulators:**

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -115,11 +115,15 @@ Logs, network flows, and UI trees can be huge. Always filter to what you need.
 - **Local capture (recommended)**: Uses mitmproxy's macOS System Extension to transparently capture simulator traffic without configuring a system proxy. Each simulator's flows are tagged with its UDID. Check `proxy_status` — if `local_capture` is non-empty, simulator traffic is already being captured. The user configures which processes to capture via `quern enable-local-capture <process_name>` (the process name is typically the Xcode target name). Use `set_local_capture` to change the process list at runtime without restarting the server.
 - **System proxy**: Configures macOS-wide proxy settings. Use `configure_system_proxy` to start capturing and `unconfigure_system_proxy` when done. Affects all Mac traffic — always unconfigure when finished.
 
+**`configure_system_proxy` can refuse, and that refusal is not an error to retry.** It returns **428** when a booted simulator does not trust the mitmproxy CA, because capturing in that state fails every HTTPS request from that device and the symptom points nowhere near the proxy — a blank screen, or an app that appears to have no network. The response names the devices and three ways out: install the certificate, set `auto_install_cert` so Quern handles it from now on, or pass `skip_cert_check` to proceed anyway.
+
+Ask the user which they want. Installing a certificate authority persists across sessions and outlives the capture window, so it needs their say-so — the same way `update_quern` does. `skip_cert_check` is the right answer when they are deliberately exercising TLS-failure paths.
+
 **Certificate verification**: If no flows are captured, verify the proxy certificate is installed on the simulator:
 1. Call `verify_proxy_setup` — performs a ground-truth check by querying the simulator's TrustStore database. Defaults to **booted simulators only**; pass `state="all"` or `device_type="device"` to check shutdown sims or physical devices
 2. Returns per-device `status`: `installed`, `not_installed`, `never_booted`, or `error`
 3. Returns `erased_devices` — UDIDs where a previously installed cert is now missing (probable device erase)
-4. If cert is missing, install it with: `xcrun simctl keychain <udid> add-root-cert ~/.mitmproxy/mitmproxy-ca-cert.pem`
+4. If the cert is missing, install it with `install_proxy_cert` — **after asking the user**. Do not shell out to `xcrun simctl keychain add-root-cert` directly: that installs a root certificate authority with no record in Quern's cert state, so `proxy_status` and the capture preflight both go on believing the device is untrusted, and nothing tracks it for removal.
 
 **Physical device proxy capture**: Physical devices need their Wi-Fi proxy configured manually in Settings. The full setup flow is: install cert → trust cert → configure Wi-Fi proxy → call `record_device_proxy_config`. After that, filter flows by the device's `client_ip`.
 
@@ -488,7 +492,7 @@ Use `ensure_devices` to boot multiple simulators at once, then run different tes
 
 **"Proxy not running"** — Check with `proxy_status` and call `start_proxy` if needed.
 
-**"No flows captured"** — Check `proxy_status`. If `local_capture` is non-empty, simulator traffic should be captured automatically — verify certs with `verify_proxy_setup`. If local capture is not enabled, the device may not be configured to route through the proxy. Check `proxy_setup_guide` for device configuration steps. Also check for certificate pinning in the app.
+**"No flows captured"** — Check `proxy_status` first; a `capture_without_cert` warning there means a booted simulator does not trust the CA, which fails HTTPS silently. Otherwise: If `local_capture` is non-empty, simulator traffic should be captured automatically — verify certs with `verify_proxy_setup`. If local capture is not enabled, the device may not be configured to route through the proxy. Check `proxy_setup_guide` for device configuration steps. Also check for certificate pinning in the app.
 
 **"Wait for element timed out"** — The element may never have appeared (a bug or wrong expectation), the timeout may be too short, or the label may differ from what you expect. Check what actually appeared with `get_screen_summary`.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -67,7 +67,7 @@ The key lives at `~/.quern/api-key`; the server's URL and port are in `~/.quern/
 | `set_local_capture` | POST | `/api/v1/proxy/local-capture` | Set local capture process list |
 | `set_bypass` | POST | `/api/v1/proxy/bypass` | Add domain patterns to the bypass allowlist |
 | `clear_bypass` | DELETE | `/api/v1/proxy/bypass` | Remove bypass patterns, or clear all |
-| `configure_system_proxy` | POST | `/api/v1/proxy/configure-system` | Auto-configure macOS system proxy |
+| `configure_system_proxy` | POST | `/api/v1/proxy/configure-system` | Auto-configure macOS system proxy. Returns **428** when a booted simulator does not trust the mitmproxy CA; pass `skip_cert_check` to proceed anyway |
 | `unconfigure_system_proxy` | POST | `/api/v1/proxy/unconfigure-system` | Restore original proxy settings |
 
 ### Intercept and mock

--- a/docs/guides/ios-proxy-simulators.md
+++ b/docs/guides/ios-proxy-simulators.md
@@ -33,9 +33,19 @@ If local capture isn't working (System Extension issues, corporate MDM blocking 
 
 The proxy certificate needs to be installed on each simulator for HTTPS decryption to work. Without it, your agent can see that traffic is happening but can't read the request/response bodies.
 
-Your agent installs this automatically when it sets up network capture. The cert persists across app installs and simulator reboots — it's only lost if you erase the simulator entirely.
+Quern checks for it before enabling capture, and **asks before installing it**. Capturing through a simulator that does not trust the certificate fails every HTTPS request from that device, and the symptom points nowhere near the proxy — a blank screen, or an app that seems to have no network — so Quern refuses to create that state rather than leaving you to discover it.
 
-If you've recently erased a simulator or created a new one, your agent may need to reinstall the cert. It detects this automatically.
+You are asked rather than having it done for you because installing a certificate authority is a bigger commitment than turning capture on: it persists across sessions, outlives the capture window, and you have to know it happened in order to undo it.
+
+If you would rather answer once:
+
+```sh
+quern set-auto-install-cert on
+```
+
+That setting also appears in the menu-bar app's Settings window, under Network capture, so it is visible and reversible from the same place. `quern set-auto-install-cert` with no argument prints the current setting.
+
+The cert persists across app installs and simulator reboots — it's only lost if you erase the simulator entirely. If you've recently erased a simulator or created a new one, Quern detects that the cert is gone and asks again.
 
 ## Per-Simulator Traffic Isolation
 

--- a/docs/guides/menu-bar-app.md
+++ b/docs/guides/menu-bar-app.md
@@ -53,10 +53,21 @@ This item is hidden if the screen-mirror app could not be built, which happens
 when Xcode Command Line Tools are missing. `quern setup` will tell you, and
 offer to open the installer.
 
-**Settings.** The update channel picker — stable or beta, the same setting as
-`quern set-channel` — and a launch-at-login toggle. It also shows the server's
-address, version and uptime, and the full UDID of the active device, which the
-menu deliberately leaves out to keep itself narrow.
+**Settings.** Three things you would otherwise reach for the CLI to change.
+
+*Network capture* carries "Install the capture certificate automatically". Off
+by default: capturing HTTPS needs each device to trust Quern's certificate
+authority, and installing one is a bigger commitment than turning capture on,
+so Quern asks the first time. Turn this on to answer once instead. The same
+setting is `quern set-auto-install-cert`, and it is shown here so a standing
+policy is visible and reversible rather than buried in a config file.
+
+*Updates* carries the channel picker, stable or beta, the same setting as
+`quern set-channel`.
+
+There is also a launch-at-login toggle, and a read-only view of the server's
+address, version and uptime, plus the full UDID of the active device — which
+the menu deliberately leaves out to keep itself narrow.
 
 ## Quitting
 

--- a/docs/release-channels.md
+++ b/docs/release-channels.md
@@ -82,6 +82,41 @@ Two reserved branches on `origin`:
 Both branches are descendants of `main` at all times. Neither contains commits
 that aren't already in `main`.
 
+### Before any of it: the documentation pass
+
+Every release so far has shipped at least one doc that contradicted the code,
+and they were found by accident rather than by looking. The 0.16.0 cut found
+four, one of which told users the opposite of what the release did. Work this
+list before the version bump, because the release tarball is archived from the
+tag and whatever is stale at that moment ships.
+
+For each item, ask "did this release change what this file asserts?" — not
+"did this release touch this file".
+
+- [ ] **`README.md`** — the feature bullets, the CLI command block, and the
+      `~/.quern/` state table. `tests/test_readme_sync.py` catches a *missing*
+      command; it cannot catch a description that is now wrong.
+- [ ] **`CONTRIBUTING.md`** — the design-decision and behaviour sections. A
+      release that establishes a rule should say so here, or the next person
+      re-derives it.
+- [ ] **`docs/agent-guide.md`** — what an agent should reach for and what a new
+      refusal means. Agents retry unexplained errors, so a new non-retryable
+      failure has to be described as one. Check too that no step tells an agent
+      to shell out around a Quern tool.
+- [ ] **`docs/api-reference.md`** — new endpoints, new request fields, new
+      status codes.
+- [ ] **`docs/guides/*.md`** — the ones whose subject the release changed. These
+      sync to quern.dev, so a stale guide is a stale public page.
+- [ ] **`macos/QuernMenuBar/README.md`** — build and release steps for the app.
+- [ ] **`CHANGELOG.md`** — rename `Unreleased`, date it, add the link ref.
+- [ ] **Run the sync** — `python3 scripts/sync-docs.py --repo <quern>` in the
+      quern.dev checkout, and commit what it changes. A guide corrected in this
+      repo and never synced leaves the site serving the old text; that happened
+      once for a week.
+- [ ] **Pick the version deliberately.** New commands, new config fields, or a
+      call that now refuses where it used to succeed are a minor bump, not a
+      patch — regardless of how the work was framed while doing it.
+
 ### Cutting a stable release
 
 ```sh

--- a/macos/QuernMenuBar/README.md
+++ b/macos/QuernMenuBar/README.md
@@ -8,11 +8,20 @@ manager with a **Restart to Update** action.
 
 - **Status** — running/stopped + uptime, read from `~/.quern/state.json`.
 - **Active device & proxy** — from `~/.quern/active-device.json` and `state.json`.
+  The sidecar carries the device's name and type as well as its UDID, so the
+  row reads `iPhone 16 Pro (Simulator)` rather than a 36-character identifier.
+  An absent type is shown unqualified rather than guessed.
 - **Start / Stop / Restart** — shells out to the installed `quern` CLI.
 - **Restart to Update** — appears only when `~/.quern/update-info.json` reports
   `update_available`; runs `quern update`, then relaunches into the new build.
-- **Settings** — full state, stable/beta channel picker, launch-at-login toggle,
-  docs link.
+- **Settings** — full state, the capture-certificate policy, stable/beta channel
+  picker, launch-at-login toggle, docs link. The certificate toggle writes
+  `auto_install_cert` via `quern set-auto-install-cert`; it is surfaced here
+  deliberately, because a standing policy to install a root certificate
+  authority should be visible and reversible rather than living only in a
+  config file. It reads a *literal* JSON boolean — `JSONSerialization` hands
+  back `NSNumber` for numbers too, and `as? Bool` accepts a numeric 1, which
+  would show the policy enabled while the server treated it as unset.
 - **Quit** — exits only the menu bar; ⌥ reveals "Quit and Stop Server".
 
 It is a **monitor + manual controller**, not the daemon's owner — it coexists
@@ -55,6 +64,20 @@ Releases are cut by a maintainer on a Mac with a Developer ID identity. The
 menu-bar app ships **inside the release tarball asset** and updates through
 Quern's existing updater (Option A — no Sparkle, no second update path).
 
+**The asset is not the only delivery path, and cannot be.** v0.15.0 reached
+every existing user without the app: their updater predated the asset
+preference, so it fetched GitHub's generated source tarball — and the code
+that prefers the asset shipped *inside* the asset, so it could not help
+itself. Any future capability delivered only through the asset has the same
+bootstrap problem.
+
+So `quern setup` fetches the app when a release install is missing it, which
+is the first code of ours that runs on an affected machine. It verifies before
+installing — a designated requirement anchored to Apple and pinned to this
+team, Gatekeeper acceptance, and the bundle's stamped version against the
+release requested — because that path downloads an executable and then
+launches it. A git checkout is left alone; developers build their own.
+
 One-time credential setup:
 
 ```sh
@@ -80,7 +103,7 @@ Per release, in two phases. The full procedure is in
 ```sh
 DEVELOPER_ID_APP="Developer ID Application: Your Name (TEAMID)" \
 NOTARY_PROFILE="my-notary-profile" \
-  ../../scripts/release-menubar.sh --app-only 0.15.0     # no leading v
+  ../../scripts/release-menubar.sh --app-only 0.16.0     # no leading v
 ```
 
 This leaves a signed, notarized `Quern.app` in `dist/` and prints the publish
@@ -91,7 +114,7 @@ nothing: no tag has been cut and no Release exists yet.
 
 ```sh
 DEVELOPER_ID_APP="Developer ID Application: Your Name (TEAMID)" \
-  ../../scripts/release-menubar.sh --publish v0.15.0
+  ../../scripts/release-menubar.sh --publish v0.16.0
 ```
 
 That assembles `dist/quern-<version>.tar.gz` (source tree at the tag + the
@@ -106,5 +129,5 @@ acceptance, and that the signing team matches `DEVELOPER_ID_APP` — which is
 why that variable is needed in both phases. A staged app can come from
 anywhere, including a previous release.
 
-The one-shot form, `release-menubar.sh v0.15.0`, still does everything in a
+The one-shot form, `release-menubar.sh v0.16.0`, still does everything in a
 single run, but it needs the tag and Release to already exist.

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quern-debug-mcp",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quern-debug-mcp",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quern-debug-mcp",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "MCP server for Quern \u2014 thin wrapper over HTTP API",
   "type": "module",
   "main": "dist/launcher.cjs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quern-debug-server"
-version = "0.15.0"
+version = "0.16.0"
 description = "Debug log capture and AI context server"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Version bump plus three doc corrections, one of which was actively misleading.

## Why 0.16.0 rather than 0.15.1

The content is not only fixes. It adds `quern set-auto-install-cert` and a config field, and `configure_system_proxy` now refuses with 428 where it previously succeeded. That is a behaviour change anyone scripting the API would notice, and the CHANGELOG states the project follows SemVer.

## The doc that was wrong

`docs/guides/ios-proxy-simulators.md` said:

> Your agent installs this automatically when it sets up network capture.

That is exactly what the cert preflight changed. A reader hitting the refusal would have had nothing to connect it to, and the guide would have told them the opposite of what happens. It now explains that Quern asks, why asking is the right default for installing a certificate authority, and how to answer once.

## The two that were incomplete

`docs/guides/menu-bar-app.md` described Settings as the update channel picker and a launch-at-login toggle. It was written before the Network capture group existed, so the new toggle — the thing that makes the CA policy visible and reversible — was undocumented.

`docs/api-reference.md` listed `configure_system_proxy` with no mention of the 428 or `skip_cert_check`.

Both guides are synced to quern.dev in that repo.

## Also

CHANGELOG section dated, and all three version strings bumped: `pyproject.toml`, `mcp/package.json`, `mcp/package-lock.json`.

## Verification

Suite 2036, unchanged — this is documentation and version strings. The README sync tests pass, which is what would catch a CLI command documented in one place and not another.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified certificate-trust checks for proxy capture, including confirmation prompts and HTTP 428 responses when simulator trust is missing.
  - Documented the `quern set-auto-install-cert` setting and corresponding menu-bar app option for automatic certificate installation.
  - Added guidance for certificate installation, troubleshooting, proxy configuration, and simulator workflows.
  - Updated menu-bar app settings and release-installation documentation.

- **Release**
  - Added the Quern 0.16.0 release entry and updated version references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->