### PR TITLE
Stop devicectl reporting simulators as physical devices

### DIFF
--- a/server/device/controller.py
+++ b/server/device/controller.py
@@ -380,7 +380,13 @@ class DeviceController(DeviceControllerUI):
         for d in sim_devices:
             self._device_type_cache[d.udid] = DeviceType.SIMULATOR
         for d in physical_devices:
-            self._device_type_cache[d.udid] = DeviceType.DEVICE
+            # The backend's own classification, not a hardcoded DEVICE. This
+            # loop runs after the simctl one, so stamping DEVICE here overwrote
+            # the correct SIMULATOR for any UDID appearing in both -- which is
+            # every simulator, once Xcode 26 started registering them as
+            # CoreDevices. devicectl now filters simulators out, and this stops
+            # the mistake being reintroduced if anything else ever returns one.
+            self._device_type_cache[d.udid] = d.device_type
             if d.os_version:
                 self.wda_client._device_os_versions[d.udid] = d.os_version
             if d.name:

--- a/server/device/devicectl.py
+++ b/server/device/devicectl.py
@@ -125,11 +125,40 @@ class DevicectlBackend:
             raw_transport = connection_props.get("transportType", "")
             connection_type = "usb" if raw_transport == "wired" else raw_transport
             tunnel_state = connection_props.get("tunnelState", "")
-            device_type_str = dev.get("hardwareProperties", {}).get("deviceType", "")
+            hardware_props = dev.get("hardwareProperties", {})
+            device_type_str = hardware_props.get("deviceType", "")
+
+            # Simulators belong to simctl, which is authoritative about them:
+            # it knows the runtime and the real boot state, and devicectl does
+            # not. Returning them here produced a second, worse entry for the
+            # same UDID -- and because the controller populates its type cache
+            # from simctl *first* and devicectl second, that entry overwrote
+            # the correct classification. `resolve_device` then wrote
+            # `{"type": "device"}` for a simulator, UI reads routed to WDA
+            # instead of sim-bridge, and `get_screen_summary` returned HTTP 500
+            # against a perfectly healthy booted simulator.
+            #
+            # Xcode 26 registers simulators as CoreDevices, so they appear here
+            # on machines where they never used to. `reality` is exactly the
+            # signal needed and was never read: it is "simulated" or "physical".
+            if hardware_props.get("reality") == "simulated":
+                continue
 
             # Map state: any active/reachable tunnel or explicit bootState = booted.
             # tunnelState values: "connected" (active tunnel), "disconnected"
             # (reachable but no tunnel yet — e.g. WiFi devices), "unavailable".
+            #
+            # Left alone deliberately. A bug report had shut-down *simulators*
+            # arriving here as booted, because they report "disconnected" too --
+            # but that is a symptom of simulators being in this list at all, and
+            # the filter above is the fix. Narrowing this rule instead would
+            # have reported a wifi-connected iPhone as shut down: measured, it
+            # carries no bootState and a disconnected tunnel while plainly
+            # being awake and deployable.
+            #
+            # The deeper problem is that the question does not apply. "Booted"
+            # is simctl's vocabulary; usbmux fills the same field with a
+            # constant because there is nothing to compute. See #147.
             boot_state = dev.get("deviceProperties", {}).get("bootState", "")
             if tunnel_state in ("connected", "disconnected"):
                 state = DeviceState.BOOTED

--- a/server/lifecycle/update_check.py
+++ b/server/lifecycle/update_check.py
@@ -60,7 +60,21 @@ def _find_project_root() -> Path | None:
 
 
 def _get_local_version() -> str | None:
-    """Read version from pyproject.toml."""
+    """Read version from pyproject.toml.
+
+    Scraped from the raw line rather than read through
+    ``importlib.metadata.version()``, and that matters more than it looks.
+    This string is sent to quern.dev as ``version=``, where it is parsed as
+    semver -- which is the only thing a tarball install has to identify itself
+    with, since it has no ``.git`` and therefore no SHA.
+
+    ``importlib.metadata`` returns the *normalised* PEP 440 form, which is not
+    semver: it rewrites ``0.14.1-beta.2`` to ``0.14.1b2``. The endpoint would
+    fail to parse that and answer "no update", silently restoring the bug where
+    tarball installs never heard about a release -- for beta users specifically,
+    who are the ones most likely to want to hear. Keep reading the literal
+    string, or teach the endpoint PEP 440 first.
+    """
     project_root = _find_project_root()
     if project_root is None:
         return None

--- a/tests/test_controller_pool_fallback.py
+++ b/tests/test_controller_pool_fallback.py
@@ -105,3 +105,50 @@ class TestPoolFallback:
         udid = await ctrl.resolve_udid()
         assert udid == "STORED"
         pool.resolve_device.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_devicectl_cannot_relabel_a_simulator_as_a_device():
+    """The controller's type cache decides how UI reads are routed.
+
+    simctl populates it first, devicectl second, and devicectl's loop used to
+    stamp `DeviceType.DEVICE` for every entry regardless of what the backend
+    said. Any UDID in both lists therefore ended up typed `device` -- which is
+    every simulator, once Xcode 26 started registering them as CoreDevices.
+    From there `resolve_device` wrote `{"type": "device"}`, UI reads routed to
+    WDA instead of sim-bridge, and `get_screen_summary` returned HTTP 500
+    against a healthy booted simulator.
+
+    devicectl now filters simulators out, so in practice this cannot happen.
+    This covers the second half: if anything ever does return one, the cache
+    must believe the backend rather than the loop it arrived in.
+    """
+    from server.device.controller import DeviceController
+    from server.models import DeviceInfo, DeviceState, DeviceType
+
+    udid = "F5AF3736-C05F-493F-AA52-CA883B13B18C"
+    sim = DeviceInfo(
+        udid=udid, name="iPhone 16 Pro", state=DeviceState.BOOTED,
+        device_type=DeviceType.SIMULATOR, os_version="iOS 26.0",
+    )
+    # The same device, as devicectl would hand it over if it ever did.
+    from_devicectl = DeviceInfo(
+        udid=udid, name="iPhone 16 Pro", state=DeviceState.BOOTED,
+        device_type=DeviceType.SIMULATOR, os_version="iOS 26.0",
+    )
+
+    ctrl = DeviceController()
+    ctrl.simctl = AsyncMock()
+    ctrl.simctl.list_devices = AsyncMock(return_value=[sim])
+    ctrl.devicectl = AsyncMock()
+    ctrl.devicectl.list_devices = AsyncMock(return_value=[from_devicectl])
+    ctrl.usbmux = AsyncMock()
+    ctrl.usbmux.list_devices = AsyncMock(return_value=[])
+    ctrl.adb = AsyncMock()
+    ctrl.adb.list_devices = AsyncMock(return_value=[])
+
+    await ctrl.list_devices()
+
+    assert ctrl._device_type_cache[udid] == DeviceType.SIMULATOR, (
+        "devicectl's pass relabelled a simulator as a physical device"
+    )

--- a/tests/test_devicectl_backend.py
+++ b/tests/test_devicectl_backend.py
@@ -342,3 +342,69 @@ class TestXcodeGate:
         with patch("asyncio.create_subprocess_exec") as exec_mock:
             assert await backend.list_devices() == []
         assert exec_mock.call_count == 0
+
+
+class TestSimulatorsAreNotPhysicalDevices:
+    """Xcode 26 registers simulators as CoreDevices, so they show up here.
+
+    Reported against 0.16.1: `resolve_device` wrote `{"type": "device"}` for a
+    simulator, UI reads routed to WDA instead of sim-bridge, and
+    `get_screen_summary` returned HTTP 500 against a healthy booted simulator.
+    `hardwareProperties.reality` is exactly the signal needed -- "simulated" or
+    "physical" -- and nothing read it.
+    """
+
+    def _with_reality(self, *realities: str) -> dict:
+        """The fixture, with one entry per given reality value."""
+        data = json.loads(_load_fixture("devicectl_list_output.json"))
+        template = data["result"]["devices"][0]
+        devices = []
+        for i, reality in enumerate(realities):
+            dev = json.loads(json.dumps(template))
+            dev["identifier"] = f"UDID-{i}"
+            dev["deviceProperties"]["name"] = f"Device {i}"
+            dev["hardwareProperties"]["reality"] = reality
+            devices.append(dev)
+        data["result"]["devices"] = devices
+        return data
+
+    @pytest.mark.asyncio
+    async def test_a_simulated_device_is_not_returned(self):
+        # simctl is authoritative about simulators: it knows the runtime and
+        # the real boot state. A second, worse entry for the same UDID is what
+        # caused the misclassification.
+        backend = DevicectlBackend()
+        backend._run_devicectl = AsyncMock(
+            return_value=(json.dumps(self._with_reality("simulated")), "")
+        )
+        assert await backend.list_devices() == []
+
+    @pytest.mark.asyncio
+    async def test_physical_devices_are_still_returned(self):
+        backend = DevicectlBackend()
+        backend._run_devicectl = AsyncMock(
+            return_value=(json.dumps(self._with_reality("physical")), "")
+        )
+        devices = await backend.list_devices()
+        assert len(devices) == 1
+        assert devices[0].device_type == DeviceType.DEVICE
+
+    @pytest.mark.asyncio
+    async def test_only_the_simulated_ones_are_dropped(self):
+        backend = DevicectlBackend()
+        backend._run_devicectl = AsyncMock(
+            return_value=(json.dumps(self._with_reality("physical", "simulated", "physical")), "")
+        )
+        devices = await backend.list_devices()
+        assert [d.udid for d in devices] == ["UDID-0", "UDID-2"]
+
+    @pytest.mark.asyncio
+    async def test_a_missing_reality_field_is_treated_as_physical(self):
+        # Older devicectl versions do not emit it. Dropping those devices would
+        # be a worse failure than the one being fixed -- physical devices would
+        # vanish -- so only an explicit "simulated" filters.
+        data = self._with_reality("physical")
+        del data["result"]["devices"][0]["hardwareProperties"]["reality"]
+        backend = DevicectlBackend()
+        backend._run_devicectl = AsyncMock(return_value=(json.dumps(data), ""))
+        assert len(await backend.list_devices()) == 1


### PR DESCRIPTION
From an external report against 0.16.1: `get_screen_summary` returns **HTTP 500 against a perfectly healthy booted simulator**.

## What happens

Xcode 26 registers simulators as CoreDevices, so they appear in `devicectl list devices` alongside real hardware. `list_devices` appended every paired, reachable device with a hardcoded `DeviceType.DEVICE` and never read `hardwareProperties.reality`, which is exactly `"simulated"` or `"physical"`.

The damage happens one layer up, in `controller.list_devices`:

```python
for d in sim_devices:
    self._device_type_cache[d.udid] = DeviceType.SIMULATOR
for d in physical_devices:
    self._device_type_cache[d.udid] = DeviceType.DEVICE   # overwrites
```

simctl fills the cache first, devicectl second and unconditionally. Any UDID in both lists ends up typed `device` — which is every simulator, once they started appearing in devicectl. `resolve_device` then writes `{"type": "device"}`, UI reads route to the WDA client instead of sim-bridge, and with no WDA build present that is a hard failure. Passing `type: "simulator"` explicitly does not override it.

## The fix

**devicectl skips simulated devices.** simctl is authoritative about simulators — it knows the runtime and the real boot state — and a second, worse entry for the same UDID can only cause this.

**The controller's cache believes the backend** rather than the loop the device arrived in, so the mistake cannot be reintroduced by anything else returning one.

Only an explicit `"simulated"` filters. Older devicectl versions omit the field, and dropping those would make physical devices vanish — a worse failure than the one being fixed.

## Deliberately not changed: the physical-device state mapping

The report also noted shut-down simulators arriving as `booted`, because they report `tunnelState: disconnected`. That is a symptom of simulators being in this list at all, and the filter is the fix.

Narrowing the rule instead reported a **wifi-connected iPhone as shut down** — measured on this machine: it carries no `bootState` and a disconnected tunnel while plainly being awake and deployable. An existing test correctly defended the current behaviour and caught the attempt.

The deeper problem is that the question does not apply: `booted` is simctl's vocabulary, and `usbmux.py` fills the same field with a constant because there is nothing to compute. Filed separately as #147.

## Honest limitation

**I could not reproduce the primary symptom here**, despite matching the reporter's Xcode 26.6 and macOS 26.6.2. Cross-referencing by UDID, none of the three devicectl entries on this machine match any of the 33 simulators simctl knows about — all three are genuinely physical and correctly labelled `physical`.

So the fix comes from the data and the reporter's evidence, not from a local repro. What I could verify locally: physical devices are still listed and unchanged, and the booted simulator types as `SIMULATOR` end to end through the controller.

## Also included

One commit from the quern.dev update-check work: a note on `_get_local_version` explaining why the version is scraped from the raw `pyproject.toml` line rather than read through `importlib.metadata`. The normalised PEP 440 form is not semver — `0.14.1-beta.2` becomes `0.14.1b2` — which the update endpoint would fail to parse, silently restoring the bug where tarball installs never hear about a release. It reads like something to tidy up, so it is written down at the function that would be tidied.

2237 tests. Three mutations, three caught.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed device listings so simulators are consistently identified as simulators when they appear in multiple device sources.
  - Prevented simulator devices from appearing in physical-device results, including simulators registered as CoreDevices with Xcode 26.
  - Preserved correct handling of physical devices and device connection states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->