### PR TITLE
Settings writes stop dropping changes, and start being logged

### DIFF
--- a/macos/QuernMenuBar/Sources/AppDelegate.swift
+++ b/macos/QuernMenuBar/Sources/AppDelegate.swift
@@ -497,7 +497,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         config.activates = true
         NSWorkspace.shared.openApplication(at: url, configuration: config) { _, error in
             guard let error else { return }
-            NSLog("Screen mirror launch failed: \(error.localizedDescription)")
+            Log.ui.error("Screen mirror launch failed: \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/macos/QuernMenuBar/Sources/LifecycleController.swift
+++ b/macos/QuernMenuBar/Sources/LifecycleController.swift
@@ -40,7 +40,7 @@ final class LifecycleController {
         var start: (@escaping (Int32, String) -> Void) -> Void = { QuernCLI.start($0) }
         var stop: (@escaping (Int32, String) -> Void) -> Void = { QuernCLI.stop($0) }
         var restart: (@escaping (Int32, String) -> Void) -> Void = { QuernCLI.restart($0) }
-        var log: (String) -> Void = { NSLog("%@", $0) }
+        var log: (String) -> Void = { Log.lifecycle.notice("\($0, privacy: .public)") }
     }
 
     /// How long to keep waiting after a nonzero exit, and how often to look.

--- a/macos/QuernMenuBar/Sources/Log.swift
+++ b/macos/QuernMenuBar/Sources/Log.swift
@@ -1,0 +1,38 @@
+// Where the menu bar's log lines go, and how to find them again.
+//
+// Everything here used to be bare `NSLog`, which lands in the unified log under
+// the process name and nothing else. That is enough to find the app's output
+// and not enough to find anything within it: a settings write, a daemon
+// restart and an update all read the same. Filtering meant grepping prose.
+//
+// `os.Logger` carries a subsystem and a category, so the same lines become
+// selectable:
+//
+//     log show --last 30m --predicate 'subsystem == "dev.quern.menubar"'
+//     log show --last 30m --predicate 'subsystem == "dev.quern.menubar" \
+//                                      AND category == "settings"'
+//     log stream --predicate 'subsystem == "dev.quern.menubar"'
+//
+// The subsystem is the bundle identifier, which is what Console.app groups by.
+// Categories are named for what a reader would be looking for rather than for
+// the type that emits them -- "settings", not "SettingWriter" -- because the
+// person filtering is chasing a behaviour, not a class.
+
+import Foundation
+import os
+
+enum Log {
+    static let subsystem = "dev.quern.menubar"
+
+    /// Writes to config.json: the three controls that shell out to the CLI.
+    static let settings = Logger(subsystem: subsystem, category: "settings")
+
+    /// Starting, stopping and restarting the daemon.
+    static let lifecycle = Logger(subsystem: subsystem, category: "lifecycle")
+
+    /// Checking for and applying updates, including the relaunch.
+    static let updater = Logger(subsystem: subsystem, category: "updater")
+
+    /// The status item and the windows it opens.
+    static let ui = Logger(subsystem: subsystem, category: "ui")
+}

--- a/macos/QuernMenuBar/Sources/QuernCLI.swift
+++ b/macos/QuernMenuBar/Sources/QuernCLI.swift
@@ -242,11 +242,13 @@ enum QuernCLI {
         run(["update"], timeout: 600, completion: completion)
     }
     static func setChannel(_ channel: String, completion: ((Int32, String) -> Void)? = nil) {
-        run(["set-channel", channel], completion: completion)
+        run(["set-channel", channel],
+            timeout: settingsWriteTimeout, completion: completion)
     }
 
     static func setAutoInstallCert(_ enabled: Bool, completion: ((Int32, String) -> Void)? = nil) {
-        run(["set-auto-install-cert", enabled ? "on" : "off"], completion: completion)
+        run(["set-auto-install-cert", enabled ? "on" : "off"],
+            timeout: settingsWriteTimeout, completion: completion)
     }
 
     /// How long a settings write may take before it is abandoned.

--- a/macos/QuernMenuBar/Sources/SettingWriter.swift
+++ b/macos/QuernMenuBar/Sources/SettingWriter.swift
@@ -1,4 +1,4 @@
-// Writes a boolean setting without losing the user's last answer.
+// Writes a setting without losing the user's last answer.
 //
 // The obvious guard -- "only write when the new value differs from the
 // snapshot" -- exists because `apply()` assigns these properties on every
@@ -20,13 +20,13 @@
 
 import Foundation
 
-final class SettingWriter {
+final class SettingWriter<Value: Equatable> {
     /// Performs the write, calling back with the process exit status.
-    typealias Write = (Bool, @escaping (Int32) -> Void) -> Void
+    typealias Write = (Value, @escaping (Int32) -> Void) -> Void
 
     private let write: Write
-    private var inFlight: Bool?
-    private var queued: Bool?
+    private var inFlight: Value?
+    private var queued: Value?
 
     /// Called when a write fails and nothing newer is waiting.
     ///
@@ -53,7 +53,7 @@ final class SettingWriter {
     /// `persisted` is what is currently on disk, used only when nothing is in
     /// flight -- once something is, where we are heading is known exactly and
     /// the snapshot is the less accurate answer.
-    func set(_ value: Bool, persisted: Bool) {
+    func set(_ value: Value, persisted: Value) {
         dispatchPrecondition(condition: .onQueue(.main))
         let heading = queued ?? inFlight ?? persisted
         guard value != heading else { return }
@@ -64,7 +64,7 @@ final class SettingWriter {
         start(value)
     }
 
-    private func start(_ value: Bool) {
+    private func start(_ value: Value) {
         inFlight = value
         write(value) { [weak self] code in
             guard let self else { return }

--- a/macos/QuernMenuBar/Sources/SettingWriter.swift
+++ b/macos/QuernMenuBar/Sources/SettingWriter.swift
@@ -21,10 +21,18 @@
 import Foundation
 
 final class SettingWriter<Value: Equatable> {
-    /// Performs the write, calling back with the process exit status.
-    typealias Write = (Value, @escaping (Int32) -> Void) -> Void
+    /// Performs the write, calling back with the exit status and whatever the
+    /// CLI printed. The output is carried because it is the only account of
+    /// *why* a write failed; without it a failed setting reverts the control
+    /// and leaves nothing to look at.
+    typealias Write = (Value, @escaping (Int32, String) -> Void) -> Void
 
     private let write: Write
+    /// What this writes, for the log. "the update check", not "updateCheck".
+    private let name: String
+    /// Where the account goes. Injected the way LifecycleController does it, so
+    /// a test can read what was logged instead of writing to the system log.
+    var log: (String) -> Void = { Log.settings.notice("\($0, privacy: .public)") }
     private var inFlight: Value?
     private var queued: Value?
 
@@ -41,7 +49,8 @@ final class SettingWriter<Value: Equatable> {
     /// matches `persisted` and stops. Assigning anything else does not.
     var onFailure: (() -> Void)?
 
-    init(write: @escaping Write) {
+    init(name: String, write: @escaping Write) {
+        self.name = name
         self.write = write
     }
 
@@ -66,9 +75,20 @@ final class SettingWriter<Value: Equatable> {
 
     private func start(_ value: Value) {
         inFlight = value
-        write(value) { [weak self] code in
+        write(value) { [weak self] code, output in
             guard let self else { return }
             self.inFlight = nil
+            // Every write, not only the failures. Forty-odd settings changes
+            // left no trace anywhere, so a write that failed reverted the
+            // control with nothing to look at -- and a write that succeeded
+            // could not be told from one that never ran.
+            if code == 0 {
+                self.log("\(self.name): set to \(value)")
+            } else {
+                let detail = output.trimmingCharacters(in: .whitespacesAndNewlines)
+                self.log("\(self.name): could not set to \(value) "
+                         + "(exit \(code))" + (detail.isEmpty ? "" : ": \(detail)"))
+            }
             if let next = self.queued {
                 // Superseded. Whether this one failed no longer matters -- the
                 // user has since asked for something else, and reverting the UI

--- a/macos/QuernMenuBar/Sources/SettingWriter.swift
+++ b/macos/QuernMenuBar/Sources/SettingWriter.swift
@@ -95,6 +95,20 @@ final class SettingWriter<Value: Equatable> {
                 // to a value they have already moved away from would be a
                 // worse answer than letting the next write settle it.
                 self.queued = nil
+                if code == 0, next == value {
+                    // Except when the queue holds what this write just put on
+                    // disk. Three clicks -- beta, stable, beta -- leave beta
+                    // queued behind a beta write, and running it sends a second
+                    // identical command. For the channel that is not merely
+                    // wasteful: `set-channel` discards the cached update check,
+                    // so the redundant write throws the update hint away again.
+                    //
+                    // Only on success. A failed write did not reach the disk,
+                    // so the queued copy of the same value is a retry rather
+                    // than a repeat, and dropping it would leave the user's
+                    // choice unwritten with nothing left to correct it.
+                    return
+                }
                 self.start(next)
                 return
             }

--- a/macos/QuernMenuBar/Sources/SettingsWindow.swift
+++ b/macos/QuernMenuBar/Sources/SettingsWindow.swift
@@ -77,38 +77,52 @@ final class SettingsModel: ObservableObject {
     /// snaps the checkbox back rather than leaving it showing a setting that
     /// was never written -- the next refresh would undo it anyway, which reads
     /// as the app forgetting.
-    var writeChannel: (String, @escaping (Int32) -> Void) -> Void = { value, done in
-        QuernCLI.setChannel(value) { code, _ in done(code) }
+    var writeChannel: (String, @escaping (Int32, String) -> Void) -> Void = { value, done in
+        QuernCLI.setChannel(value) { code, output in done(code, output) }
     }
 
-    var writeAutoInstallCert: (Bool, @escaping (Int32) -> Void) -> Void = { value, done in
-        QuernCLI.setAutoInstallCert(value) { code, _ in done(code) }
+    var writeAutoInstallCert: (Bool, @escaping (Int32, String) -> Void) -> Void = { value, done in
+        QuernCLI.setAutoInstallCert(value) { code, output in done(code, output) }
     }
 
     lazy var channelWriter: SettingWriter<String> = {
-        let writer = SettingWriter<String> { [weak self] value, done in
+        let writer = SettingWriter<String>(name: "the update channel") { [weak self] value, done in
             self?.writeChannel(value, done)
         }
         writer.onFailure = { [weak self] in
             guard let self, let persisted = self.snapshot.update.channel else { return }
             self.reconcileChannel(persisted)
         }
+        writer.log = { [weak self] in self?.logSettings($0) }
         return writer
     }()
 
     lazy var certWriter: SettingWriter<Bool> = {
-        let writer = SettingWriter<Bool> { [weak self] value, done in
+        let writer = SettingWriter<Bool>(
+            name: "automatic certificate install"
+        ) { [weak self] value, done in
             self?.writeAutoInstallCert(value, done)
         }
         writer.onFailure = { [weak self] in
             guard let self else { return }
             self.reconcileCert(self.snapshot.proxy.autoInstallCert)
         }
+        writer.log = { [weak self] in self?.logSettings($0) }
         return writer
     }()
 
     private func reconcileChannel(_ value: String) { channel = value }
     private func reconcileCert(_ value: Bool) { autoInstallCert = value }
+
+    /// Where the settings writers send their account.
+    ///
+    /// Injected at the model rather than on each writer so a test can silence
+    /// all three at once. Without it the test binary writes into the real
+    /// system log, which is both noise in someone's Console and a trap: a run
+    /// of the suite leaves lines that look exactly like the app's, and reading
+    /// them back as evidence of the app working is a mistake I made while
+    /// verifying this feature.
+    var logSettings: (String) -> Void = { Log.settings.notice("\($0, privacy: .public)") }
 
     /// Runs the CLI. Injected only so a test can stand in for the subprocess.
     ///
@@ -116,12 +130,14 @@ final class SettingsModel: ObservableObject {
     /// the failure handler, would leave the production wiring untested -- and
     /// measured: two regressions survived their own mutations that way,
     /// because the mutation landed in code the test had substituted out.
-    var writeAutoCheck: (Bool, @escaping (Int32) -> Void) -> Void = { value, done in
-        QuernCLI.setUpdateCheck(value) { code, _ in done(code) }
+    var writeAutoCheck: (Bool, @escaping (Int32, String) -> Void) -> Void = { value, done in
+        QuernCLI.setUpdateCheck(value) { code, output in done(code, output) }
     }
 
     lazy var autoCheckWriter: SettingWriter<Bool> = {
-        let writer = SettingWriter { [weak self] value, done in
+        let writer = SettingWriter<Bool>(
+            name: "the automatic update check"
+        ) { [weak self] value, done in
             self?.writeAutoCheck(value, done)
         }
         writer.onFailure = { [weak self] in
@@ -132,6 +148,7 @@ final class SettingsModel: ObservableObject {
             guard let self else { return }
             self.reconcile(self.snapshot.update.autoCheck)
         }
+        writer.log = { [weak self] in self?.logSettings($0) }
         return writer
     }()
     /// What the version row knows, which is not the same as what it can show.
@@ -304,7 +321,7 @@ enum LoginItem {
             }
             return true
         } catch {
-            NSLog("Login item toggle failed: \(error.localizedDescription)")
+            Log.settings.error("Login item toggle failed: \(error.localizedDescription, privacy: .public)")
             return false
         }
     }

--- a/macos/QuernMenuBar/Sources/SettingsWindow.swift
+++ b/macos/QuernMenuBar/Sources/SettingsWindow.swift
@@ -22,7 +22,14 @@ final class SettingsModel: ObservableObject {
     @Published var channel: String = "stable" {
         didSet {
             guard channel != oldValue else { return }
-            channelWriter.set(channel, persisted: snapshot.update.channel ?? channel)
+            // `oldValue`, not `channel`, when no snapshot has landed yet.
+            // `?? channel` passed the new value as its own persisted value, so
+            // the writer saw no difference and never wrote -- the picker moved
+            // and `set-channel` never ran. `readChannel()` falls back to the
+            // default rather than returning nil, so this window is only before
+            // the first refresh, but StateReader polls every three seconds and
+            // Settings can be opened inside it.
+            channelWriter.set(channel, persisted: snapshot.update.channel ?? oldValue)
         }
     }
 
@@ -90,8 +97,15 @@ final class SettingsModel: ObservableObject {
             self?.writeChannel(value, done)
         }
         writer.onFailure = { [weak self] in
-            guard let self, let persisted = self.snapshot.update.channel else { return }
-            self.reconcileChannel(persisted)
+            guard let self else { return }
+            // The default rather than giving up when no snapshot has landed.
+            // A failed write leaves config.json without a channel, and the
+            // server reads that absence as the default -- so showing it is
+            // showing what is in effect, and returning early would leave the
+            // picker on a value nothing wrote.
+            self.reconcileChannel(
+                self.snapshot.update.channel ?? StateReader.defaultChannel
+            )
         }
         writer.log = { [weak self] in self?.logSettings($0) }
         return writer

--- a/macos/QuernMenuBar/Sources/SettingsWindow.swift
+++ b/macos/QuernMenuBar/Sources/SettingsWindow.swift
@@ -12,8 +12,26 @@ final class SettingsModel: ObservableObject {
     @Published var snapshot = QuernSnapshot()
     @Published var loginEnabled = LoginItem.isEnabled()
     @Published var startOnLaunch = StartOnLaunch.isEnabled
-    @Published var channel: String = "stable"
-    @Published var autoInstallCert: Bool = false
+    /// The update channel. Writes through the same path as the toggles below.
+    ///
+    /// Getting this one wrong costs more than a stale value: `set-channel`
+    /// discards the cached update check as part of the same operation, because
+    /// a verdict computed against the old channel is invalid. So a write the
+    /// user did not ask for does not merely persist the wrong string, it also
+    /// wipes the update hint.
+    @Published var channel: String = "stable" {
+        didSet {
+            guard channel != oldValue else { return }
+            channelWriter.set(channel, persisted: snapshot.update.channel ?? channel)
+        }
+    }
+
+    @Published var autoInstallCert: Bool = false {
+        didSet {
+            guard autoInstallCert != oldValue else { return }
+            certWriter.set(autoInstallCert, persisted: snapshot.proxy.autoInstallCert)
+        }
+    }
     /// The checkbox's state, and the only thing the view binds to.
     ///
     /// The decision about whether a change should be written lives here rather
@@ -59,6 +77,39 @@ final class SettingsModel: ObservableObject {
     /// snaps the checkbox back rather than leaving it showing a setting that
     /// was never written -- the next refresh would undo it anyway, which reads
     /// as the app forgetting.
+    var writeChannel: (String, @escaping (Int32) -> Void) -> Void = { value, done in
+        QuernCLI.setChannel(value) { code, _ in done(code) }
+    }
+
+    var writeAutoInstallCert: (Bool, @escaping (Int32) -> Void) -> Void = { value, done in
+        QuernCLI.setAutoInstallCert(value) { code, _ in done(code) }
+    }
+
+    lazy var channelWriter: SettingWriter<String> = {
+        let writer = SettingWriter<String> { [weak self] value, done in
+            self?.writeChannel(value, done)
+        }
+        writer.onFailure = { [weak self] in
+            guard let self, let persisted = self.snapshot.update.channel else { return }
+            self.reconcileChannel(persisted)
+        }
+        return writer
+    }()
+
+    lazy var certWriter: SettingWriter<Bool> = {
+        let writer = SettingWriter<Bool> { [weak self] value, done in
+            self?.writeAutoInstallCert(value, done)
+        }
+        writer.onFailure = { [weak self] in
+            guard let self else { return }
+            self.reconcileCert(self.snapshot.proxy.autoInstallCert)
+        }
+        return writer
+    }()
+
+    private func reconcileChannel(_ value: String) { channel = value }
+    private func reconcileCert(_ value: Bool) { autoInstallCert = value }
+
     /// Runs the CLI. Injected only so a test can stand in for the subprocess.
     ///
     /// Deliberately the lowest seam there is. Replacing the whole writer, or
@@ -69,7 +120,7 @@ final class SettingsModel: ObservableObject {
         QuernCLI.setUpdateCheck(value) { code, _ in done(code) }
     }
 
-    lazy var autoCheckWriter: SettingWriter = {
+    lazy var autoCheckWriter: SettingWriter<Bool> = {
         let writer = SettingWriter { [weak self] value, done in
             self?.writeAutoCheck(value, done)
         }
@@ -177,9 +228,18 @@ final class SettingsModel: ObservableObject {
     }
 
     func apply(_ snap: QuernSnapshot) {
+        // Assigned first, always. Every `reconcile` below passes the value now
+        // in this snapshot, so `didSet` hands `set()` a value equal to the
+        // `persisted` it also hands over and the writer's own guard stops
+        // there. Assign the snapshot afterwards and every refresh writes the
+        // file back to what it already holds, three times a second.
         snapshot = snap
-        if let c = snap.update.channel { channel = c }
-        autoInstallCert = snap.proxy.autoInstallCert
+        // None of these while a write is outstanding. The file still holds the
+        // old value until the write lands, so assigning from it would push the
+        // control back to where the user just moved it from -- and, worse,
+        // queue that echo as a fresh request. The next refresh reconciles.
+        if let c = snap.update.channel, !channelWriter.isBusy { reconcileChannel(c) }
+        if !certWriter.isBusy { reconcileCert(snap.proxy.autoInstallCert) }
         // Not while a write is outstanding. This runs on every refresh, and the
         // file still holds the old value until the write lands -- so assigning
         // from it mid-write pushes the checkbox back to where the user just
@@ -284,13 +344,6 @@ struct SettingsView: View {
                     Toggle(isOn: $model.autoInstallCert) {
                         Text("Install the capture certificate automatically")
                     }
-                    .onChange(of: model.autoInstallCert) { newValue in
-                        // Same guard as the channel picker below: apply()
-                        // assigns this on every fresh snapshot, and writing
-                        // back on that path would shell out on each refresh.
-                        guard newValue != model.snapshot.proxy.autoInstallCert else { return }
-                        QuernCLI.setAutoInstallCert(newValue)
-                    }
                     .accessibilityLabel("Install the capture certificate automatically")
 
                     // Says what it costs, not just what it does. This installs
@@ -341,18 +394,6 @@ struct SettingsView: View {
                         .labelsHidden()
                         .pickerStyle(.segmented)
                         .frame(maxWidth: 220)
-                        .onChange(of: model.channel) { newValue in
-                            // Only write when the user actually moved the
-                            // picker. `apply()` assigns this too, whenever a
-                            // fresh snapshot lands, and writing back on that
-                            // path shells out to `quern set-channel` with the
-                            // value already on disk. That is not a no-op:
-                            // setting the channel clears the cached update
-                            // check, so merely opening Settings on a beta
-                            // machine wiped the update hint.
-                            guard newValue != model.snapshot.update.channel else { return }
-                            QuernCLI.setChannel(newValue)
-                        }
                         .accessibilityLabel("Update channel")
                         .accessibilityValue(model.channel)
                         Spacer()

--- a/macos/QuernMenuBar/Sources/Updater.swift
+++ b/macos/QuernMenuBar/Sources/Updater.swift
@@ -54,6 +54,12 @@ final class Updater {
         var relaunch: ((String) -> Void)?
         /// What the update recorded about itself. See UpdateResult.
         var readResult: () -> UpdateResult? = { UpdateResult.read() }
+        /// Where the account goes. Injected for the same reason
+        /// LifecycleController injects its own: without it the test binary
+        /// writes into the real system log, and those lines are
+        /// indistinguishable from the app's when read back.
+        var log: (String) -> Void = { Log.updater.notice("\($0, privacy: .public)") }
+        var logError: (String) -> Void = { Log.updater.error("\($0, privacy: .public)") }
     }
 
     private let deps: Dependencies
@@ -116,7 +122,7 @@ final class Updater {
                 // was on, what it skipped, which external tools are behind --
                 // and throwing it away on success left no record anywhere of a
                 // successful or no-op update.
-                NSLog("quern update exited \(code):\n\(output)")
+                self.deps.log("quern update exited \(code): \(output)")
                 if code != 0 {
                     // `quern update` runs the whole update synchronously, so
                     // this completion does not arrive for a minute or more and
@@ -126,7 +132,7 @@ final class Updater {
                     // rather than paraphrasing it.
                     self.inProgress = false
                     status(.finished("Update failed"))
-                    NSLog("quern update failed (\(code)): \(output)")
+                    self.deps.logError("quern update failed (\(code)): \(output)")
                     failure("The update did not complete", output)
                     return
                 }
@@ -249,7 +255,7 @@ final class Updater {
         config.createsNewApplicationInstance = true
         NSWorkspace.shared.openApplication(at: bundleURL, configuration: config) { [weak self] _, error in
             if let error {
-                NSLog("Relaunch failed: \(error.localizedDescription)")
+                self?.deps.logError("Relaunch failed: \(error.localizedDescription)")
                 // Same reasoning as the missing-bundle path: without this the
                 // status stays on "Restarting…" forever after a launch that
                 // never happened.

--- a/macos/QuernMenuBar/Tests/SettingWriterTests.swift
+++ b/macos/QuernMenuBar/Tests/SettingWriterTests.swift
@@ -75,27 +75,48 @@ enum SettingWriterTests {
             rig.writer.set(false, persisted: true)
             rig.pending[0](0, "")
             // Not three writes: the middle answer was superseded before it ran.
-            Harness.expect(rig.requested, [false, false], "writes")
+            // And not two either -- the queued value is what the write that
+            // just succeeded already put on disk, so repeating it sends a
+            // command nobody asked for. This assertion used to read
+            // [false, false], encoding that redundant write as correct.
+            Harness.expect(rig.requested, [false], "writes")
         }
 
-        Harness.test("a value already queued is not queued twice") {
-            // Asserts on the queue rather than on the writes. The version that
-            // checked only `requested` passed against its own mutation:
-            // dropping `queued` from `heading` still produced [false, true],
-            // because the second queue attempt overwrites the first with the
-            // same value. Only a third distinct request makes the difference
-            // visible.
+        Harness.test("a queued value equal to the one just written is dropped") {
+            // beta, stable, beta before the first write returns. The queue ends
+            // holding beta, which is exactly what the in-flight write is about
+            // to put on disk -- so running it sends a second identical command.
+            // For the channel that is not merely wasteful: `set-channel`
+            // discards the cached update check, so the redundant write throws
+            // away the update hint a second time.
             let rig = Rig(answersImmediately: nil)
             rig.writer.set(false, persisted: true)
             rig.writer.set(true, persisted: true)
-            rig.writer.set(true, persisted: true)
             rig.writer.set(false, persisted: true)
             rig.pending[0](0, "")
-            // Not [false, true, false]: the repeat was recognised as already
-            // queued, so the last distinct answer replaced it rather than
-            // stacking behind it.
-            Harness.expect(rig.requested, [false, false], "writes")
+            Harness.expect(rig.requested, [false], "a redundant write went out")
         }
+
+        Harness.test("but a queued value is retried when the write failed") {
+            // Same shape, failed write. The value is not on disk, so the queued
+            // copy of it is not redundant -- dropping it would leave the user's
+            // choice unwritten with nothing to correct it.
+            let rig = Rig(answersImmediately: nil)
+            rig.writer.set(false, persisted: true)
+            rig.writer.set(true, persisted: true)
+            rig.writer.set(false, persisted: true)
+            rig.pending[0](1, "")
+            Harness.expect(rig.requested, [false, false], "the retry was dropped")
+        }
+
+        // Removed: "a value already queued is not queued twice".
+        //
+        // It promised a behaviour the design makes structurally impossible --
+        // `queued` is one slot, so a repeat overwrites itself -- and no
+        // mutation distinguished it. A review flagged it as passing against
+        // its own mutation once; the redundant-write fix then collapsed its
+        // scenario entirely. "only the last answer is written when several
+        // arrive" covers what it was reaching for.
 
         Harness.test("a failed write hands back the value to show instead") {
             let rig = Rig(answersImmediately: 1)
@@ -512,6 +533,43 @@ enum SettingWriteLoggingTests {
             let rig = Rig()
             rig.writer.set(false, persisted: false)
             Harness.expect(rig.lines.isEmpty, "logged a write it did not make")
+        }
+    }
+}
+
+// The channel before any snapshot has landed.
+//
+// `readChannel()` never returns nil -- it falls back to the default -- so
+// `snapshot.update.channel` is only nil before the first refresh. That window
+// is real: StateReader polls every three seconds, and Settings can be opened
+// inside it.
+enum ChannelWithoutASnapshotTests {
+    static func all() {
+        Harness.test("the first change writes even with no snapshot yet") {
+            // `?? channel` passed the new value as its own persisted value, so
+            // the writer saw no difference and never wrote. The picker moved
+            // to beta and `set-channel beta` never ran.
+            let model = SettingsModel()
+            var wrote: [String] = []
+            model.logSettings = { _ in }
+            model.writeChannel = { value, _ in wrote.append(value) }
+
+            Harness.expect(model.snapshot.update.channel == nil,
+                           "precondition: no snapshot has landed")
+            model.channel = "beta"
+
+            Harness.expect(wrote, ["beta"], "the first channel change was dropped")
+        }
+
+        Harness.test("and still does not write when nothing changed") {
+            let model = SettingsModel()
+            var wrote: [String] = []
+            model.logSettings = { _ in }
+            model.writeChannel = { value, _ in wrote.append(value) }
+
+            model.channel = "stable"   // already the initial value
+
+            Harness.expect(wrote.isEmpty, "wrote a change that was not one")
         }
     }
 }

--- a/macos/QuernMenuBar/Tests/SettingWriterTests.swift
+++ b/macos/QuernMenuBar/Tests/SettingWriterTests.swift
@@ -13,7 +13,7 @@ enum SettingWriterTests {
         /// comparison could not see and every defect here lived in.
         private(set) var pending: [(Int32) -> Void] = []
         private(set) var fellBackTo: [Bool] = []
-        var writer: SettingWriter!
+        var writer: SettingWriter<Bool>!
 
         /// `answersImmediately: nil` parks each completion instead.
         init(answersImmediately: Int32? = 0) {
@@ -282,6 +282,152 @@ enum ReconcileInvariantTests {
                 Harness.expect(model.autoCheckUpdates, value, "UI followed \(value)")
             }
             Harness.expect(wrote.isEmpty, "reconciling with the file wrote to it")
+        }
+    }
+}
+
+// The other two controls in the same window, driven through the real model.
+//
+// Same defects, same shape, and the same rule about where to inject: only the
+// subprocess is replaced, so the writers, their failure handlers and the
+// model's guards are the shipped ones. A rig that stood in for any of those
+// would pass while production stayed broken -- measured, twice.
+enum OtherSettingsWritingTests {
+    private final class Rig {
+        let model = SettingsModel()
+        private(set) var channels: [String] = []
+        private(set) var certs: [Bool] = []
+        private var pendingChannel: [(Int32) -> Void] = []
+        private var pendingCert: [(Int32) -> Void] = []
+        var channel: String
+        var cert: Bool
+
+        init(channel: String = "stable", cert: Bool = false) {
+            self.channel = channel
+            self.cert = cert
+            model.writeChannel = { [unowned self] value, done in
+                self.channels.append(value)
+                self.pendingChannel.append(done)
+            }
+            model.writeAutoInstallCert = { [unowned self] value, done in
+                self.certs.append(value)
+                self.pendingCert.append(done)
+            }
+            refresh()
+        }
+
+        func refresh() {
+            var snap = QuernSnapshot()
+            var info = UpdateInfo()
+            info.channel = channel
+            snap.update = info
+            snap.proxy = ProxyPolicy(autoInstallCert: cert)
+            model.apply(snap)
+        }
+
+        func completeChannel(_ code: Int32, persisting: String? = nil) {
+            let done = pendingChannel.removeFirst()
+            if code == 0, let persisting { channel = persisting }
+            done(code)
+        }
+
+        func completeCert(_ code: Int32, persisting: Bool? = nil) {
+            let done = pendingCert.removeFirst()
+            if code == 0, let persisting { cert = persisting }
+            done(code)
+        }
+    }
+
+    static func all() {
+        Harness.test("a refresh never rewrites the channel it just read") {
+            // The reason this control had a guard at all, and why it matters
+            // more here than anywhere else: `set-channel` discards the cached
+            // update check, so merely opening Settings on a beta machine used
+            // to wipe the update hint.
+            let rig = Rig(channel: "beta")
+            for _ in 0..<5 { rig.refresh() }
+            Harness.expect(rig.channels.isEmpty, "a refresh wrote the channel back")
+            Harness.expect(rig.model.channel, "beta", "the picker followed")
+        }
+
+        Harness.test("a second channel change while the first is in flight is kept") {
+            let rig = Rig(channel: "stable")
+            rig.model.channel = "beta"
+            rig.model.channel = "stable"
+            Harness.expect(rig.channels, ["beta"], "only the first has run")
+            rig.completeChannel(0, persisting: "beta")
+            Harness.expect(rig.channels, ["beta", "stable"], "the second followed")
+        }
+
+        Harness.test("a refresh during a channel write does not undo it") {
+            let rig = Rig(channel: "stable")
+            rig.model.channel = "beta"
+            rig.refresh()
+            Harness.expect(rig.model.channel, "beta", "a refresh reverted the picker")
+            rig.completeChannel(0, persisting: "beta")
+            Harness.expect(rig.channels, ["beta"], "a refresh queued a reversal")
+        }
+
+        Harness.test("a failed channel write shows what is on disk") {
+            let rig = Rig(channel: "stable")
+            rig.model.channel = "beta"
+            rig.completeChannel(1)
+            Harness.expect(rig.model.channel, "stable", "should show the disk")
+            Harness.expect(rig.channels.count, 1, "the revert issued another write")
+        }
+
+        Harness.test("a refresh never rewrites the certificate policy") {
+            let rig = Rig(cert: true)
+            for _ in 0..<5 { rig.refresh() }
+            Harness.expect(rig.certs.isEmpty, "a refresh wrote the policy back")
+            Harness.expect(rig.model.autoInstallCert, true, "the toggle followed")
+        }
+
+        Harness.test("a second certificate change in flight is kept") {
+            let rig = Rig(cert: false)
+            rig.model.autoInstallCert = true
+            rig.model.autoInstallCert = false
+            Harness.expect(rig.certs, [true], "only the first has run")
+            rig.completeCert(0, persisting: true)
+            Harness.expect(rig.certs, [true, false], "the second followed")
+        }
+
+        Harness.test("a refresh during a certificate write does not undo it") {
+            // Asserts the visible state, not just that no write went out. The
+            // write is already suppressed by the writer's own guard, so the
+            // isBusy check exists solely to stop the control flicking back to
+            // the old value while the write is in flight -- and only an
+            // assertion on the control can see that.
+            let rig = Rig(cert: false)
+            rig.model.autoInstallCert = true
+            rig.refresh()
+            Harness.expect(rig.model.autoInstallCert, true,
+                           "a refresh reverted the toggle mid-write")
+            rig.completeCert(0, persisting: true)
+            Harness.expect(rig.certs, [true], "a refresh queued a reversal")
+        }
+
+        Harness.test("a failed certificate write shows what is on disk") {
+            let rig = Rig(cert: false)
+            rig.model.autoInstallCert = true
+            rig.completeCert(1)
+            Harness.expect(rig.model.autoInstallCert, false, "should show the disk")
+            Harness.expect(rig.certs.count, 1, "the revert issued another write")
+        }
+
+        Harness.test("the two controls do not interfere") {
+            // They share a snapshot and a window, and a user can move both
+            // before either write lands.
+            let rig = Rig(channel: "stable", cert: false)
+            rig.model.channel = "beta"
+            rig.model.autoInstallCert = true
+            Harness.expect(rig.channels, ["beta"], "channel write")
+            Harness.expect(rig.certs, [true], "cert write")
+            rig.completeChannel(0, persisting: "beta")
+            rig.completeCert(0, persisting: true)
+            rig.refresh()
+            Harness.expect(rig.model.channel, "beta", "channel settled")
+            Harness.expect(rig.model.autoInstallCert, true, "cert settled")
         }
     }
 }

--- a/macos/QuernMenuBar/Tests/SettingWriterTests.swift
+++ b/macos/QuernMenuBar/Tests/SettingWriterTests.swift
@@ -11,20 +11,21 @@ enum SettingWriterTests {
         /// Completions the CLI has not answered yet. A test decides when -- and
         /// whether -- each one comes back, which is the state the snapshot
         /// comparison could not see and every defect here lived in.
-        private(set) var pending: [(Int32) -> Void] = []
+        private(set) var pending: [(Int32, String) -> Void] = []
         private(set) var fellBackTo: [Bool] = []
         var writer: SettingWriter<Bool>!
 
         /// `answersImmediately: nil` parks each completion instead.
         init(answersImmediately: Int32? = 0) {
-            writer = SettingWriter { [unowned self] value, done in
+            writer = SettingWriter(name: "a test setting") { [unowned self] value, done in
                 self.requested.append(value)
                 if let code = answersImmediately {
-                    done(code)
+                    done(code, "")
                 } else {
                     self.pending.append(done)
                 }
             }
+            writer.log = { _ in }
             writer.onFailure = { [unowned self] in self.fellBackTo.append(true) }
         }
     }
@@ -54,7 +55,7 @@ enum SettingWriterTests {
             rig.writer.set(true, persisted: true)
             Harness.expect(rig.requested, [false], "only the first has run")
 
-            rig.pending[0](0)   // the `off` write returns
+            rig.pending[0](0, "")   // the `off` write returns
             Harness.expect(rig.requested, [false, true], "the `on` write followed")
         }
 
@@ -72,7 +73,7 @@ enum SettingWriterTests {
             rig.writer.set(false, persisted: true)
             rig.writer.set(true, persisted: true)
             rig.writer.set(false, persisted: true)
-            rig.pending[0](0)
+            rig.pending[0](0, "")
             // Not three writes: the middle answer was superseded before it ran.
             Harness.expect(rig.requested, [false, false], "writes")
         }
@@ -89,7 +90,7 @@ enum SettingWriterTests {
             rig.writer.set(true, persisted: true)
             rig.writer.set(true, persisted: true)
             rig.writer.set(false, persisted: true)
-            rig.pending[0](0)
+            rig.pending[0](0, "")
             // Not [false, true, false]: the repeat was recognised as already
             // queued, so the last distinct answer replaced it rather than
             // stacking behind it.
@@ -115,7 +116,7 @@ enum SettingWriterTests {
             let rig = Rig(answersImmediately: nil)
             rig.writer.set(false, persisted: true)
             rig.writer.set(true, persisted: true)
-            rig.pending[0](1)   // the `off` write failed
+            rig.pending[0](1, "")   // the `off` write failed
             Harness.expect(rig.fellBackTo.isEmpty, "reverted despite a newer request")
             Harness.expect(rig.requested, [false, true], "the newer write ran")
         }
@@ -124,7 +125,7 @@ enum SettingWriterTests {
             let rig = Rig(answersImmediately: nil)
             rig.writer.set(false, persisted: true)
             Harness.expect(rig.writer.isBusy, true, "busy during the write")
-            rig.pending[0](0)
+            rig.pending[0](0, "")
             Harness.expect(rig.writer.isBusy, false, "still busy afterwards")
         }
     }
@@ -168,13 +169,14 @@ enum SettingsModelWritingTests {
     private final class Rig {
         let model = SettingsModel()
         private(set) var requested: [Bool] = []
-        private var pending: [(Int32) -> Void] = []
+        private var pending: [(Int32, String) -> Void] = []
         var persisted: Bool
 
         init(persisted: Bool) {
             self.persisted = persisted
             // Only the subprocess is replaced. The writer, its failure handler
             // and the model's guards are all the shipped ones.
+            model.logSettings = { _ in }
             model.writeAutoCheck = { [unowned self] value, done in
                 self.requested.append(value)
                 self.pending.append(done)
@@ -194,7 +196,7 @@ enum SettingsModelWritingTests {
         func completeFirst(_ code: Int32, persisting: Bool? = nil) {
             let done = pending.removeFirst()
             if code == 0, let persisting { persisted = persisting }
-            done(code)
+            done(code, "")
         }
     }
 
@@ -271,6 +273,7 @@ enum ReconcileInvariantTests {
             // the value it already holds -- three times a second.
             let model = SettingsModel()
             var wrote: [Bool] = []
+            model.logSettings = { _ in }
             model.writeAutoCheck = { value, _ in wrote.append(value) }
 
             for value in [false, true, false, false, true] {
@@ -297,14 +300,15 @@ enum OtherSettingsWritingTests {
         let model = SettingsModel()
         private(set) var channels: [String] = []
         private(set) var certs: [Bool] = []
-        private var pendingChannel: [(Int32) -> Void] = []
-        private var pendingCert: [(Int32) -> Void] = []
+        private var pendingChannel: [(Int32, String) -> Void] = []
+        private var pendingCert: [(Int32, String) -> Void] = []
         var channel: String
         var cert: Bool
 
         init(channel: String = "stable", cert: Bool = false) {
             self.channel = channel
             self.cert = cert
+            model.logSettings = { _ in }
             model.writeChannel = { [unowned self] value, done in
                 self.channels.append(value)
                 self.pendingChannel.append(done)
@@ -328,13 +332,13 @@ enum OtherSettingsWritingTests {
         func completeChannel(_ code: Int32, persisting: String? = nil) {
             let done = pendingChannel.removeFirst()
             if code == 0, let persisting { channel = persisting }
-            done(code)
+            done(code, "")
         }
 
         func completeCert(_ code: Int32, persisting: Bool? = nil) {
             let done = pendingCert.removeFirst()
             if code == 0, let persisting { cert = persisting }
-            done(code)
+            done(code, "")
         }
     }
 
@@ -428,6 +432,86 @@ enum OtherSettingsWritingTests {
             rig.refresh()
             Harness.expect(rig.model.channel, "beta", "channel settled")
             Harness.expect(rig.model.autoInstallCert, true, "cert settled")
+        }
+    }
+}
+
+// What the log says about a settings write.
+//
+// Asserted because it is the only account there is. Forty-odd settings changes
+// during one session of hand-testing left no trace anywhere: a write that
+// failed reverted the control with nothing to look at, and a write that
+// succeeded could not be told from one that never ran.
+enum SettingWriteLoggingTests {
+    private final class Rig {
+        private(set) var lines: [String] = []
+        private var pending: [(Int32, String) -> Void] = []
+        var writer: SettingWriter<Bool>!
+
+        init() {
+            writer = SettingWriter(name: "the thing") { [unowned self] _, done in
+                self.pending.append(done)
+            }
+            writer.log = { [unowned self] in self.lines.append($0) }
+        }
+
+        func complete(_ code: Int32, _ output: String = "") {
+            pending.removeFirst()(code, output)
+        }
+    }
+
+    static func all() {
+        Harness.test("a successful write is logged") {
+            let rig = Rig()
+            rig.writer.set(true, persisted: false)
+            rig.complete(0)
+            Harness.expect(rig.lines.count, 1, "lines")
+            Harness.expect(rig.lines.first?.contains("the thing") == true,
+                           "the line does not say what was written")
+            Harness.expect(rig.lines.first?.contains("true") == true,
+                           "the line does not say what it was set to")
+        }
+
+        Harness.test("a failed write logs the exit code and the CLI's reason") {
+            // The reason is the whole point. "Could not set it" with no cause
+            // is the dead end this project keeps removing.
+            let rig = Rig()
+            rig.writer.set(true, persisted: false)
+            rig.complete(1, "Error: could not find project root")
+            Harness.expect(rig.lines.count, 1, "lines")
+            let line = rig.lines.first ?? ""
+            Harness.expect(line.contains("exit 1"), "no exit code: \(line)")
+            Harness.expect(line.contains("could not find project root"),
+                           "the CLI's reason was dropped: \(line)")
+        }
+
+        Harness.test("a failure with no output still names the exit code") {
+            // A process killed by the watchdog prints nothing. The line must
+            // not trail off into an empty colon.
+            let rig = Rig()
+            rig.writer.set(true, persisted: false)
+            rig.complete(-3, "   \n  ")
+            let line = rig.lines.first ?? ""
+            Harness.expect(line.contains("exit -3"), "no exit code: \(line)")
+            Harness.expect(line.hasSuffix(":") == false, "trailing colon: \(line)")
+        }
+
+        Harness.test("every write in a queue is logged, not just the last") {
+            // Two clicks, two writes, two lines. Logging only the settled value
+            // would hide a first write that failed on its way to a second that
+            // worked.
+            let rig = Rig()
+            rig.writer.set(true, persisted: false)
+            rig.writer.set(false, persisted: false)
+            rig.complete(0)
+            rig.complete(0)
+            Harness.expect(rig.lines.count, 2, "lines")
+        }
+
+        Harness.test("a write that was never made is not logged") {
+            let rig = Rig()
+            rig.writer.set(false, persisted: false)
+            Harness.expect(rig.lines.isEmpty, "logged a write it did not make")
         }
     }
 }

--- a/macos/QuernMenuBar/Tests/UpdaterTests.swift
+++ b/macos/QuernMenuBar/Tests/UpdaterTests.swift
@@ -48,6 +48,8 @@ enum UpdaterTests {
 
         var deps = Updater.Dependencies()
         deps.scheduler = clock
+        deps.log = { _ in }
+        deps.logError = { _ in }
         // Injected, or the default reads the real ~/.quern/last-update.json and
         // the developer's own last update decides what these tests see. Left as
         // "no record", which is the pre-existing behaviour: fall back to the
@@ -282,6 +284,8 @@ enum UpdaterTests {
             let record = Rig.Record()
             var deps = Updater.Dependencies()
             deps.scheduler = clock
+        deps.log = { _ in }
+        deps.logError = { _ in }
             deps.readResult = { record.result }
             deps.readVersion = { done in
                 record.versionCalls += 1

--- a/macos/QuernMenuBar/Tests/main.swift
+++ b/macos/QuernMenuBar/Tests/main.swift
@@ -15,8 +15,9 @@ SettingsWriteTimeoutTests.all()
 SettingsModelWritingTests.all()
 ReconcileInvariantTests.all()
 OtherSettingsWritingTests.all()
+SettingWriteLoggingTests.all()
 MinimumDisplayTests.all()
 FlagTests.all()
 // The count is deliberate. See Harness.report(expected:) -- without it, a suite
 // that runs nothing exits 0.
-exit(Harness.report(expected: 85))
+exit(Harness.report(expected: 90))

--- a/macos/QuernMenuBar/Tests/main.swift
+++ b/macos/QuernMenuBar/Tests/main.swift
@@ -14,8 +14,9 @@ SettingWriterTests.all()
 SettingsWriteTimeoutTests.all()
 SettingsModelWritingTests.all()
 ReconcileInvariantTests.all()
+OtherSettingsWritingTests.all()
 MinimumDisplayTests.all()
 FlagTests.all()
 // The count is deliberate. See Harness.report(expected:) -- without it, a suite
 // that runs nothing exits 0.
-exit(Harness.report(expected: 76))
+exit(Harness.report(expected: 85))

--- a/macos/QuernMenuBar/Tests/main.swift
+++ b/macos/QuernMenuBar/Tests/main.swift
@@ -16,8 +16,9 @@ SettingsModelWritingTests.all()
 ReconcileInvariantTests.all()
 OtherSettingsWritingTests.all()
 SettingWriteLoggingTests.all()
+ChannelWithoutASnapshotTests.all()
 MinimumDisplayTests.all()
 FlagTests.all()
 // The count is deliberate. See Harness.report(expected:) -- without it, a suite
 // that runs nothing exits 0.
-exit(Harness.report(expected: 90))
+exit(Harness.report(expected: 93))


### PR DESCRIPTION
Closes #144. The certificate toggle and channel picker had the defect #143 fixed for the update-check toggle; they were left alone there deliberately.

## The bug

Both guarded their write against the snapshot, which lags a click by up to one refresh. Change either twice inside that window and the second change compares against a stale value, matches, and returns. The write never happens, so the control shows one thing and the file holds the other until something else refreshes and silently undoes it.

The channel is the worse of the two. `set-channel` discards the cached update check as part of the same operation, because a verdict computed against the old channel is invalid. So a write the user did not ask for does not merely persist the wrong string, it wipes the update hint too.

## What changed

`SettingWriter` is generic over an equatable value, so the channel's `String` serializes the same way the booleans do. Both controls now compare against where the setting is heading — queued, then in flight, then persisted — rather than against what was last read from disk.

Both decisions moved out of the view. `SettingsView` cannot be instantiated without SwiftUI rendering it, so logic in `.onChange` is logic no test can reach — which is how #143's first attempt shipped two regressions its own tests passed over. The view now only binds.

Both writers get the 20s deadline rather than `run()`'s 120s default. Because writes are serialized, that deadline is the upper bound on how long a queued change waits for its predecessor.

Untouched: **Launch at login** and **Start the server when Quern launches**. Both write synchronously — the login-item API and `UserDefaults` — with no completion to race. Measured: 23 clean flips at ~180ms intervals, none dropped.

## Logging

Spamming these controls by hand produced roughly forty changes, about twenty of which spawned a subprocess, and left no record anywhere. A failed write reverted the control with nothing to look at; a successful one could not be told from one that never ran.

Every write is now logged with its value, and on failure the exit code and whatever the CLI printed. Tagged, too — all seven `NSLog` sites moved to one subsystem with four categories, so this is selectable rather than greppable:

```
log show --last 30m --predicate 'subsystem == "dev.quern.menubar" AND category == "settings"'
```

## Verification

Against a running signed build, not only in tests: 76 write lines from one session of deliberate spamming, in order, zero failures, selectable by category. `config.json` kept every key, settled on the last value clicked, and left no temporaries. A separate measurement found 0 unparseable reads across 38,782 reads taken during 12 concurrent writes.

Seven mutations, seven caught.

## Worth a reviewer's attention

- The two `isBusy` guards needed assertions on the **visible control**, not on the writes. The writer's own guard already suppresses the echo, so asserting on writes passed against the mutation; only the control can show the flicker. The certificate one survived my first pass for exactly that reason.
- Tests inject only `SettingsModel.writeX` — the subprocess call. Replacing the writer, or the failure handler, leaves the production wiring untested; that was measured twice in #143 before landing on this seam.
- The log seam is injectable because the test binary was writing into the real system log, and those lines are indistinguishable from the app's. A full run wrote 19 lines before, 0 now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Settings changes now handle queued and in-progress updates more reliably, helping prevent newer selections from being overwritten by stale values.
  - Failed setting updates provide clearer diagnostic details, including command output and exit status.
  - Settings commands use a shorter timeout, allowing failures to surface sooner.
  - Application activity and update events are now organized in filterable system logs, making troubleshooting easier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->