### PR TITLE
Put the Settings window on one gutter, and stop the UDID overflowing

### DIFF
--- a/macos/QuernMenuBar/Sources/SettingsWindow.swift
+++ b/macos/QuernMenuBar/Sources/SettingsWindow.swift
@@ -348,6 +348,40 @@ struct SettingsView: View {
     private var u: UpdateInfo { model.snapshot.update }
     private var d: ActiveDevice { model.snapshot.device }
 
+    /// Padding inside a GroupBox, on top of whatever the box insets itself.
+    ///
+    /// Applied by hand because the boxes have to agree and SwiftUI will not
+    /// make them. Before this there were three different gutters in one
+    /// window: one box padded by 6, another not padded at all, and the three
+    /// built from `grid()` not padded either.
+    private static let contentInset: CGFloat = 6
+
+    /// How far the bottom group sits in, to line its checkboxes up with the
+    /// ones inside the boxes above.
+    ///
+    /// A separate number from `contentInset`, and larger, because it covers a
+    /// different distance: a GroupBox's own inset *plus* the padding we add on
+    /// top of it. The two toggles and the button down there sit outside any
+    /// box, so nothing aligns them for free -- and being the only controls in
+    /// the window without a container makes a shallower gutter obvious rather
+    /// than subtle.
+    ///
+    /// Measured, not derived: a GroupBox's own inset is not a published
+    /// constant, and reading it out of SwiftUI at runtime would be a worse
+    /// dependency than a number with a comment.
+    ///
+    /// 11 is the gap between the checkbox glyphs, taken off a screenshot by
+    /// finding the leftmost blue pixel of each one: those inside a box start
+    /// at x=54, these started at x=43.
+    ///
+    /// Three earlier guesses -- 6, 12, 15 -- all appeared to do nothing, and
+    /// the reason was not the number. A stray brace had attached this padding
+    /// to the whole body rather than to this group, so every value shifted the
+    /// entire window and left the gap exactly where it was. Worth remembering
+    /// that "the fix had no effect" is evidence about the wiring at least as
+    /// often as it is about the value.
+    private static let outsideBoxInset: CGFloat = 11
+
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             Text("Quern").font(.title2).bold()
@@ -388,7 +422,7 @@ struct SettingsView: View {
                         .font(.callout)
                         .fixedSize(horizontal: false, vertical: true)
                 }
-                .padding(6)
+                .padding(Self.contentInset)
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
 
@@ -424,7 +458,13 @@ struct SettingsView: View {
                         }
                         .labelsHidden()
                         .pickerStyle(.segmented)
-                        .frame(maxWidth: 220)
+                        // `.leading`, because frame(maxWidth:) centres by
+                        // default. The segmented control is about 115 wide in
+                        // a 220 box, so it sat ~50pt right of where the label
+                        // column ends -- clear of the value column every row
+                        // above lines up on. Centred was always wrong here; it
+                        // only became obvious once this box gained padding.
+                        .frame(maxWidth: 220, alignment: .leading)
                         .accessibilityLabel("Update channel")
                         .accessibilityValue(model.channel)
                         Spacer()
@@ -436,35 +476,45 @@ struct SettingsView: View {
                         Text("Up to date").foregroundColor(.secondary).font(.callout)
                     }
                 }
+                .padding(Self.contentInset)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
 
-            // No .accessibilityLabel here, and not for want of trying. In an
-            // NSHostingController the modifier reaches Text but is dropped by
-            // Toggle, Button and GroupBox's label -- measured: the checkbox
-            // ends up with no AXTitle and no AXDescription attribute at all,
-            // and neither .accessibilityLabel nor .accessibilityElement
-            // (children: .combine) changes that. So VoiceOver announces this
-            // as a bare "checkbox". Left unfixed rather than papered over with
-            // a modifier that does nothing.
-            Toggle("Launch at login", isOn: $model.loginEnabled)
-                .onChange(of: model.loginEnabled) { newValue in
-                    if !LoginItem.setEnabled(newValue) {
-                        // Revert the toggle if the OS refused.
-                        model.loginEnabled = LoginItem.isEnabled()
+            // The toggles and the button below sit outside any GroupBox, so
+            // they align with the box *frames* rather than with the content
+            // inside them -- a second gutter about six points shallower than
+            // the one every row above uses. Grouped and inset by hand to put
+            // them on the same line.
+            VStack(alignment: .leading, spacing: 16) {
+                // No .accessibilityLabel here, and not for want of trying. In an
+                // NSHostingController the modifier reaches Text but is dropped by
+                // Toggle, Button and GroupBox's label -- measured: the checkbox
+                // ends up with no AXTitle and no AXDescription attribute at all,
+                // and neither .accessibilityLabel nor .accessibilityElement
+                // (children: .combine) changes that. So VoiceOver announces this
+                // as a bare "checkbox". Left unfixed rather than papered over with
+                // a modifier that does nothing.
+                Toggle("Launch at login", isOn: $model.loginEnabled)
+                    .onChange(of: model.loginEnabled) { newValue in
+                        if !LoginItem.setEnabled(newValue) {
+                            // Revert the toggle if the OS refused.
+                            model.loginEnabled = LoginItem.isEnabled()
+                        }
                     }
-                }
 
-            Toggle("Start the server when Quern launches", isOn: $model.startOnLaunch)
-                .onChange(of: model.startOnLaunch) { newValue in
-                    StartOnLaunch.isEnabled = newValue
-                }
+                Toggle("Start the server when Quern launches", isOn: $model.startOnLaunch)
+                    .onChange(of: model.startOnLaunch) { newValue in
+                        StartOnLaunch.isEnabled = newValue
+                    }
 
-            HStack {
-                Button("Documentation") {
-                    NSWorkspace.shared.open(URL(string: "https://quern.dev/docs")!)
+                HStack {
+                    Button("Documentation") {
+                        NSWorkspace.shared.open(URL(string: "https://quern.dev/docs")!)
+                    }
+                    Spacer()
                 }
-                Spacer()
             }
+            .padding(.leading, Self.outsideBoxInset)
         }
         .padding(20)
         .frame(width: 420)
@@ -486,11 +536,28 @@ struct SettingsView: View {
                         .foregroundColor(.secondary)
                         .frame(width: 90, alignment: .leading)
                         .accessibilityLabel("\(section) \(row.0)")
-                    Text(row.1).textSelection(.enabled)
+                    Text(row.1)
+                        .textSelection(.enabled)
+                        // Let the row grow instead of spilling out of the box.
+                        //
+                        // A 36-character simulator UDID does not fit the value
+                        // column, so it wrapped to a second line -- but nothing
+                        // told the row to reserve the height for it, so the
+                        // tail rendered past the GroupBox and over the section
+                        // below. Selecting the text made it obvious because
+                        // that re-laid it out; the overflow was there either
+                        // way. Same modifier, for the same reason, as the
+                        // certificate explanation further down.
+                        .fixedSize(horizontal: false, vertical: true)
                     Spacer()
                 }
             }
         }
+        // The same inset the other two boxes apply to their own content. All
+        // five boxes now share one gutter, and the value column here lines up
+        // with the channel picker below, which sits after a label column of
+        // the same width.
+        .padding(Self.contentInset)
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 


### PR DESCRIPTION
Cosmetic, found by eye and fixed against a running signed build over five rounds of screenshots.

## Four gutters in one window

| Where | Inner padding before |
|---|---|
| Server, Proxy, Active device (all use `grid()`) | none |
| Network capture | 6 |
| Updates | none |
| The toggles and button at the bottom | outside any box, so aligned to box *frames* |

Now: one named constant for the padding inside a box, applied in the three places that have to agree, and a second for the bottom group — a different distance, since it also covers the box's own inset.

## The channel picker

Moved too, and this one was a pre-existing bug rather than a knock-on:

```swift
.frame(maxWidth: 220)   // centres by default
```

The segmented control measures about 115 in a 220 box, so it sat ~50pt right of where its label column ends — clear of the value column every row above aligns on. It only became visible once the box around it gained padding. Now `.frame(maxWidth: 220, alignment: .leading)`.

## The UDID overflow

A real 36-character simulator UDID does not fit the value column. It wrapped to a second line while nothing reserved the height for it, so the tail rendered past the GroupBox and over the section below. Clicking the text appeared to cause it; it only forced a re-layout that made it visible. The overflow was always there, and a synthetic short UDID (`ABCD-1234`, left in a state file during development) had been hiding it.

`.fixedSize(horizontal: false, vertical: true)` on the value, so the row takes the height it needs — the same modifier the certificate explanation in this window already uses. Wrapping rather than truncating, because a UDID you can read and select is worth more than one that fits on a line.

## Worth a reviewer's attention

The bottom inset took four passes, and the first three failed for a reason worth recording. A stray brace had attached the padding to the whole body rather than to that group, so every value shifted the entire window and left the relative gap untouched. Three guesses "had no effect" and I reached for a bigger number each time instead of reading that as evidence about the wiring. With it attached correctly the value is just the measured gap — 11 points, taken from the leftmost blue pixel of each checkbox glyph in a screenshot.

Both magic numbers carry comments recording how they were arrived at, since neither is derivable: a GroupBox's own inset is not a published constant, and reading it out of SwiftUI at runtime would be a worse dependency than a number with an explanation.

No behaviour change, so no new tests. 2232 Python and 93 Swift tests unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Improved Settings window spacing and alignment for a more consistent layout.
  * Long setting values now wrap within their containers instead of extending beyond them.
  * Refined the placement of channel selection, toggles, and the Documentation button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->