### PR TITLE
Install the menu-bar app where it can be found, and actually relaunch it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **An update never replaced a running menu-bar app** — setup launched it with `open`, which activates a running instance rather than starting the new binary. So after `quern update` the old build kept running while setup reported "Launched", which was true and described something that had not happened. A running instance is now asked to quit first.
+- **The menu-bar app is installed where you can find it** — it lived in the install payload directory under `~/.local`, a dot-directory Spotlight excludes. It did not appear in search or Launchpad, and was in neither place a person looks. Since quitting it is a menu item, that made it effectively unrestartable. It now installs to `~/Applications`.
+
 ## [0.16.0] - 2026-09-11
 
 ### Added

--- a/server/lifecycle/setup.py
+++ b/server/lifecycle/setup.py
@@ -624,6 +624,25 @@ def build_preview_app() -> CheckResult:
 RELEASE_TEAM_ID = "3QUH73KW5Q"
 
 
+MENUBAR_APP_DIR = Path.home() / "Applications"
+"""Where the menu-bar app is installed for the user to find.
+
+Not the install root. The release asset delivers the app to
+``~/.local/share/quern``, but that is a dot-directory: Spotlight excludes it,
+Launchpad does not look there, and neither does a person. An app nobody can
+find is one nobody can restart -- which matters because quitting it is a menu
+item.
+
+~/Applications rather than /Applications so no admin prompt appears inside an
+otherwise unprivileged setup.
+"""
+
+
+def menubar_app_path() -> Path:
+    """The installed location of the menu-bar app."""
+    return MENUBAR_APP_DIR / "Quern.app"
+
+
 class _UntrustedBundle(RuntimeError):
     """The downloaded app is not the one we would have published.
 
@@ -721,8 +740,12 @@ def fetch_menubar_app(project_root: Path) -> CheckResult | None:
         return None
     if (project_root / ".git").exists():
         return None
+    # Both locations. The asset delivers to the install root and
+    # launch_menubar_app moves it to ~/Applications, so after the first setup
+    # the app is only in the second place -- checking the delivery location
+    # alone would re-download it on every run.
     app = project_root / "Quern.app"
-    if app.exists():
+    if app.exists() or menubar_app_path().exists():
         return None
 
     import json as _json
@@ -880,30 +903,81 @@ def fetch_menubar_app(project_root: Path) -> CheckResult | None:
 
 
 def launch_menubar_app(project_root: Path) -> CheckResult | None:
-    """Launch the bundled menu-bar app so it self-registers as a login item.
+    """Install the menu-bar app where it can be found, and (re)launch it.
 
-    Tarball releases built by ``scripts/release-menubar.sh`` include a signed
-    ``Quern.app`` at the install root. Opening it once lets the app register
-    itself for launch-at-login (via SMAppService). LaunchServices activates an
-    existing instance rather than spawning a duplicate, so this is safe to call
-    on every setup/update. Returns None for source-only installs (no app).
+    Two things this has to get right, both learned the hard way.
+
+    **Location.** The release asset delivers ``Quern.app`` to the install root,
+    which lives under ``~/.local`` -- a dot-directory Spotlight excludes. An
+    app installed there cannot be found by search, does not appear in
+    Launchpad, and is in neither place a person looks. Since quitting it is a
+    menu item, that makes it unrestartable in practice. It is moved to
+    ``~/Applications``.
+
+    **Relaunch.** ``open`` on a bundle activates a running instance rather than
+    starting the new binary, so after an update the old build simply stayed
+    running while setup reported "Launched" -- true, and describing something
+    that had not happened. A running instance is asked to quit first.
+
+    Returns None for source-only installs (no app in the payload).
     """
-    app = project_root / "Quern.app"
-    if not app.exists():
+    delivered = project_root / "Quern.app"
+    installed = menubar_app_path()
+
+    if not delivered.exists() and not installed.exists():
         return None
-    rc, _out, err = _run(["open", str(app)])
+
+    # Move the delivered copy into place, replacing any older install.
+    if delivered.exists():
+        try:
+            MENUBAR_APP_DIR.mkdir(parents=True, exist_ok=True)
+            staging = installed.with_name("Quern.app.incoming")
+            shutil.rmtree(staging, ignore_errors=True)
+            shutil.move(str(delivered), str(staging))
+            # Quit before replacing: a running app whose bundle is swapped
+            # underneath it keeps executing the old image from an inode that
+            # no longer has a name, which is a confusing state to debug.
+            _quit_menubar_app()
+            shutil.rmtree(installed, ignore_errors=True)
+            os.replace(str(staging), str(installed))
+        except OSError as e:
+            return CheckResult(
+                name="Menu-bar app",
+                status=CheckStatus.WARNING,
+                message=f"Could not install to {MENUBAR_APP_DIR}",
+                detail=f"{e}\n      Run it from {delivered} instead.",
+            )
+    else:
+        _quit_menubar_app()
+
+    rc, _out, err = _run(["open", str(installed)])
     if rc == 0:
         return CheckResult(
             name="Menu-bar app",
             status=CheckStatus.OK,
-            message="Launched (registers itself for launch-at-login)",
+            message=f"Running from {installed}",
         )
     return CheckResult(
         name="Menu-bar app",
         status=CheckStatus.WARNING,
         message="Could not launch Quern.app",
-        detail=err.strip() or f"Try: open {app}",
+        detail=err.strip() or f"Try: open {installed}",
     )
+
+
+def _quit_menubar_app() -> None:
+    """Ask a running menu-bar app to quit, so a new build can take over.
+
+    Best-effort and deliberately gentle: `osascript` asks the app to quit
+    rather than killing it, so it can tear down its status item cleanly. If
+    nothing is running, this is a no-op that costs a fraction of a second.
+    """
+    _run(["osascript", "-e", 'tell application "Quern" to quit'], timeout=10)
+    for _ in range(20):
+        rc, out, _err = _run(["pgrep", "-f", "Quern.app/Contents/MacOS/QuernMenuBar"])
+        if rc != 0 or not out.strip():
+            return
+        time.sleep(0.25)
 
 
 def _install_skills(project_root: Path) -> CheckResult:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1347,6 +1347,7 @@ class TestFetchMenubarApp:
         from server.lifecycle import setup as setup_mod
 
         monkeypatch.setattr(setup_mod.platform, "system", lambda: "Darwin")
+        monkeypatch.setattr(setup_mod, "MENUBAR_APP_DIR", tmp_path / "Applications")
         payload = json.dumps({"assets": []}).encode()
 
         class _Resp:
@@ -1368,6 +1369,7 @@ class TestFetchMenubarApp:
         from server.lifecycle import setup as setup_mod
 
         monkeypatch.setattr(setup_mod.platform, "system", lambda: "Darwin")
+        monkeypatch.setattr(setup_mod, "MENUBAR_APP_DIR", tmp_path / "Applications")
         monkeypatch.setattr(
             "urllib.request.urlopen",
             lambda *a, **k: (_ for _ in ()).throw(OSError("network is down")),
@@ -1396,6 +1398,7 @@ class TestFetchMenubarApp:
         from server.lifecycle import setup as setup_mod
 
         monkeypatch.setattr(setup_mod.platform, "system", lambda: "Darwin")
+        monkeypatch.setattr(setup_mod, "MENUBAR_APP_DIR", tmp_path / "Applications")
         payload = json.dumps({
             "assets": [{
                 "name": "quern-9.9.9.tar.gz",
@@ -1543,6 +1546,7 @@ class TestFetchMenubarApp:
         from server.lifecycle import setup as setup_mod
 
         monkeypatch.setattr(setup_mod.platform, "system", lambda: "Darwin")
+        monkeypatch.setattr(setup_mod, "MENUBAR_APP_DIR", tmp_path / "Applications")
         monkeypatch.setattr("server.get_version", lambda: "9.9.9")
         payload = json.dumps({
             "assets": [{
@@ -1596,6 +1600,7 @@ class TestFetchMenubarApp:
         from server.lifecycle import setup as setup_mod
 
         monkeypatch.setattr(setup_mod.platform, "system", lambda: "Darwin")
+        monkeypatch.setattr(setup_mod, "MENUBAR_APP_DIR", tmp_path / "Applications")
         monkeypatch.setattr("server.get_version", lambda: "9.9.9")
         payload = json.dumps({
             "assets": [{
@@ -1619,3 +1624,75 @@ class TestFetchMenubarApp:
         result = setup_mod.fetch_menubar_app(tmp_path)
         assert result.status == CheckStatus.ERROR
         assert "not on github.com" in (result.detail or "")
+
+
+class TestMenubarInstallLocation:
+    """The app was installed into the payload directory under ~/.local, which
+    Spotlight excludes, and `open` activated the running old build instead of
+    starting the new one — so an update could never deliver a new app to
+    anyone already running one."""
+
+    def test_the_app_is_installed_where_a_person_can_find_it(self, tmp_path, monkeypatch):
+        from server.lifecycle import setup as setup_mod
+
+        root = tmp_path / "install"
+        apps = tmp_path / "Applications"
+        (root / "Quern.app").mkdir(parents=True)
+
+        monkeypatch.setattr(setup_mod, "MENUBAR_APP_DIR", apps)
+        monkeypatch.setattr(setup_mod, "_run", lambda cmd, timeout=30: (0, "", ""))
+
+        result = setup_mod.launch_menubar_app(root)
+
+        assert (apps / "Quern.app").exists(), "app was not installed to ~/Applications"
+        assert not (root / "Quern.app").exists(), "a second copy was left in the payload dir"
+        assert result.status == CheckStatus.OK
+
+    def test_a_running_instance_is_quit_before_the_new_one_opens(self, tmp_path, monkeypatch):
+        """`open` activates a running instance rather than starting the new
+        binary. Without a quit first, setup reports "Launched" while the old
+        build keeps running — true, and describing something that did not
+        happen."""
+        from server.lifecycle import setup as setup_mod
+
+        root = tmp_path / "install"
+        apps = tmp_path / "Applications"
+        (root / "Quern.app").mkdir(parents=True)
+        calls: list[list[str]] = []
+
+        def record(cmd, timeout=30):
+            calls.append(cmd)
+            if cmd[0] == "pgrep":
+                return (1, "", "")   # nothing running after the quit
+            return (0, "", "")
+
+        monkeypatch.setattr(setup_mod, "MENUBAR_APP_DIR", apps)
+        monkeypatch.setattr(setup_mod, "_run", record)
+        setup_mod.launch_menubar_app(root)
+
+        quit_at = next(i for i, c in enumerate(calls) if c[0] == "osascript")
+        open_at = next(i for i, c in enumerate(calls) if c[0] == "open")
+        assert quit_at < open_at, "opened the app before asking the old one to quit"
+
+    def test_an_already_installed_app_is_not_refetched(self, tmp_path, monkeypatch):
+        """After the first setup the app lives only in ~/Applications.
+        Checking the payload directory alone would download it every run."""
+        from server.lifecycle import setup as setup_mod
+
+        root = tmp_path / "install"
+        root.mkdir()
+        apps = tmp_path / "Applications"
+        (apps / "Quern.app").mkdir(parents=True)
+
+        monkeypatch.setattr(setup_mod, "MENUBAR_APP_DIR", apps)
+        monkeypatch.setattr(setup_mod.platform, "system", lambda: "Darwin")
+        monkeypatch.setattr(setup_mod, "MENUBAR_APP_DIR", tmp_path / "Applications")
+        _forbid_network(monkeypatch)
+
+        assert setup_mod.fetch_menubar_app(root) is None
+
+    def test_a_source_only_install_is_left_alone(self, tmp_path, monkeypatch):
+        from server.lifecycle import setup as setup_mod
+
+        monkeypatch.setattr(setup_mod, "MENUBAR_APP_DIR", tmp_path / "Applications")
+        assert setup_mod.launch_menubar_app(tmp_path / "install") is None


### PR DESCRIPTION
From a real update report: it completed with no failures, and the old menu-bar app kept running. The reporter then quit it and could not find it again to restart.

Two bugs, and the second explains the first.

## An update never replaced a running app

`launch_menubar_app` opened the bundle on every setup, relying on this, which its own comment stated as a reason it was safe:

> LaunchServices activates an existing instance rather than spawning a duplicate

That behaviour is real, and it is exactly the problem. After an update replaces the bundle on disk, `open` activates the *old running binary* and setup reports "Launched" — true, and describing something that did not happen. An update could therefore never deliver a new menu-bar app to anyone already running one.

A running instance is now asked to quit first, with `osascript` rather than a kill so it can tear down its status item cleanly, and the new build is opened after it exits.

## The app was effectively unfindable

It was installed into the release payload directory, which lives under `~/.local`. That is a dot-directory, so Spotlight excludes it. The app did not appear in search or Launchpad, and was in neither place a person looks for an application.

That matters because quitting it is a menu item. Quit it once and there is no supported way back — which is precisely what happened.

It installs to `~/Applications` now. Standard location, indexed by Spotlight, and no admin prompt inside an otherwise unprivileged setup.

`fetch_menubar_app` checks both locations, since after the move the app only exists in the second one and checking the payload directory alone would re-download the asset on every run.

## Test isolation, again

Fixing this surfaced five tests reading the developer's real `~/Applications`. They passed here and would have failed on a machine without the app installed — the same shape as the tunneld plist tests CI caught earlier today. They are isolated now.

## Verification

End to end against the live v0.16.0 asset: fetched, moved to `~/Applications`, still stapled and Gatekeeper-accepted at the new path, and not re-downloaded on a second run. Both guards mutation-tested — opening without quitting first, and leaving the app in the payload directory, each fail their test.

Suite 2040.

## For anyone already stuck

The app is at `~/.local/share/quern/Quern.app`. Until this ships:

```sh
pkill -f QuernMenuBar && open ~/.local/share/quern/Quern.app
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Menu-bar app updates now ask any running instance to quit before replacing and launching the new version.
  - The menu-bar app is now installed in `~/Applications`, providing a more accessible and consistent installation location.
  - Updates avoid unnecessary downloads when the app is already available in its delivery or installation location.
  - Installation and update behavior now handles source-only setups without attempting an invalid launch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->